### PR TITLE
feat(zpl): add public font preview endpoint for ZPL fonts landing page

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -25,11 +25,17 @@ import { GoogleAuthProvider } from './config/google-auth.provider.js';
       load: [appConfig],
       envFilePath: ['.env.local', '.env'],
     }),
-    // Rate limiting global: 100 requests por minuto por IP
+    // Rate limiting: default 100 req/min, public-preview 5 req/min
     ThrottlerModule.forRoot([
       {
+        name: 'default',
         ttl: 60000, // 1 minuto
         limit: 100, // 100 requests
+      },
+      {
+        name: 'public-preview',
+        ttl: 60000, // 1 minuto
+        limit: 5, // 5 requests
       },
     ]),
     AuthModule,

--- a/src/modules/zpl/dto/font-preview-public.dto.ts
+++ b/src/modules/zpl/dto/font-preview-public.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsOptional, IsEnum, MaxLength } from 'class-validator';
+import { LabelSize } from '../enums/label-size.enum.js';
+
+export class FontPreviewPublicDto {
+  @ApiProperty({
+    description: 'ZPL content to preview (max 2KB). Must contain ^XA and ^XZ.',
+    example: '^XA^A0N,50,50^FO20,20^FDHello World^FS^XZ',
+    maxLength: 2048,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(2048)
+  zplContent: string;
+
+  @ApiProperty({
+    description: 'Label size (default 4x6)',
+    example: LabelSize.FOUR_BY_SIX,
+    enum: LabelSize,
+    default: LabelSize.FOUR_BY_SIX,
+    required: false,
+  })
+  @IsEnum(LabelSize)
+  @IsOptional()
+  labelSize?: LabelSize;
+}

--- a/src/modules/zpl/zpl.controller.ts
+++ b/src/modules/zpl/zpl.controller.ts
@@ -14,6 +14,7 @@ import {
   HttpException,
   UseGuards,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { v4 as uuidv4 } from 'uuid';
 import { ZplService } from './zpl.service.js';
 import { ConvertZplDto } from './dto/convert-zpl.dto.js';
@@ -42,6 +43,7 @@ import {
   BatchDownloadResponseDto,
 } from './dto/batch.dto.js';
 import { ErrorCodes } from '../../common/constants/error-codes.js';
+import { FontPreviewPublicDto } from './dto/font-preview-public.dto.js';
 
 interface ProcessZplDto {
   zplContent: string;
@@ -659,6 +661,58 @@ export class ZplController {
         summary: result.summary,
       },
     };
+  }
+
+  // ============== PUBLIC FONT PREVIEW ENDPOINT ==============
+
+  @Post('font-preview')
+  @HttpCode(HttpStatus.OK)
+  @Throttle({ 'public-preview': {} })
+  @ApiOperation({
+    summary: 'Public font preview (no auth required)',
+    description: 'Generates a single PNG preview from ZPL content. Rate limited to 5 requests per minute per IP. No authentication required.',
+  })
+  @ApiBody({ type: FontPreviewPublicDto })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Preview generated successfully',
+    schema: {
+      properties: {
+        image: {
+          type: 'string',
+          description: 'PNG image as base64 data URI',
+          example: 'data:image/png;base64,...',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Invalid ZPL content',
+  })
+  @ApiResponse({
+    status: HttpStatus.TOO_MANY_REQUESTS,
+    description: 'Rate limit exceeded (5 req/min)',
+  })
+  async fontPreview(
+    @Body() dto: FontPreviewPublicDto,
+  ): Promise<{ image: string }> {
+    this.validateZplContent(dto.zplContent);
+
+    // Enforce single label for public endpoint
+    const xaCount = (dto.zplContent.match(/\^XA/g) || []).length;
+    if (xaCount !== 1) {
+      throw new HttpException(
+        {
+          error: ErrorCodes.INVALID_ZPL,
+          message: 'Only a single label (one ^XA..^XZ block) is allowed',
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const labelSize = dto.labelSize || LabelSize.FOUR_BY_SIX;
+    return this.zplService.getPublicFontPreview(dto.zplContent, labelSize);
   }
 
   // ============== BATCH PROCESSING ENDPOINTS ==============

--- a/src/modules/zpl/zpl.service.ts
+++ b/src/modules/zpl/zpl.service.ts
@@ -1553,6 +1553,34 @@ export class ZplService {
     }
   }
 
+  // ============== PUBLIC FONT PREVIEW ==============
+
+  /**
+   * Generates a single PNG preview from ZPL content (public, no auth required).
+   * Caller must validate that zplContent contains exactly one label.
+   */
+  async getPublicFontPreview(
+    zplContent: string,
+    labelSize: LabelSize,
+  ): Promise<{ image: string }> {
+    try {
+      const buffer = await this.getSingleLabelaryPngImage(zplContent, labelSize);
+
+      return {
+        image: `data:image/png;base64,${buffer.toString('base64')}`,
+      };
+    } catch (error: any) {
+      this.logger.error(`Public font preview error: ${error.message}`);
+      throw new HttpException(
+        {
+          error: ErrorCodes.SERVER_ERROR,
+          message: 'Error generating font preview',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
   // ============== BATCH PROCESSING ==============
 
   /**

--- a/src/scripts/generate-font-previews.ts
+++ b/src/scripts/generate-font-previews.ts
@@ -1,0 +1,146 @@
+/**
+ * Script to generate static font preview PNGs for all 16 ZPL fonts.
+ * Uploads to GCS at font-previews/font-{code}.png with public access.
+ *
+ * Run with: npx ts-node -r tsconfig-paths/register src/scripts/generate-font-previews.ts
+ */
+
+import { Storage } from '@google-cloud/storage';
+import axios from 'axios';
+import * as dotenv from 'dotenv';
+import * as fs from 'fs';
+import * as path from 'path';
+
+dotenv.config({ path: ['.env.local', '.env'] });
+
+// Try to load credentials from file if env var not set
+const credentialsPath = path.join(process.cwd(), 'firebase-credentials.json');
+if (!process.env.GOOGLE_CREDENTIALS && fs.existsSync(credentialsPath)) {
+  process.env.GOOGLE_CREDENTIALS = fs.readFileSync(credentialsPath, 'utf8');
+}
+
+const ZPL_FONTS = ['0', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'P', 'Q', 'R', 'S', 'T', 'U', 'V'] as const;
+
+const LABEL_SIZE = '4x6';
+const SAMPLE_TEXT = 'ABCDabcd 12345';
+const GCS_BUCKET_OVERRIDE = 'zplpdf-public-assets';
+const GCS_FOLDER = 'font-previews';
+const RATE_LIMIT_DELAY_MS = 1100;
+
+function buildZpl(fontCode: string): string {
+  return `^XA^A${fontCode}N,50,50^FO20,20^FD${SAMPLE_TEXT}^FS^XZ`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main() {
+  console.log('Starting font preview generation...\n');
+
+  // Initialize GCS
+  const bucketName = process.env.GCP_STORAGE_BUCKET;
+  if (!bucketName) {
+    console.error('Error: GCP_STORAGE_BUCKET environment variable is required');
+    process.exit(1);
+  }
+
+  let credentials: any = null;
+  const googleCredentials = process.env.GOOGLE_CREDENTIALS;
+
+  if (googleCredentials) {
+    try {
+      credentials = JSON.parse(googleCredentials);
+      if (credentials.private_key) {
+        credentials.private_key = credentials.private_key.replace(/\\n/g, '\n');
+      }
+      console.log(`Using GCP project: ${credentials.project_id}`);
+    } catch (error) {
+      console.error('Error parsing GOOGLE_CREDENTIALS:', error);
+      process.exit(1);
+    }
+  }
+
+  const storageOptions: any = {};
+  if (credentials) {
+    storageOptions.credentials = credentials;
+    storageOptions.projectId = credentials.project_id;
+  }
+
+  const storage = new Storage(storageOptions);
+  const targetBucket = GCS_BUCKET_OVERRIDE || bucketName;
+  const bucket = storage.bucket(targetBucket);
+
+  console.log(`Bucket: ${targetBucket}`);
+  console.log(`Fonts to process: ${ZPL_FONTS.length}`);
+  console.log(`Label size: ${LABEL_SIZE}`);
+  console.log('');
+
+  const results: { font: string; url: string; status: string }[] = [];
+
+  for (const fontCode of ZPL_FONTS) {
+    const zpl = buildZpl(fontCode);
+    const fileName = `${GCS_FOLDER}/font-${fontCode}.png`;
+
+    try {
+      console.log(`Processing font ${fontCode}...`);
+
+      // Call Labelary API for PNG
+      const url = `http://api.labelary.com/v1/printers/8dpmm/labels/${LABEL_SIZE}/0/`;
+      const response = await axios.post(url, zpl, {
+        headers: {
+          Accept: 'image/png',
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        responseType: 'arraybuffer',
+        timeout: 30000,
+      });
+
+      const pngBuffer = Buffer.from(response.data);
+
+      // Upload to GCS (bucket-level access controls public visibility)
+      const file = bucket.file(fileName);
+      await file.save(pngBuffer, {
+        metadata: {
+          contentType: 'image/png',
+          cacheControl: 'public, max-age=31536000',
+        },
+      });
+
+      const publicUrl = `https://storage.googleapis.com/${targetBucket}/${fileName}`;
+      results.push({ font: fontCode, url: publicUrl, status: 'OK' });
+      console.log(`  -> ${publicUrl}`);
+    } catch (error: any) {
+      const errorMsg = error.response?.status
+        ? `HTTP ${error.response.status}`
+        : error.message;
+      results.push({ font: fontCode, url: '', status: `ERROR: ${errorMsg}` });
+      console.error(`  -> Error: ${errorMsg}`);
+    }
+
+    // Rate limit delay between calls
+    if (fontCode !== ZPL_FONTS[ZPL_FONTS.length - 1]) {
+      await sleep(RATE_LIMIT_DELAY_MS);
+    }
+  }
+
+  // Summary
+  console.log('\n========== Generation Complete ==========');
+  const successful = results.filter((r) => r.status === 'OK');
+  const failed = results.filter((r) => r.status !== 'OK');
+  console.log(`Successful: ${successful.length}/${ZPL_FONTS.length}`);
+
+  if (failed.length > 0) {
+    console.log('\nFailed:');
+    failed.forEach((r) => console.log(`  Font ${r.font}: ${r.status}`));
+  }
+
+  console.log('\nGenerated URLs:');
+  successful.forEach((r) => console.log(`  font-${r.font}: ${r.url}`));
+  console.log('==========================================\n');
+}
+
+main().catch((error) => {
+  console.error('Generation failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **Public endpoint** `POST /api/zpl/font-preview` — no auth required, rate limited to 5 req/min per IP
- **Named throttler** `public-preview` in `app.module.ts` for granular rate limiting
- **Font preview script** `src/scripts/generate-font-previews.ts` — generates 16 static PNGs via Labelary API and uploads to GCS bucket `zplpdf-public-assets`
- **DTO validation** — max 2KB ZPL content, single label only, label size enum
- Static images live at `https://storage.googleapis.com/zplpdf-public-assets/font-previews/font-{code}.png`

Supports frontend issue gustavojmarrero/zplpdf_front#142 for the `/en/zpl-fonts` SEO landing page (9,900 searches/month, KD ~0).

## Test plan

- [x] `POST /api/zpl/font-preview` returns base64 PNG for valid ZPL
- [x] Returns 400 for invalid ZPL (missing ^XA/^XZ, multiple labels)
- [x] DTO validation rejects empty body, content > 2KB
- [x] Rate limit returns 429 after 5 requests/min
- [x] 16 font preview PNGs accessible via public GCS URLs
- [ ] Verify endpoint appears in Swagger `/docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)