### PR TITLE
fix(throttler): identificar cliente por user/job/batch en lugar de IP

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { ThrottlerModule } from '@nestjs/throttler';
+import { CustomThrottlerGuard } from './common/guards/custom-throttler.guard.js';
 import { APP_GUARD } from '@nestjs/core';
 import { AppController } from './app.controller.js';
 import { AppService } from './app.service.js';
@@ -56,7 +57,7 @@ import { GoogleAuthProvider } from './config/google-auth.provider.js';
     GoogleAuthProvider,
     {
       provide: APP_GUARD,
-      useClass: ThrottlerGuard,
+      useClass: CustomThrottlerGuard,
     },
   ],
   exports: [GoogleAuthProvider],

--- a/src/common/guards/custom-throttler.guard.ts
+++ b/src/common/guards/custom-throttler.guard.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
+import type { FirebaseUser } from '../decorators/current-user.decorator.js';
+
+interface ThrottlerRequest {
+  user?: FirebaseUser;
+  params?: { jobId?: string; batchId?: string };
+  ip?: string;
+}
+
+// Detras del rewrite server-side de Vercel, todas las requests llegan desde
+// las mismas IPs de edge lambdas, asi que la cuota por IP se llena con
+// trafico ajeno. Priorizamos identidades estables presentes en la request.
+//
+// Nota: el storage in-memory de @nestjs/throttler (ThrottlerStorageService)
+// nunca elimina keys del Map interno — solo expira sus contadores. Con
+// jobId/batchId (UUIDs) como tracker, la cardinalidad crece con cada job
+// nuevo. En Cloud Run el reciclo de contenedores lo mitiga; si el volumen
+// sube significativamente, migrar a Redis storage o LRU custom.
+@Injectable()
+export class CustomThrottlerGuard extends ThrottlerGuard {
+  protected async getTracker(req: ThrottlerRequest): Promise<string> {
+    if (req.user?.uid) return `user:${req.user.uid}`;
+    if (req.params?.jobId) return `job:${req.params.jobId}`;
+    if (req.params?.batchId) return `batch:${req.params.batchId}`;
+    return `ip:${req.ip ?? 'anonymous'}`;
+  }
+}

--- a/src/common/guards/index.ts
+++ b/src/common/guards/index.ts
@@ -1,2 +1,3 @@
 export * from './firebase-auth.guard.js';
 export * from './cron-auth.guard.js';
+export * from './custom-throttler.guard.js';


### PR DESCRIPTION
Closes #43

## Problema

Polling legitimo de `GET /api/zpl/status/:jobId` recibia ráfagas de `429 ThrottlerException` con conversiones que terminaban bien. Ejemplo real (job `7723a05f-...`): el frontend hizo solo 10 polls en ~1m43s — backoff exponencial saludable — pero 4 fueron rechazadas con 429.

## Causa raíz

Los logs HTTP del backend mostraron 3 IPs distintas para el mismo usuario y user-agent (`54.160.46.199`, `54.226.79.138`, `98.90.203.3`). Son IPs de **lambdas edge de Vercel**.

El frontend tiene un rewrite server-side en `next.config.js`:
```js
{ source: '/api/:path*', destination: 'https://api.zplpdf.com/api/:path*' }
```

Esto hace que **Vercel proxee** todas las requests al backend, así que la IP que ve Cloud Run no es la del usuario final sino la del lambda — IPs **compartidas entre todos los visitantes del sitio**. El throttler de NestJS de 100 req/min/IP estaba contando tráfico de usuarios ajenos contra la misma cuota.

`app.set('trust proxy', true)` en `main.ts:16` no resuelve esto porque Vercel no propaga la IP del cliente final cuando hace rewrites a hosts externos.

## Solución

Custom `ThrottlerGuard` que prioriza identidades estables presentes en la request:

```
userId   → endpoints autenticados (/convert, /download, /batch, etc.)
jobId    → polling público (/status/:jobId, /queue-position/:jobId)
batchId  → polling de batches (/batch/status/:batchId)
ip       → fallback final
```

Cada job/batch obtiene su propia cuota de 100 req/min independiente. Usuarios autenticados se trackean por `uid`. Solo endpoints sin contexto (ej. `/font-preview`) caen al bucket de IP.

## Cambios

- **Nuevo** `src/common/guards/custom-throttler.guard.ts` — extiende `ThrottlerGuard` y override `getTracker()`.
- **Modificado** `src/common/guards/index.ts` — export del nuevo guard.
- **Modificado** `src/app.module.ts` — `APP_GUARD` ahora usa `CustomThrottlerGuard`.

## Deuda técnica documentada

El storage in-memory de `@nestjs/throttler` (`ThrottlerStorageService`) nunca elimina keys del Map interno — solo expira sus contadores. Con `jobId/batchId` (UUIDs) como key, la cardinalidad crece con cada job nuevo. En Cloud Run el reciclo de contenedores lo mitiga; si el volumen crece significativamente, migrar a Redis storage o LRU custom. Está anotado en el comentario del guard.

## Test plan

- [ ] Local: `PORT=8080 npm run start:dev`. Pollear `/api/zpl/status/<uuid>` 200+ veces y confirmar que no se dispara 429 (cada jobId tiene cuota propia).
- [ ] Local: pollear `/api/zpl/status/<uuid-A>` 90 veces y luego `/api/zpl/status/<uuid-B>` 90 veces dentro del mismo minuto: ambos deben pasar.
- [ ] Local: pollear el mismo jobId 110 veces en 60s y confirmar que el 101° devuelve 429 (rate limit sigue funcionando).
- [ ] Producción: tras deploy, monitorear `gcloud logging` filtrando por `ThrottlerException` durante 1 hora — no deberían aparecer en `/status/:jobId`.
- [ ] Verificar que `/convert` autenticado sigue protegido por el límite de 100 req/min/usuario.