### PR TITLE
fix(usage): leer solo el periodo actual y eliminar docs basura

### DIFF
--- a/src/common/services/period-calculator.service.ts
+++ b/src/common/services/period-calculator.service.ts
@@ -1,19 +1,11 @@
 import { Injectable } from '@nestjs/common';
+import {
+  calculateCurrentPeriod as calcCurrentPeriod,
+  PeriodInfo,
+  UserForPeriod,
+} from './period-calculator.util.js';
 
-export interface PeriodInfo {
-  periodStart: Date;
-  periodEnd: Date;
-  periodId: string;
-}
-
-export interface UserForPeriod {
-  id: string;
-  plan: 'free' | 'pro' | 'promax' | 'enterprise';
-  createdAt: Date;
-  // Fechas del período de suscripción (sincronizadas desde Stripe webhooks)
-  subscriptionPeriodStart?: Date;
-  subscriptionPeriodEnd?: Date;
-}
+export type { PeriodInfo, UserForPeriod };
 
 @Injectable()
 export class PeriodCalculatorService {
@@ -23,68 +15,6 @@ export class PeriodCalculatorService {
    * - Pro/Enterprise: usa fechas guardadas en Firestore (sincronizadas desde Stripe)
    */
   calculateCurrentPeriod(user: UserForPeriod): PeriodInfo {
-    if (user.plan === 'free') {
-      return this.calculateFreePeriod(user.id, user.createdAt);
-    }
-
-    // Pro/Enterprise: usar fechas guardadas en Firestore
-    if (user.subscriptionPeriodStart && user.subscriptionPeriodEnd) {
-      const periodStart = user.subscriptionPeriodStart instanceof Date
-        ? user.subscriptionPeriodStart
-        : new Date(user.subscriptionPeriodStart);
-      const periodEnd = user.subscriptionPeriodEnd instanceof Date
-        ? user.subscriptionPeriodEnd
-        : new Date(user.subscriptionPeriodEnd);
-
-      return {
-        periodStart,
-        periodEnd,
-        periodId: this.generatePeriodId(user.id, periodStart),
-      };
-    }
-
-    // Fallback para usuarios Pro sin fechas de período (pendiente migración)
-    return this.calculateFreePeriod(user.id, user.createdAt);
-  }
-
-  /**
-   * Plan Free: período mensual desde fecha de registro
-   * Ejemplo: Usuario registrado el 15 de enero
-   * - Período 1: 15 enero → 15 febrero
-   * - Período 2: 15 febrero → 15 marzo
-   */
-  private calculateFreePeriod(userId: string, createdAt: Date): PeriodInfo {
-    const now = new Date();
-    const registrationDay = createdAt.getDate();
-
-    // Encontrar el periodStart más reciente
-    let periodStart = new Date(now.getFullYear(), now.getMonth(), registrationDay);
-
-    // Si el día de registro aún no ha llegado este mes, el período empezó el mes pasado
-    if (periodStart > now) {
-      periodStart.setMonth(periodStart.getMonth() - 1);
-    }
-
-    // periodEnd = periodStart + 1 mes - 1 milisegundo
-    const periodEnd = new Date(periodStart);
-    periodEnd.setMonth(periodEnd.getMonth() + 1);
-    periodEnd.setMilliseconds(periodEnd.getMilliseconds() - 1);
-
-    return {
-      periodStart,
-      periodEnd,
-      periodId: this.generatePeriodId(userId, periodStart),
-    };
-  }
-
-  /**
-   * Genera ID único para el período
-   * Formato: userId_YYYYMMDD (fecha de inicio del período)
-   */
-  private generatePeriodId(userId: string, periodStart: Date): string {
-    const year = periodStart.getFullYear();
-    const month = String(periodStart.getMonth() + 1).padStart(2, '0');
-    const day = String(periodStart.getDate()).padStart(2, '0');
-    return `${userId}_${year}${month}${day}`;
+    return calcCurrentPeriod(user);
   }
 }

--- a/src/common/services/period-calculator.util.ts
+++ b/src/common/services/period-calculator.util.ts
@@ -1,0 +1,62 @@
+export interface PeriodInfo {
+  periodStart: Date;
+  periodEnd: Date;
+  periodId: string;
+}
+
+export interface UserForPeriod {
+  id: string;
+  plan: 'free' | 'pro' | 'promax' | 'enterprise';
+  createdAt: Date;
+  subscriptionPeriodStart?: Date;
+  subscriptionPeriodEnd?: Date;
+}
+
+export function generatePeriodId(userId: string, periodStart: Date): string {
+  const year = periodStart.getFullYear();
+  const month = String(periodStart.getMonth() + 1).padStart(2, '0');
+  const day = String(periodStart.getDate()).padStart(2, '0');
+  return `${userId}_${year}${month}${day}`;
+}
+
+export function calculateFreePeriod(userId: string, createdAt: Date, now: Date = new Date()): PeriodInfo {
+  const registrationDay = createdAt.getDate();
+
+  let periodStart = new Date(now.getFullYear(), now.getMonth(), registrationDay);
+  if (periodStart > now) {
+    periodStart.setMonth(periodStart.getMonth() - 1);
+  }
+
+  const periodEnd = new Date(periodStart);
+  periodEnd.setMonth(periodEnd.getMonth() + 1);
+  periodEnd.setMilliseconds(periodEnd.getMilliseconds() - 1);
+
+  return {
+    periodStart,
+    periodEnd,
+    periodId: generatePeriodId(userId, periodStart),
+  };
+}
+
+export function calculateCurrentPeriod(user: UserForPeriod, now: Date = new Date()): PeriodInfo {
+  if (user.plan === 'free') {
+    return calculateFreePeriod(user.id, user.createdAt, now);
+  }
+
+  if (user.subscriptionPeriodStart && user.subscriptionPeriodEnd) {
+    const periodStart = user.subscriptionPeriodStart instanceof Date
+      ? user.subscriptionPeriodStart
+      : new Date(user.subscriptionPeriodStart);
+    const periodEnd = user.subscriptionPeriodEnd instanceof Date
+      ? user.subscriptionPeriodEnd
+      : new Date(user.subscriptionPeriodEnd);
+
+    return {
+      periodStart,
+      periodEnd,
+      periodId: generatePeriodId(user.id, periodStart),
+    };
+  }
+
+  return calculateFreePeriod(user.id, user.createdAt, now);
+}

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -641,23 +641,35 @@ export class FirestoreService {
   }
 
   /**
-   * Incrementa contadores de uso usando el periodId calculado externamente
+   * Incrementa contadores de uso de forma atómica con upsert.
+   *
+   * Usa `set({...}, { merge: true })` + FieldValue.increment, así:
+   * - Si el doc existe → solo aplica los incrementos.
+   * - Si NO existe → crea el doc con userId/periodStart/periodEnd y los contadores iniciales.
+   *
+   * Esto cubre los caminos que no pasan por getOrCreateUsageWithPeriod, como el
+   * bypass de admins en checkCanConvert o el fallback de recordConversion.
    */
   async incrementUsageWithPeriod(
     userId: string,
-    periodId: string,
+    periodInfo: { periodId: string; periodStart: Date; periodEnd: Date },
     pdfCount: number,
     labelCount: number,
   ): Promise<void> {
     try {
-      const docRef = this.firestore.collection(this.usageCollection).doc(periodId);
-      // Incremento atómico — evita race conditions bajo concurrencia.
-      // getOrCreateUsageWithPeriod garantiza la creación del doc antes de llegar aquí.
-      await docRef.update({
-        pdfCount: FieldValue.increment(pdfCount),
-        labelCount: FieldValue.increment(labelCount),
-      });
-      this.logger.log(`Uso incrementado para usuario: ${userId} (${periodId})`);
+      const docRef = this.firestore.collection(this.usageCollection).doc(periodInfo.periodId);
+      await docRef.set(
+        {
+          odId: periodInfo.periodId,
+          userId,
+          periodStart: periodInfo.periodStart,
+          periodEnd: periodInfo.periodEnd,
+          pdfCount: FieldValue.increment(pdfCount),
+          labelCount: FieldValue.increment(labelCount),
+        },
+        { merge: true },
+      );
+      this.logger.log(`Uso incrementado para usuario: ${userId} (${periodInfo.periodId})`);
     } catch (error) {
       this.logger.error(`Error al incrementar uso con período: ${error.message}`);
       throw error;

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -631,9 +631,25 @@ export class FirestoreService {
         labelCount: 0,
       };
 
-      await docRef.set(newUsage);
-      this.logger.log(`Nuevo periodo de uso creado para usuario: ${userId} (${periodInfo.periodId})`);
-      return newUsage;
+      // create() es atómico: falla con ALREADY_EXISTS si el doc apareció entre
+      // el get() y ahora (ej. un incrementUsageWithPeriod concurrente lo creó).
+      // Eso evita que un set() con contadores en 0 pise uso ya registrado.
+      try {
+        await docRef.create(newUsage);
+        this.logger.log(`Nuevo periodo de uso creado para usuario: ${userId} (${periodInfo.periodId})`);
+        return newUsage;
+      } catch (createError) {
+        if (createError?.code === 6 /* ALREADY_EXISTS */) {
+          const existing = await docRef.get();
+          const data = existing.data();
+          return {
+            ...data,
+            periodStart: data.periodStart?.toDate?.() || data.periodStart,
+            periodEnd: data.periodEnd?.toDate?.() || data.periodEnd,
+          } as Usage;
+        }
+        throw createError;
+      }
     } catch (error) {
       this.logger.error(`Error al obtener/crear uso con período: ${error.message}`);
       throw error;

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Firestore } from '@google-cloud/firestore';
+import { Firestore, FieldValue } from '@google-cloud/firestore';
 import { ConfigService } from '@nestjs/config';
 import { DEFAULT_PLAN_LIMITS } from '../../common/interfaces/user.interface.js';
 import type { User, PlanType } from '../../common/interfaces/user.interface.js';
@@ -16,6 +16,7 @@ import type {
   SubscriptionEvent,
 } from '../../common/interfaces/finance.interface.js';
 import { ErrorIdGenerator } from '../../common/utils/error-id-generator.js';
+import { calculateCurrentPeriod } from '../../common/services/period-calculator.util.js';
 import type {
   EmailLanguage,
   FreeInactiveUser,
@@ -438,12 +439,14 @@ export class FirestoreService {
 
   // ============== Usage ==============
 
+  /** @deprecated Formato legacy `_YYYYMM` (mes calendario). Usar `PeriodCalculatorService` + `getOrCreateUsageWithPeriod`. */
   private generateUsageId(userId: string, date: Date = new Date()): string {
     const year = date.getFullYear();
     const month = String(date.getMonth() + 1).padStart(2, '0');
     return `${userId}_${year}${month}`;
   }
 
+  /** @deprecated Formato legacy `_YYYYMM`. Usar `getOrCreateUsageWithPeriod`. */
   private createNewUsagePeriod(userId: string): Usage {
     const now = new Date();
     const periodStart = new Date(now.getFullYear(), now.getMonth(), 1);
@@ -459,6 +462,7 @@ export class FirestoreService {
     };
   }
 
+  /** @deprecated Sin call sites tras la migración. Usar `getOrCreateUsageWithPeriod(userId, periodInfo)` con `PeriodCalculatorService`. */
   async getOrCreateUsage(userId: string): Promise<Usage> {
     try {
       const usageId = this.generateUsageId(userId);
@@ -491,6 +495,7 @@ export class FirestoreService {
     }
   }
 
+  /** @deprecated Sin call sites tras la migración. Usar `incrementUsageWithPeriod`. */
   async incrementUsage(
     userId: string,
     pdfCount: number,
@@ -508,10 +513,10 @@ export class FirestoreService {
         newUsage.labelCount = labelCount;
         await docRef.set(newUsage);
       } else {
-        // Increment existing counts
+        // Atomic increment to avoid race conditions
         await docRef.update({
-          pdfCount: (doc.data().pdfCount || 0) + pdfCount,
-          labelCount: (doc.data().labelCount || 0) + labelCount,
+          pdfCount: FieldValue.increment(pdfCount),
+          labelCount: FieldValue.increment(labelCount),
         });
       }
 
@@ -522,6 +527,7 @@ export class FirestoreService {
     }
   }
 
+  /** @deprecated Reemplazado por `CronService.resetExpiredUsage` que usa el flujo `_YYYYMMDD`. */
   async resetExpiredUsage(): Promise<number> {
     try {
       const now = new Date();
@@ -645,17 +651,13 @@ export class FirestoreService {
   ): Promise<void> {
     try {
       const docRef = this.firestore.collection(this.usageCollection).doc(periodId);
-      const doc = await docRef.get();
-
-      if (doc.exists) {
-        await docRef.update({
-          pdfCount: (doc.data().pdfCount || 0) + pdfCount,
-          labelCount: (doc.data().labelCount || 0) + labelCount,
-        });
-        this.logger.log(`Uso incrementado para usuario: ${userId} (${periodId})`);
-      } else {
-        this.logger.warn(`Documento de uso no encontrado: ${periodId}`);
-      }
+      // Incremento atómico — evita race conditions bajo concurrencia.
+      // getOrCreateUsageWithPeriod garantiza la creación del doc antes de llegar aquí.
+      await docRef.update({
+        pdfCount: FieldValue.increment(pdfCount),
+        labelCount: FieldValue.increment(labelCount),
+      });
+      this.logger.log(`Uso incrementado para usuario: ${userId} (${periodId})`);
     } catch (error) {
       this.logger.error(`Error al incrementar uso con período: ${error.message}`);
       throw error;
@@ -1765,11 +1767,26 @@ export class FirestoreService {
           const userData = doc.data();
           const userId = doc.id;
 
-          // Get current usage (will be recalculated in AdminService)
+          // Get current usage for the user's actual billing period
           let usage = { pdfCount: 0, labelCount: 0 };
           try {
-            const usageDoc = await this.getOrCreateUsage(userId);
-            usage = { pdfCount: usageDoc.pdfCount, labelCount: usageDoc.labelCount };
+            const createdAt = userData.createdAt?.toDate?.() || (userData.createdAt ? new Date(userData.createdAt) : null);
+            if (createdAt) {
+              const sps = userData.subscriptionPeriodStart?.toDate?.()
+                || (userData.subscriptionPeriodStart ? new Date(userData.subscriptionPeriodStart) : undefined);
+              const spe = userData.subscriptionPeriodEnd?.toDate?.()
+                || (userData.subscriptionPeriodEnd ? new Date(userData.subscriptionPeriodEnd) : undefined);
+              const periodInfo = calculateCurrentPeriod({
+                id: userId,
+                plan: (userData.plan as PlanType) || 'free',
+                createdAt,
+                subscriptionPeriodStart: sps,
+                subscriptionPeriodEnd: spe,
+              });
+              const usageMap = await this.batchGetUsage([periodInfo.periodId]);
+              const u = usageMap.get(periodInfo.periodId);
+              if (u) usage = { pdfCount: u.pdfCount || 0, labelCount: u.labelCount || 0 };
+            }
           } catch {
             // Ignore usage errors
           }
@@ -1871,6 +1888,84 @@ export class FirestoreService {
     }
   }
 
+  /**
+   * Lee el doc de usage del período ACTUAL para cada usuario activo (no-admin)
+   * usando PeriodCalculator. Devuelve una sola entrada por usuario.
+   *
+   * Reemplaza al patrón anterior de barrer toda la colección usage, que
+   * incluía periodos vencidos y duplicaba usuarios con docs históricos.
+   */
+  private async getCurrentPeriodUsageEntries(): Promise<Array<{
+    userId: string;
+    plan: PlanType;
+    user: any;
+    pdfCount: number;
+    labelCount: number;
+    periodStart: Date;
+    periodEnd: Date;
+  }>> {
+    const now = new Date();
+    const usersSnapshot = await this.firestore.collection(this.usersCollection).get();
+
+    const candidates: Array<{
+      userId: string;
+      plan: PlanType;
+      user: any;
+      periodId: string;
+      periodStart: Date;
+      periodEnd: Date;
+    }> = [];
+
+    for (const userDoc of usersSnapshot.docs) {
+      const u = userDoc.data();
+      if (u.role === 'admin') continue;
+
+      const plan = (u.plan as PlanType) || 'free';
+      const createdAt = u.createdAt?.toDate?.() || (u.createdAt ? new Date(u.createdAt) : null);
+      if (!createdAt) continue;
+
+      const subscriptionPeriodStart = u.subscriptionPeriodStart?.toDate?.()
+        || (u.subscriptionPeriodStart ? new Date(u.subscriptionPeriodStart) : undefined);
+      const subscriptionPeriodEnd = u.subscriptionPeriodEnd?.toDate?.()
+        || (u.subscriptionPeriodEnd ? new Date(u.subscriptionPeriodEnd) : undefined);
+
+      const periodInfo = calculateCurrentPeriod(
+        {
+          id: userDoc.id,
+          plan,
+          createdAt,
+          subscriptionPeriodStart,
+          subscriptionPeriodEnd,
+        },
+        now,
+      );
+
+      candidates.push({
+        userId: userDoc.id,
+        plan,
+        user: u,
+        periodId: periodInfo.periodId,
+        periodStart: periodInfo.periodStart,
+        periodEnd: periodInfo.periodEnd,
+      });
+    }
+
+    const usageMap = await this.batchGetUsage(candidates.map((c) => c.periodId));
+
+    return candidates.map((c) => {
+      const usage = usageMap.get(c.periodId);
+      return {
+        userId: c.userId,
+        plan: c.plan,
+        user: c.user,
+        pdfCount: usage?.pdfCount || 0,
+        labelCount: usage?.labelCount || 0,
+        periodStart: c.periodStart,
+        periodEnd: c.periodEnd,
+      };
+    });
+  }
+
   async getUsersNearLimit(threshold: number = 80): Promise<Array<{
     id: string;
     email: string;
@@ -1881,69 +1976,30 @@ export class FirestoreService {
     periodEnd: Date;
   }>> {
     try {
-      // Get all current usage documents
-      const usageSnapshot = await this.firestore.collection(this.usageCollection).get();
+      const entries = await this.getCurrentPeriodUsageEntries();
 
-      // Batch read: obtener todos los usuarios únicos en una sola consulta
-      const userIds = usageSnapshot.docs.map((doc) => doc.data().userId).filter(Boolean);
-      const userDataMap: Record<string, any> = {};
-
-      if (userIds.length > 0) {
-        const userRefs = userIds.map((id) =>
-          this.firestore.collection(this.usersCollection).doc(id),
-        );
-        const userDocs = await this.firestore.getAll(...userRefs);
-        userDocs.forEach((doc) => {
-          if (doc.exists) {
-            userDataMap[doc.id] = doc.data();
-          }
-        });
-      }
-
-      const usersNearLimit: Array<{
-        id: string;
-        email: string;
-        plan: PlanType;
-        pdfCount: number;
-        pdfLimit: number;
-        percentUsed: number;
-        periodEnd: Date;
-      }> = [];
-
-      // Procesar sin consultas adicionales
-      for (const doc of usageSnapshot.docs) {
-        const usageData = doc.data();
-        const userId = usageData.userId;
-        const userData = userDataMap[userId];
-
-        if (!userData) continue;
-
-        // Exclude admin users from metrics
-        if (userData.role === 'admin') continue;
-
-        const plan = userData.plan as PlanType;
-        const planLimits = userData.planLimits || DEFAULT_PLAN_LIMITS[plan];
-        const pdfLimit = planLimits?.maxPdfsPerMonth || DEFAULT_PLAN_LIMITS[plan].maxPdfsPerMonth;
-
-        const percentUsed = (usageData.pdfCount / pdfLimit) * 100;
-
-        if (percentUsed >= threshold) {
-          usersNearLimit.push({
-            id: userId,
-            email: userData.email,
-            plan,
-            pdfCount: usageData.pdfCount,
+      const usersNearLimit = entries
+        .map((e) => {
+          const planLimits = e.user.planLimits || DEFAULT_PLAN_LIMITS[e.plan];
+          const pdfLimit = planLimits?.maxPdfsPerMonth || DEFAULT_PLAN_LIMITS[e.plan].maxPdfsPerMonth;
+          const percentUsed = (e.pdfCount / pdfLimit) * 100;
+          return {
+            id: e.userId,
+            email: e.user.email,
+            plan: e.plan,
+            pdfCount: e.pdfCount,
             pdfLimit,
             percentUsed: Math.round(percentUsed),
-            periodEnd: usageData.periodEnd?.toDate?.() || usageData.periodEnd,
-          });
-        }
-      }
+            periodEnd: e.periodEnd,
+            _rawPct: percentUsed,
+          };
+        })
+        .filter((r) => r._rawPct >= threshold)
+        .sort((a, b) => b._rawPct - a._rawPct)
+        .slice(0, 20)
+        .map(({ _rawPct, ...rest }) => rest);
 
-      // Sort by percentUsed descending
-      usersNearLimit.sort((a, b) => b.percentUsed - a.percentUsed);
-
-      return usersNearLimit.slice(0, 20); // Return top 20
+      return usersNearLimit;
     } catch (error) {
       this.logger.error(`Error al obtener usuarios cerca del límite: ${error.message}`);
       throw error;
@@ -1960,76 +2016,33 @@ export class FirestoreService {
     periodEnd: Date;
   }>> {
     try {
-      // Get all current usage documents
-      const usageSnapshot = await this.firestore.collection(this.usageCollection).get();
+      const entries = await this.getCurrentPeriodUsageEntries();
 
-      // Batch read: get all unique users in a single query
-      const userIds = usageSnapshot.docs.map((doc) => doc.data().userId).filter(Boolean);
-      const userDataMap: Record<string, any> = {};
-
-      if (userIds.length > 0) {
-        const userRefs = userIds.map((id) =>
-          this.firestore.collection(this.usersCollection).doc(id),
-        );
-        const userDocs = await this.firestore.getAll(...userRefs);
-        userDocs.forEach((doc) => {
-          if (doc.exists) {
-            userDataMap[doc.id] = doc.data();
-          }
-        });
-      }
-
-      const usersNearLabelLimit: Array<{
-        id: string;
-        email: string;
-        plan: PlanType;
-        labelCount: number;
-        labelLimit: number;
-        percentUsed: number;
-        periodEnd: Date;
-      }> = [];
-
-      // Process without additional queries
-      for (const doc of usageSnapshot.docs) {
-        const usageData = doc.data();
-        const userId = usageData.userId;
-        const userData = userDataMap[userId];
-
-        if (!userData) continue;
-
-        // Exclude admin users from metrics
-        if (userData.role === 'admin') continue;
-
-        const plan = userData.plan as PlanType;
-        const planLimits = userData.planLimits || DEFAULT_PLAN_LIMITS[plan];
-
-        // Calculate monthly label limit as maxPdfsPerMonth * maxLabelsPerPdf
-        const maxPdfs = planLimits?.maxPdfsPerMonth || DEFAULT_PLAN_LIMITS[plan].maxPdfsPerMonth;
-        const maxLabelsPerPdf = planLimits?.maxLabelsPerPdf || DEFAULT_PLAN_LIMITS[plan].maxLabelsPerPdf;
-        const labelLimit = maxPdfs * maxLabelsPerPdf;
-
-        // Skip enterprise users (unlimited)
-        if (plan === 'enterprise') continue;
-
-        const percentUsed = (usageData.labelCount / labelLimit) * 100;
-
-        if (percentUsed >= threshold) {
-          usersNearLabelLimit.push({
-            id: userId,
-            email: userData.email,
-            plan,
-            labelCount: usageData.labelCount,
+      const usersNearLabelLimit = entries
+        .filter((e) => e.plan !== 'enterprise')
+        .map((e) => {
+          const planLimits = e.user.planLimits || DEFAULT_PLAN_LIMITS[e.plan];
+          const maxPdfs = planLimits?.maxPdfsPerMonth || DEFAULT_PLAN_LIMITS[e.plan].maxPdfsPerMonth;
+          const maxLabelsPerPdf = planLimits?.maxLabelsPerPdf || DEFAULT_PLAN_LIMITS[e.plan].maxLabelsPerPdf;
+          const labelLimit = maxPdfs * maxLabelsPerPdf;
+          const percentUsed = (e.labelCount / labelLimit) * 100;
+          return {
+            id: e.userId,
+            email: e.user.email,
+            plan: e.plan,
+            labelCount: e.labelCount,
             labelLimit,
             percentUsed: Math.round(percentUsed),
-            periodEnd: usageData.periodEnd?.toDate?.() || usageData.periodEnd,
-          });
-        }
-      }
+            periodEnd: e.periodEnd,
+            _rawPct: percentUsed,
+          };
+        })
+        .filter((r) => r._rawPct >= threshold)
+        .sort((a, b) => b._rawPct - a._rawPct)
+        .slice(0, 20)
+        .map(({ _rawPct, ...rest }) => rest);
 
-      // Sort by percentUsed descending
-      usersNearLabelLimit.sort((a, b) => b.percentUsed - a.percentUsed);
-
-      return usersNearLabelLimit.slice(0, 20); // Return top 20
+      return usersNearLabelLimit;
     } catch (error) {
       this.logger.error(`Error al obtener usuarios cerca del límite de etiquetas: ${error.message}`);
       throw error;
@@ -2043,24 +2056,7 @@ export class FirestoreService {
     '75-100': number;
   }> {
     try {
-      // Get all current usage documents
-      const usageSnapshot = await this.firestore.collection(this.usageCollection).get();
-
-      // Batch read: get all unique users in a single query
-      const userIds = usageSnapshot.docs.map((doc) => doc.data().userId).filter(Boolean);
-      const userDataMap: Record<string, any> = {};
-
-      if (userIds.length > 0) {
-        const userRefs = userIds.map((id) =>
-          this.firestore.collection(this.usersCollection).doc(id),
-        );
-        const userDocs = await this.firestore.getAll(...userRefs);
-        userDocs.forEach((doc) => {
-          if (doc.exists) {
-            userDataMap[doc.id] = doc.data();
-          }
-        });
-      }
+      const entries = await this.getCurrentPeriodUsageEntries();
 
       const distribution = {
         '0-25': 0,
@@ -2069,28 +2065,15 @@ export class FirestoreService {
         '75-100': 0,
       };
 
-      // Process and categorize users
-      for (const doc of usageSnapshot.docs) {
-        const usageData = doc.data();
-        const userId = usageData.userId;
-        const userData = userDataMap[userId];
+      for (const e of entries) {
+        if (e.plan === 'enterprise') continue;
 
-        if (!userData) continue;
-
-        // Exclude admin users from metrics
-        if (userData.role === 'admin') continue;
-
-        const plan = userData.plan as PlanType;
-
-        // Skip enterprise users (unlimited)
-        if (plan === 'enterprise') continue;
-
-        const planLimits = userData.planLimits || DEFAULT_PLAN_LIMITS[plan];
-        const maxPdfs = planLimits?.maxPdfsPerMonth || DEFAULT_PLAN_LIMITS[plan].maxPdfsPerMonth;
-        const maxLabelsPerPdf = planLimits?.maxLabelsPerPdf || DEFAULT_PLAN_LIMITS[plan].maxLabelsPerPdf;
+        const planLimits = e.user.planLimits || DEFAULT_PLAN_LIMITS[e.plan];
+        const maxPdfs = planLimits?.maxPdfsPerMonth || DEFAULT_PLAN_LIMITS[e.plan].maxPdfsPerMonth;
+        const maxLabelsPerPdf = planLimits?.maxLabelsPerPdf || DEFAULT_PLAN_LIMITS[e.plan].maxLabelsPerPdf;
         const labelLimit = maxPdfs * maxLabelsPerPdf;
 
-        const percentUsed = (usageData.labelCount / labelLimit) * 100;
+        const percentUsed = (e.labelCount / labelLimit) * 100;
 
         if (percentUsed <= 25) {
           distribution['0-25']++;
@@ -2126,101 +2109,42 @@ export class FirestoreService {
   }>> {
     try {
       const now = new Date();
+      const entries = await this.getCurrentPeriodUsageEntries();
 
-      // Get all current usage documents
-      const usageSnapshot = await this.firestore.collection(this.usageCollection).get();
+      const projections = entries
+        .filter((e) => e.pdfCount > 0)
+        .map((e) => {
+          const planLimits = e.user.planLimits || DEFAULT_PLAN_LIMITS[e.plan];
+          const planLimit = planLimits?.maxPdfsPerMonth || DEFAULT_PLAN_LIMITS[e.plan].maxPdfsPerMonth;
 
-      // Batch read: get all unique users in a single query
-      const userIds = usageSnapshot.docs.map((doc) => doc.data().userId).filter(Boolean);
-      const userDataMap: Record<string, any> = {};
+          const daysElapsed = Math.max(
+            1,
+            Math.ceil((now.getTime() - e.periodStart.getTime()) / (1000 * 60 * 60 * 24)),
+          );
+          const dailyRate = e.pdfCount / daysElapsed;
+          const projectedDaysToExhaust = dailyRate > 0 ? Math.round((planLimit / dailyRate) * 10) / 10 : 999;
 
-      if (userIds.length > 0) {
-        const userRefs = userIds.map((id) =>
-          this.firestore.collection(this.usersCollection).doc(id),
-        );
-        const userDocs = await this.firestore.getAll(...userRefs);
-        userDocs.forEach((doc) => {
-          if (doc.exists) {
-            userDataMap[doc.id] = doc.data();
-          }
+          let status: 'critical' | 'risk' | 'normal';
+          if (projectedDaysToExhaust < 15) status = 'critical';
+          else if (projectedDaysToExhaust < 24) status = 'risk';
+          else status = 'normal';
+
+          return {
+            id: e.userId,
+            email: e.user.email || 'unknown',
+            name: e.user.displayName || '',
+            plan: e.plan,
+            billingPeriodStart: e.periodStart,
+            billingPeriodEnd: e.periodEnd,
+            planLimit,
+            pdfsUsed: e.pdfCount,
+            daysElapsed,
+            dailyRate: Math.round(dailyRate * 100) / 100,
+            projectedDaysToExhaust,
+            status,
+          };
         });
-      }
 
-      const projections: Array<{
-        id: string;
-        email: string;
-        name: string;
-        plan: PlanType;
-        billingPeriodStart: Date;
-        billingPeriodEnd: Date;
-        planLimit: number;
-        pdfsUsed: number;
-        daysElapsed: number;
-        dailyRate: number;
-        projectedDaysToExhaust: number;
-        status: 'critical' | 'risk' | 'normal';
-      }> = [];
-
-      for (const doc of usageSnapshot.docs) {
-        const usageData = doc.data();
-        const userId = usageData.userId;
-        const userData = userDataMap[userId];
-
-        if (!userData) continue;
-
-        // Exclude admin users from metrics
-        if (userData.role === 'admin') continue;
-
-        const pdfsUsed = usageData.pdfCount || 0;
-
-        // Only include users with activity (pdfsUsed > 0)
-        if (pdfsUsed === 0) continue;
-
-        const plan = userData.plan as PlanType;
-        const planLimits = userData.planLimits || DEFAULT_PLAN_LIMITS[plan];
-        const planLimit = planLimits?.maxPdfsPerMonth || DEFAULT_PLAN_LIMITS[plan].maxPdfsPerMonth;
-
-        // Get period dates
-        const periodStart = usageData.periodStart?.toDate?.() || new Date(usageData.periodStart);
-        const periodEnd = usageData.periodEnd?.toDate?.() || new Date(usageData.periodEnd);
-
-        // Calculate days elapsed (minimum 1 to avoid division by zero)
-        const daysElapsed = Math.max(1, Math.ceil((now.getTime() - periodStart.getTime()) / (1000 * 60 * 60 * 24)));
-
-        // Calculate daily rate
-        const dailyRate = pdfsUsed / daysElapsed;
-
-        // Calculate projected days to exhaust plan
-        // If dailyRate is 0, set to Infinity (will never exhaust)
-        const projectedDaysToExhaust = dailyRate > 0 ? Math.round((planLimit / dailyRate) * 10) / 10 : 999;
-
-        // Determine status based on projected days
-        let status: 'critical' | 'risk' | 'normal';
-        if (projectedDaysToExhaust < 15) {
-          status = 'critical';
-        } else if (projectedDaysToExhaust < 24) {
-          status = 'risk';
-        } else {
-          status = 'normal';
-        }
-
-        projections.push({
-          id: userId,
-          email: userData.email || 'unknown',
-          name: userData.displayName || '',
-          plan,
-          billingPeriodStart: periodStart,
-          billingPeriodEnd: periodEnd,
-          planLimit,
-          pdfsUsed,
-          daysElapsed,
-          dailyRate: Math.round(dailyRate * 100) / 100,
-          projectedDaysToExhaust,
-          status,
-        });
-      }
-
-      // Sort by projectedDaysToExhaust ascending (most critical first)
       projections.sort((a, b) => a.projectedDaysToExhaust - b.projectedDaysToExhaust);
 
       return projections;
@@ -4899,17 +4823,37 @@ export class FirestoreService {
         filteredUsers.push({ userId, userData, daysInactive, lastActivityAt });
       }
 
-      // PHASE 3: OPTIMIZATION - Batch read all usage documents in one query
-      const usageRefs = filteredUsers.map(({ userId }) =>
-        this.firestore.collection(this.usageCollection).doc(this.generateUsageId(userId)),
+      // PHASE 3: OPTIMIZATION - Batch read all usage documents for current period in one query
+      const periodIdByUser = new Map<string, string>();
+      for (const { userId, userData } of filteredUsers) {
+        const createdAt = userData.createdAt?.toDate?.() || (userData.createdAt ? new Date(userData.createdAt) : null);
+        if (!createdAt) continue;
+        const sps = userData.subscriptionPeriodStart?.toDate?.()
+          || (userData.subscriptionPeriodStart ? new Date(userData.subscriptionPeriodStart) : undefined);
+        const spe = userData.subscriptionPeriodEnd?.toDate?.()
+          || (userData.subscriptionPeriodEnd ? new Date(userData.subscriptionPeriodEnd) : undefined);
+        const periodInfo = calculateCurrentPeriod({
+          id: userId,
+          plan: (userData.plan as PlanType) || 'free',
+          createdAt,
+          subscriptionPeriodStart: sps,
+          subscriptionPeriodEnd: spe,
+        });
+        periodIdByUser.set(userId, periodInfo.periodId);
+      }
+      const usageRefs = [...periodIdByUser.values()].map((id) =>
+        this.firestore.collection(this.usageCollection).doc(id),
       );
       const usageDocs = usageRefs.length > 0 ? await this.firestore.getAll(...usageRefs) : [];
-      const usageMap = new Map<string, FirebaseFirestore.DocumentData>();
-      usageDocs.forEach((doc, index) => {
-        if (doc.exists) {
-          usageMap.set(filteredUsers[index].userId, doc.data()!);
-        }
+      const usageByPeriodId = new Map<string, FirebaseFirestore.DocumentData>();
+      usageDocs.forEach((doc) => {
+        if (doc.exists) usageByPeriodId.set(doc.id, doc.data()!);
       });
+      const usageMap = new Map<string, FirebaseFirestore.DocumentData>();
+      for (const [userId, periodId] of periodIdByUser.entries()) {
+        const data = usageByPeriodId.get(periodId);
+        if (data) usageMap.set(userId, data);
+      }
 
       // PHASE 4: OPTIMIZATION - Parallel email queries instead of sequential
       const emailPromises = filteredUsers.map(({ userId }) =>
@@ -4980,13 +4924,13 @@ export class FirestoreService {
   }
 
   /**
-   * Get PRO power users (users with high PDF count in a given month)
-   * Used for testimonial requests and recognition
-   * Returns structured response with users, summary, and pagination
+   * @deprecated Reemplazada por EmailService.getPowerUsersWithPeriod, que usa el período
+   * de facturación de cada usuario (esquema `_YYYYMMDD`) en vez del mes calendario legacy
+   * (`_YYYYMM`). Conservada como stub para evitar romper integraciones externas.
    */
   async getProPowerUsers(params: {
-    minPercentile?: number; // Minimum percentile (e.g., 90 for top 10%)
-    month?: string; // Format: YYYY-MM (defaults to previous month)
+    minPercentile?: number;
+    month?: string;
     page?: number;
     limit?: number;
   }): Promise<{
@@ -5017,137 +4961,21 @@ export class FirestoreService {
       totalPages: number;
     };
   }> {
-    const { minPercentile = 90, month, page = 1, limit = 50 } = params;
-
-    // Default to previous month
-    const targetDate = month
-      ? new Date(`${month}-01`)
-      : new Date(new Date().getFullYear(), new Date().getMonth() - 1, 1);
-    // Format: YYYYMM (without hyphen) to match generateUsageId() format
-    const targetMonth = `${targetDate.getFullYear()}${String(targetDate.getMonth() + 1).padStart(2, '0')}`;
-
-    // Initialize summary
-    const summary = {
-      total: 0,
-      topPerformers: 0,
-      avgMonthlyPdfs: 0,
-      byPlan: { free: 0, pro: 0, promax: 0, enterprise: 0 },
+    this.logger.warn(
+      'getProPowerUsers (calendar-month, _YYYYMM) is deprecated. ' +
+      'Caller should use EmailService.getPowerUsersWithPeriod instead.',
+    );
+    const { page = 1, limit = 50 } = params;
+    return {
+      users: [],
+      summary: {
+        total: 0,
+        topPerformers: 0,
+        avgMonthlyPdfs: 0,
+        byPlan: { free: 0, pro: 0, promax: 0, enterprise: 0 },
+      },
+      pagination: { page, limit, total: 0, totalPages: 0 },
     };
-
-    try {
-      // Get all users with any plan for summary
-      const usersSnapshot = await this.firestore
-        .collection(this.usersCollection)
-        .get();
-
-      const allUsersWithUsage: Array<{
-        userId: string;
-        userEmail: string;
-        displayName?: string;
-        language: EmailLanguage;
-        pdfsThisMonth: number;
-        labelsThisMonth: number;
-        monthsAsPro: number;
-        plan: string;
-      }> = [];
-
-      let totalPdfs = 0;
-      let usersWithUsage = 0;
-
-      // OPTIMIZATION: Batch read all usage documents in one query instead of N queries
-      const usageRefs = usersSnapshot.docs.map(doc =>
-        this.firestore.collection(this.usageCollection).doc(`${doc.id}_${targetMonth}`),
-      );
-
-      // Batch read: 1 query for all usage docs instead of N individual queries
-      const usageDocs = usageRefs.length > 0 ? await this.firestore.getAll(...usageRefs) : [];
-
-      // Create Map for O(1) lookup
-      const usageMap = new Map<string, FirebaseFirestore.DocumentData>();
-      usageDocs.forEach((doc, index) => {
-        if (doc.exists) {
-          usageMap.set(usersSnapshot.docs[index].id, doc.data()!);
-        }
-      });
-
-      // Now iterate without additional queries
-      for (const doc of usersSnapshot.docs) {
-        const userData = doc.data();
-        const userId = doc.id;
-
-        // Get usage from Map (O(1) lookup, no query)
-        const usageData = usageMap.get(userId) || null;
-        const pdfCount = usageData?.pdfCount || 0;
-
-        if (pdfCount > 0) {
-          usersWithUsage++;
-          totalPdfs += pdfCount;
-
-          // Count by plan
-          const plan = userData.plan || 'free';
-          if (plan === 'free') summary.byPlan.free++;
-          else if (plan === 'pro') summary.byPlan.pro++;
-          else if (plan === 'promax') summary.byPlan.promax++;
-          else if (plan === 'enterprise') summary.byPlan.enterprise++;
-
-          // Calculate months as PRO
-          const createdAt = userData.createdAt?.toDate?.() || userData.createdAt || new Date();
-          const monthsAsPro = Math.floor((new Date().getTime() - createdAt.getTime()) / (30 * 24 * 60 * 60 * 1000));
-
-          allUsersWithUsage.push({
-            userId,
-            userEmail: userData.email,
-            displayName: userData.displayName,
-            language: this.detectLanguageFromCountry(userData.country),
-            pdfsThisMonth: pdfCount,
-            labelsThisMonth: usageData?.labelCount || 0,
-            monthsAsPro: Math.max(1, monthsAsPro),
-            plan,
-          });
-        }
-      }
-
-      // Sort by PDF count (highest first)
-      allUsersWithUsage.sort((a, b) => b.pdfsThisMonth - a.pdfsThisMonth);
-
-      // Calculate percentile threshold
-      const percentileIndex = Math.floor(allUsersWithUsage.length * (1 - minPercentile / 100));
-      const percentileThreshold = allUsersWithUsage[percentileIndex]?.pdfsThisMonth || 0;
-
-      // Filter to power users (above percentile threshold)
-      const powerUsers = allUsersWithUsage.filter(u => u.pdfsThisMonth >= percentileThreshold);
-
-      // Update summary
-      summary.total = powerUsers.length;
-      summary.topPerformers = Math.min(10, powerUsers.length); // Top 10 performers
-      summary.avgMonthlyPdfs = usersWithUsage > 0 ? Math.round(totalPdfs / usersWithUsage) : 0;
-
-      // Apply pagination
-      const totalPages = Math.ceil(powerUsers.length / limit);
-      const startIndex = (page - 1) * limit;
-      const paginatedUsers = powerUsers.slice(startIndex, startIndex + limit);
-
-      // Remove plan field from output
-      const users = paginatedUsers.map(({ plan, ...user }) => user);
-
-      return {
-        users,
-        summary,
-        pagination: {
-          page,
-          limit,
-          total: powerUsers.length,
-          totalPages,
-        },
-      };
-    } catch (error) {
-      this.logger.error(`Error getting PRO power users: ${error.message}`);
-      return {
-        users: [],
-        summary,
-        pagination: { page, limit, total: 0, totalPages: 0 },
-      };
-    }
   }
 
   /**

--- a/src/modules/email/email.service.ts
+++ b/src/modules/email/email.service.ts
@@ -814,8 +814,9 @@ export class EmailService {
         return null;
       }
 
-      // Get usage data for pdfCount and period dates
-      const usage = await this.firestoreService.getOrCreateUsage(userId);
+      // Get usage data for pdfCount and period dates (período actual del usuario)
+      const periodInfo = this.periodCalculatorService.calculateCurrentPeriod(user);
+      const usage = await this.firestoreService.getOrCreateUsageWithPeriod(userId, periodInfo);
       const limit = user.planLimits?.maxPdfsPerMonth || 25;
       const pdfsUsed = usage.pdfCount || 0;
 
@@ -1017,8 +1018,8 @@ export class EmailService {
         return { scheduled: 0, skipped: 0, executedAt: new Date() };
       }
 
-      // Get power users from previous month (top 10% of users)
-      const powerUsersResponse = await this.firestoreService.getProPowerUsers({
+      // Get power users using each user's billing period (top 10%)
+      const powerUsersResponse = await this.getPowerUsersWithPeriod({
         minPercentile: 90,
         limit: 50,
       });

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -419,7 +419,7 @@ export class UsersService {
     status: 'completed' | 'failed',
     outputFormat: 'pdf' | 'png' | 'jpeg' = 'pdf',
     fileUrl?: string,
-    periodId?: string,
+    periodInfo?: PeriodInfo,
     userPlan?: 'free' | 'pro' | 'enterprise',
   ): Promise<void> {
     // Save to history (use null instead of undefined for Firestore)
@@ -457,16 +457,15 @@ export class UsersService {
 
     // Increment usage only for completed conversions
     if (status === 'completed') {
-      if (periodId) {
-        // Usar el periodId proporcionado (más eficiente)
-        await this.firestoreService.incrementUsageWithPeriod(userId, periodId, 1, labelCount);
-      } else {
-        // Fallback: calcular período (para compatibilidad hacia atrás)
+      let effectivePeriod = periodInfo;
+      if (!effectivePeriod) {
         const user = await this.firestoreService.getUserById(userId);
         if (user) {
-          const periodInfo = this.periodCalculatorService.calculateCurrentPeriod(user);
-          await this.firestoreService.incrementUsageWithPeriod(userId, periodInfo.periodId, 1, labelCount);
+          effectivePeriod = this.periodCalculatorService.calculateCurrentPeriod(user);
         }
+      }
+      if (effectivePeriod) {
+        await this.firestoreService.incrementUsageWithPeriod(userId, effectivePeriod, 1, labelCount);
       }
 
       // Check and trigger limit emails (fire-and-forget)

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -492,8 +492,9 @@ export class UsersService {
       const user = await this.firestoreService.getUserById(userId);
       if (!user) return;
 
-      // Get usage data for pdfCount and period dates
-      const usage = await this.firestoreService.getOrCreateUsage(userId);
+      // Get usage data for pdfCount and period dates (período actual del usuario)
+      const periodInfo = this.periodCalculatorService.calculateCurrentPeriod(user);
+      const usage = await this.firestoreService.getOrCreateUsageWithPeriod(userId, periodInfo);
       const pdfCount = usage.pdfCount || 0;
       const limit = user.planLimits?.maxPdfsPerMonth || DEFAULT_PLAN_LIMITS.free.maxPdfsPerMonth;
       const percentage = (pdfCount / limit) * 100;

--- a/src/modules/zpl/zpl.service.ts
+++ b/src/modules/zpl/zpl.service.ts
@@ -12,6 +12,7 @@ import { Writable } from 'stream';
 import { pdfToPng, PngPageOutput } from 'pdf-to-png-converter';
 import { FirestoreService, ConversionStatus, ErrorLogData } from '../cache/firestore.service.js';
 import { UsersService } from '../users/users.service.js';
+import type { PeriodInfo } from '../../common/services/period-calculator.service.js';
 import { OutputFormat } from './enums/output-format.enum.js';
 import type { BatchJob, BatchFileJob, BatchLimits } from './interfaces/batch.interface.js';
 import { BATCH_LIMITS } from './interfaces/batch.interface.js';
@@ -311,9 +312,9 @@ export class ZplService {
       }
 
       // Encolar el trabajo para procesamiento asincrono
-      const periodId = canConvert.periodInfo?.periodId;
+      const periodInfo = canConvert.periodInfo;
       setTimeout(() => {
-        this.processZplConversionWithUser(zplContent, labelSize, jobId, userId, labelCount, outputFormat, periodId, userPlan as 'free' | 'pro' | 'enterprise');
+        this.processZplConversionWithUser(zplContent, labelSize, jobId, userId, labelCount, outputFormat, periodInfo, userPlan as 'free' | 'pro' | 'enterprise');
       }, 100);
 
       // Guardar ZPL para debugging de forma asíncrona (no bloquea)
@@ -350,7 +351,7 @@ export class ZplService {
     userId: string,
     labelCount: number,
     outputFormat: OutputFormat = OutputFormat.PDF,
-    periodId?: string,
+    periodInfo?: PeriodInfo,
     userPlan?: 'free' | 'pro' | 'enterprise',
   ): Promise<void> {
     try {
@@ -368,7 +369,7 @@ export class ZplService {
           'completed',
           outputFormat,
           job.resultUrl,
-          periodId,
+          periodInfo,
           userPlan,
         );
         // Update ZPL debug result
@@ -384,7 +385,7 @@ export class ZplService {
           'failed',
           outputFormat,
           undefined,
-          periodId,
+          periodInfo,
           userPlan,
         );
         // Update ZPL debug result
@@ -403,7 +404,7 @@ export class ZplService {
           'failed',
           outputFormat,
           undefined,
-          periodId,
+          periodInfo,
           userPlan,
         );
         // Update ZPL debug result
@@ -1711,8 +1712,7 @@ export class ZplService {
       }));
 
       // Iniciar procesamiento asíncrono
-      const periodId = userLimits.periodInfo?.periodId;
-      this.processBatchFiles(batchId, files, batchJobs, labelSize, outputFormat, periodId);
+      this.processBatchFiles(batchId, files, batchJobs, labelSize, outputFormat, userLimits.periodInfo);
 
       return { batchId, jobs: jobsMapping };
     } catch (error) {
@@ -1734,7 +1734,7 @@ export class ZplService {
     jobs: BatchFileJob[],
     labelSize: string,
     outputFormat: 'pdf' | 'png' | 'jpeg',
-    periodId?: string,
+    periodInfo?: PeriodInfo,
   ): Promise<void> {
     const size = this.getLabelSize(labelSize);
     let completedCount = 0;
@@ -1816,7 +1816,7 @@ export class ZplService {
             'completed',
             outputFormat,
             undefined,
-            periodId,
+            periodInfo,
           );
         }
 
@@ -1838,7 +1838,7 @@ export class ZplService {
               'failed',
               outputFormat,
               undefined,
-              periodId,
+              periodInfo,
             );
           } catch (recordError) {
             this.logger.error(`Error registrando conversión fallida: ${recordError.message}`);

--- a/src/scripts/cleanup-usage-legacy.ts
+++ b/src/scripts/cleanup-usage-legacy.ts
@@ -1,0 +1,141 @@
+/**
+ * Cleanup script para la colección `usage`.
+ *
+ * Borra docs basura acumulados tras la convivencia de dos esquemas de período:
+ *   - Legacy `_YYYYMM` (mes calendario, generado por el ya-eliminado getOrCreateUsage)
+ *   - Moderno `_YYYYMMDD` (aniversario del usuario / Stripe, generado por
+ *     getOrCreateUsageWithPeriod)
+ *
+ * Reglas de borrado:
+ *   1. Cualquier doc `_YYYYMM` con pdfCount=0 y labelCount=0 → borrar (residuo).
+ *   2. Cualquier doc `_YYYYMMDD` con pdfCount=0 y labelCount=0 cuyo periodEnd
+ *      ya pasó → borrar (período cerrado sin uso real).
+ *   3. Docs `_YYYYMM` con datos reales → NO borrar; loggear para migración manual.
+ *   4. Docs `_YYYYMMDD` del período actual (incluso si están en 0) → conservar.
+ *
+ * Uso:
+ *   npx tsx src/scripts/cleanup-usage-legacy.ts            # dry-run (default)
+ *   npx tsx src/scripts/cleanup-usage-legacy.ts --execute  # aplica borrados
+ */
+
+import admin from 'firebase-admin';
+import dotenv from 'dotenv';
+import fs from 'fs';
+import path from 'path';
+
+dotenv.config();
+
+const execute = process.argv.includes('--execute');
+
+const credentialsPath = path.join(process.cwd(), 'firebase-credentials.json');
+if (!process.env.FIREBASE_CREDENTIALS && fs.existsSync(credentialsPath)) {
+  process.env.FIREBASE_CREDENTIALS = fs.readFileSync(credentialsPath, 'utf8');
+}
+
+async function main(): Promise<void> {
+  const raw = process.env.FIREBASE_CREDENTIALS || process.env.GOOGLE_CREDENTIALS;
+  if (!raw) {
+    console.error('No Firebase credentials found');
+    process.exit(1);
+  }
+  const parsed = JSON.parse(raw);
+  if (parsed.private_key) parsed.private_key = parsed.private_key.replace(/\\n/g, '\n');
+
+  admin.initializeApp({
+    credential: admin.credential.cert(parsed),
+    projectId: process.env.FIREBASE_PROJECT_ID || parsed.project_id,
+  });
+  const db = admin.firestore();
+
+  console.log(`Mode: ${execute ? 'EXECUTE (will delete docs)' : 'DRY-RUN (no writes)'}`);
+  console.log('Reading usage collection...');
+
+  const snap = await db.collection('usage').get();
+  console.log(`Total docs: ${snap.size}`);
+
+  const now = new Date();
+  const toDelete: string[] = [];
+  const preserveLegacyWithData: Array<{ id: string; pdf: number; labels: number; userId: string }> = [];
+  let legacyEmptyDeleted = 0;
+  let modernExpiredEmptyDeleted = 0;
+  let modernCurrentPreserved = 0;
+  let modernExpiredWithDataPreserved = 0;
+
+  for (const doc of snap.docs) {
+    const id = doc.id;
+    const data = doc.data();
+    const lastPart = id.split('_').pop() || '';
+    const pdf = data.pdfCount || 0;
+    const labels = data.labelCount || 0;
+    const isEmpty = pdf === 0 && labels === 0;
+    const periodEnd: Date | null = data.periodEnd?.toDate?.()
+      || (data.periodEnd ? new Date(data.periodEnd) : null);
+
+    if (/^\d{6}$/.test(lastPart)) {
+      if (isEmpty) {
+        toDelete.push(id);
+        legacyEmptyDeleted++;
+      } else {
+        preserveLegacyWithData.push({ id, pdf, labels, userId: data.userId });
+      }
+    } else if (/^\d{8}$/.test(lastPart)) {
+      const isCurrent = !!periodEnd && periodEnd >= now;
+      if (isCurrent) {
+        modernCurrentPreserved++;
+      } else if (isEmpty) {
+        toDelete.push(id);
+        modernExpiredEmptyDeleted++;
+      } else {
+        modernExpiredWithDataPreserved++;
+      }
+    } else {
+      console.warn(`Skipping unknown id format: ${id}`);
+    }
+  }
+
+  console.log('\n=== Plan ===');
+  console.log(`Legacy _YYYYMM empty (delete): ${legacyEmptyDeleted}`);
+  console.log(`Legacy _YYYYMM with data (PRESERVE, manual migration needed): ${preserveLegacyWithData.length}`);
+  console.log(`Modern _YYYYMMDD expired empty (delete): ${modernExpiredEmptyDeleted}`);
+  console.log(`Modern _YYYYMMDD expired with data (preserve as history): ${modernExpiredWithDataPreserved}`);
+  console.log(`Modern _YYYYMMDD current period (preserve): ${modernCurrentPreserved}`);
+  console.log(`Total to delete: ${toDelete.length}`);
+
+  if (preserveLegacyWithData.length > 0) {
+    console.log('\n--- Legacy docs WITH data (manual review) ---');
+    for (const d of preserveLegacyWithData) {
+      console.log(`  ${d.id}  pdf=${d.pdf} labels=${d.labels} userId=${d.userId}`);
+    }
+  }
+
+  if (!execute) {
+    console.log('\nDry-run done. Re-run with --execute to delete.');
+    process.exit(0);
+  }
+
+  if (toDelete.length === 0) {
+    console.log('\nNothing to delete.');
+    process.exit(0);
+  }
+
+  console.log(`\nDeleting ${toDelete.length} docs in batches of 500...`);
+  let deleted = 0;
+  for (let i = 0; i < toDelete.length; i += 500) {
+    const batch = db.batch();
+    const chunk = toDelete.slice(i, i + 500);
+    for (const id of chunk) {
+      batch.delete(db.collection('usage').doc(id));
+    }
+    await batch.commit();
+    deleted += chunk.length;
+    console.log(`  Deleted ${deleted}/${toDelete.length}`);
+  }
+
+  console.log(`\nDone. Deleted ${deleted} docs.`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Cleanup failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Refactoriza `getUsersNearLimit` y 3 funciones hermanas para que lean solo el doc del **período actual** de cada usuario (vía `PeriodCalculatorService` + `batchGetUsage`). El dashboard admin ya no reporta excesos espurios (>100%) ni duplicados — investigación previa: 0/1217 usuarios excedían realmente su límite, los 20 "near limit" eran 100% ruido histórico.
- Migra los 4 callsites legacy de `getOrCreateUsage` (`_YYYYMM`, mes calendario) a `getOrCreateUsageWithPeriod` (`_YYYYMMDD`, aniversario del usuario / Stripe). Detiene la generación continua de docs basura desde emails y listados admin.
- `incrementUsageWithPeriod` ahora usa `FieldValue.increment` para incremento atómico (elimina race condition de read-then-write bajo concurrencia).
- `getProPowerUsers` (que leía docs `_YYYYMM` inline) reemplazada por stub `@deprecated`; el único caller (`email.service.scheduleProPowerUserEmails`) ya redirigido a `getPowerUsersWithPeriod` existente.
- Script `src/scripts/cleanup-usage-legacy.ts` para borrar docs basura (dry-run por defecto, `--execute` aplica).
- Extracción de lógica de período a `period-calculator.util.ts` para evitar dependencia circular `CacheModule → PeriodModule → BillingModule`.

## Impacto en producción

Ejecutado el cleanup: **4786 → 1305 docs** en colección `usage` (-3481). Se preservan:
- 1034 docs históricos con datos reales
- 270 docs del período actual de cada usuario
- 1 doc legacy con datos (`aWtRK9nOnZQpEhSw9nJ4ci2Pkwq2_202512`, pdf=14, labels=471) para migración manual posterior

Verificación post-fix contra Firestore real: los 4 usuarios "problema" (zaincholan11, francomorashop, jesicapatino23, ecommerce@amalfi) ahora muestran su uso real del período actual (0-36%, no 380%/100%). Solo 2 usuarios quedan legítimamente entre 80-100%.

## Test plan

- [ ] Verificar que `/api/admin/metrics` devuelve `usersNearLimit` sin duplicados ni `percentUsed > 100%` para free puros
- [ ] Verificar que `/api/admin/metrics` devuelve `usersNearLabelLimit`, `getLabelUsageDistribution` y `getConsumptionProjection` coherentes (un registro por usuario, basado en período actual)
- [ ] Confirmar que tras 24h de tráfico la colección `usage` NO crece con nuevos docs `_YYYYMM`
- [ ] Confirmar que conversiones siguen incrementando `pdfCount`/`labelCount` correctamente
- [ ] (Opcional) decidir qué hacer con el doc legacy preservado `aWtRK9nOnZQpEhSw9nJ4ci2Pkwq2_202512`

🤖 Generated with [Claude Code](https://claude.com/claude-code)