### PR TITLE
fix(email): usar límite real del plan en email de bloqueo (#46)

### DIFF
--- a/src/common/services/period-calculator.util.spec.ts
+++ b/src/common/services/period-calculator.util.spec.ts
@@ -1,0 +1,104 @@
+import {
+  calculateCurrentPeriod,
+  calculateFreePeriod,
+  generatePeriodId,
+  UserForPeriod,
+} from './period-calculator.util';
+
+describe('period-calculator.util', () => {
+  describe('calculateFreePeriod (usuario Free registrado a mitad de mes)', () => {
+    // Usuario registrado el 15 de enero. El período mensual debe correr del día 15
+    // al día 15 del mes siguiente, NO del 1 al 31 (mes calendario).
+    const userId = 'user-free-1';
+    const createdAt = new Date(2026, 0, 15); // 15 ene 2026
+
+    it('ancla periodStart al día de registro del período que contiene "now"', () => {
+      const now = new Date(2026, 4, 20); // 20 may 2026
+      const period = calculateFreePeriod(userId, createdAt, now);
+
+      expect(period.periodStart).toEqual(new Date(2026, 4, 15)); // 15 may
+      expect(period.periodStart.getTime()).toBeLessThanOrEqual(now.getTime());
+      expect(period.periodEnd.getTime()).toBeGreaterThan(now.getTime());
+      expect(period.periodId).toBe(`${userId}_20260515`);
+    });
+
+    it('retrocede un mes cuando "now" es anterior al día de registro del mes actual', () => {
+      const now = new Date(2026, 4, 10); // 10 may (antes del día 15)
+      const period = calculateFreePeriod(userId, createdAt, now);
+
+      // El período vigente arrancó el 15 de abril, no el 15 de mayo (que es futuro).
+      expect(period.periodStart).toEqual(new Date(2026, 3, 15)); // 15 abr
+      expect(period.periodId).toBe(`${userId}_20260415`);
+    });
+
+    it('es determinista: el mismo usuario y "now" producen el mismo periodId', () => {
+      const now = new Date(2026, 4, 20);
+      const a = calculateFreePeriod(userId, createdAt, now);
+      const b = calculateFreePeriod(userId, createdAt, now);
+      expect(a.periodId).toBe(b.periodId);
+    });
+  });
+
+  describe('calculateCurrentPeriod (unificación bloqueo ↔ emails)', () => {
+    // Garantía central del issue #46: el bloqueo de conversiones y los emails de
+    // límite deben usar EXACTAMENTE el mismo periodId. Como ambos flujos llaman a
+    // calculateCurrentPeriod(user), basta probar que para un mismo usuario Free
+    // registrado a mitad de mes la función devuelve un periodId estable.
+    const freeUser: UserForPeriod = {
+      id: 'user-mid-month',
+      plan: 'free',
+      createdAt: new Date(2026, 0, 17), // registrado el 17
+    };
+
+    it('Free deriva el período de createdAt (no de mes calendario)', () => {
+      const now = new Date(2026, 4, 25); // 25 may
+      const period = calculateCurrentPeriod(freeUser, now);
+
+      expect(period.periodStart).toEqual(new Date(2026, 4, 17)); // 17 may
+      expect(period.periodId).toBe('user-mid-month_20260517');
+    });
+
+    it('bloqueo y emails obtienen el mismo periodId para el mismo usuario y momento', () => {
+      const now = new Date(2026, 4, 25);
+
+      // Simula los dos call sites independientes: checkCanConvert (bloqueo) y
+      // checkAndTriggerLimitEmails / triggerBlockedEmail (emails).
+      const periodEnBloqueo = calculateCurrentPeriod(freeUser, now);
+      const periodEnEmail = calculateCurrentPeriod(freeUser, now);
+
+      expect(periodEnEmail.periodId).toBe(periodEnBloqueo.periodId);
+      expect(periodEnEmail.periodStart).toEqual(periodEnBloqueo.periodStart);
+      expect(periodEnEmail.periodEnd).toEqual(periodEnBloqueo.periodEnd);
+    });
+
+    it('Lite sin suscripción de Stripe también deriva el período de createdAt', () => {
+      const liteUser: UserForPeriod = { ...freeUser, plan: 'lite' };
+      const now = new Date(2026, 4, 25);
+      const period = calculateCurrentPeriod(liteUser, now);
+
+      expect(period.periodStart).toEqual(new Date(2026, 4, 17));
+      expect(period.periodId).toBe('user-mid-month_20260517');
+    });
+
+    it('Pro con período de Stripe usa esas fechas, no createdAt', () => {
+      const proUser: UserForPeriod = {
+        id: 'user-pro',
+        plan: 'pro',
+        createdAt: new Date(2026, 0, 17),
+        subscriptionPeriodStart: new Date(2026, 4, 3),
+        subscriptionPeriodEnd: new Date(2026, 5, 3),
+      };
+      const now = new Date(2026, 4, 25);
+      const period = calculateCurrentPeriod(proUser, now);
+
+      expect(period.periodStart).toEqual(new Date(2026, 4, 3));
+      expect(period.periodId).toBe('user-pro_20260503');
+    });
+  });
+
+  describe('generatePeriodId', () => {
+    it('formatea como userId_YYYYMMDD con padding', () => {
+      expect(generatePeriodId('u1', new Date(2026, 2, 5))).toBe('u1_20260305');
+    });
+  });
+});

--- a/src/modules/email/email.service.spec.ts
+++ b/src/modules/email/email.service.spec.ts
@@ -1,0 +1,122 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { EmailService } from './email.service';
+import { FirestoreService } from '../cache/firestore.service';
+import { PeriodCalculatorService } from '../../common/services/period-calculator.service';
+import { User } from '../../common/interfaces/user.interface';
+
+describe('EmailService.triggerBlockedEmail', () => {
+  let service: EmailService;
+  let firestore: { getUserById: jest.Mock; getOrCreateUsageWithPeriod: jest.Mock; getOrCreateUsage: jest.Mock };
+  let periodCalculator: PeriodCalculatorService;
+
+  const baseUser: User = {
+    id: 'user-free-mid-month',
+    email: 'free@example.com',
+    displayName: 'Free User',
+    emailVerified: true,
+    plan: 'free',
+    role: 'user',
+    country: 'MX',
+    // Registrado a mitad de mes: el período corre por aniversario, no mes calendario.
+    createdAt: new Date(2026, 0, 17),
+  } as User;
+
+  beforeEach(async () => {
+    firestore = {
+      getUserById: jest.fn(),
+      getOrCreateUsageWithPeriod: jest.fn(),
+      // Método legacy: NO debe invocarse desde el flujo de límites.
+      getOrCreateUsage: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmailService,
+        PeriodCalculatorService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) =>
+              key === 'RESEND_API_KEY' ? 'test-key' : undefined,
+          },
+        },
+        { provide: FirestoreService, useValue: firestore },
+      ],
+    }).compile();
+
+    service = module.get<EmailService>(EmailService);
+    periodCalculator = module.get<PeriodCalculatorService>(PeriodCalculatorService);
+  });
+
+  function mockUsage(user: User, pdfCount: number) {
+    const period = periodCalculator.calculateCurrentPeriod(user);
+    firestore.getUserById.mockResolvedValue(user);
+    firestore.getOrCreateUsageWithPeriod.mockResolvedValue({
+      odId: period.periodId,
+      pdfCount,
+      periodStart: period.periodStart,
+      periodEnd: period.periodEnd,
+    });
+    return period;
+  }
+
+  it('encola conversion_blocked para un usuario Free que alcanzó su límite real de 10', async () => {
+    // Regresión del bug: el fallback hardcodeado `|| 25` dejaba a los usuarios Free
+    // (límite real 10) sin email de bloqueo, porque 10 < 25.
+    mockUsage(baseUser, 10);
+    const queueSpy = jest
+      .spyOn(service, 'queueLimitEmail')
+      .mockResolvedValue('queued-id');
+
+    const result = await service.triggerBlockedEmail(baseUser.id);
+
+    expect(result).toBe('queued-id');
+    expect(queueSpy).toHaveBeenCalledWith(
+      baseUser.id,
+      'conversion_blocked',
+      expect.objectContaining({ pdfsUsed: 10, limit: 10 }),
+    );
+  });
+
+  it('usa el período por aniversario (getOrCreateUsageWithPeriod), no el legacy', async () => {
+    const period = mockUsage(baseUser, 10);
+    jest.spyOn(service, 'queueLimitEmail').mockResolvedValue('queued-id');
+
+    await service.triggerBlockedEmail(baseUser.id);
+
+    // El email lee el MISMO período que usa el bloqueo de conversiones.
+    expect(firestore.getOrCreateUsageWithPeriod).toHaveBeenCalledWith(
+      baseUser.id,
+      expect.objectContaining({ periodId: period.periodId }),
+    );
+    expect(firestore.getOrCreateUsage).not.toHaveBeenCalled();
+  });
+
+  it('no encola si el usuario Free aún no alcanzó el límite (9/10)', async () => {
+    mockUsage(baseUser, 9);
+    const queueSpy = jest.spyOn(service, 'queueLimitEmail');
+
+    const result = await service.triggerBlockedEmail(baseUser.id);
+
+    expect(result).toBeNull();
+    expect(queueSpy).not.toHaveBeenCalled();
+  });
+
+  it('respeta el límite real de Lite (25) sin el hardcode previo', async () => {
+    const liteUser = { ...baseUser, plan: 'lite' } as User;
+    mockUsage(liteUser, 25);
+    const queueSpy = jest
+      .spyOn(service, 'queueLimitEmail')
+      .mockResolvedValue('queued-id');
+
+    const result = await service.triggerBlockedEmail(liteUser.id);
+
+    expect(result).toBe('queued-id');
+    expect(queueSpy).toHaveBeenCalledWith(
+      liteUser.id,
+      'conversion_blocked',
+      expect.objectContaining({ pdfsUsed: 25, limit: 25 }),
+    );
+  });
+});

--- a/src/modules/email/email.service.ts
+++ b/src/modules/email/email.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { Resend } from 'resend';
 import { FirestoreService } from '../cache/firestore.service.js';
 import { PeriodCalculatorService } from '../../common/services/period-calculator.service.js';
+import { DEFAULT_PLAN_LIMITS } from '../../common/interfaces/user.interface.js';
 import type {
   EmailType,
   AbVariant,
@@ -817,7 +818,11 @@ export class EmailService {
       // Get usage data for pdfCount and period dates (período actual del usuario)
       const periodInfo = this.periodCalculatorService.calculateCurrentPeriod(user);
       const usage = await this.firestoreService.getOrCreateUsageWithPeriod(userId, periodInfo);
-      const limit = user.planLimits?.maxPdfsPerMonth || 25;
+      // Usar el límite real del plan (Free=10, Lite=25). El fallback hardcodeado a 25
+      // dejaba sin enviar el email de bloqueo a usuarios Free, que se bloquean a los 10.
+      const limit = user.planLimits?.maxPdfsPerMonth
+        || DEFAULT_PLAN_LIMITS[user.plan]?.maxPdfsPerMonth
+        || DEFAULT_PLAN_LIMITS.free.maxPdfsPerMonth;
       const pdfsUsed = usage.pdfCount || 0;
 
       if (pdfsUsed < limit) {

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -118,9 +118,10 @@ export class UsersController {
     summary: 'Get user limits and current usage',
     description:
       'El período de uso es mensual desde la fecha de registro del usuario (createdAt), ' +
-      'NO mes calendario. Free y Lite calculan el período a partir de createdAt; Pro/Pro Max/' +
-      'Enterprise usan el período de facturación de Stripe almacenado en Firestore. Este mismo ' +
-      'período se usa para el bloqueo de conversiones y para los emails de límite (80%, 100%, bloqueo).',
+      'NO mes calendario. Free siempre calcula el período a partir de createdAt. Los planes con ' +
+      'período de facturación de Stripe almacenado en Firestore (Lite/Pro/Pro Max/Enterprise) usan ' +
+      'ese período de Stripe; si no hay período de Stripe disponible, se usa createdAt como fallback. ' +
+      'Este mismo período se usa para el bloqueo de conversiones y para los emails de límite (80%, 100%, bloqueo).',
   })
   @ApiResponse({
     status: 200,

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -114,7 +114,14 @@ export class UsersController {
   }
 
   @Get('limits')
-  @ApiOperation({ summary: 'Get user limits and current usage' })
+  @ApiOperation({
+    summary: 'Get user limits and current usage',
+    description:
+      'El período de uso es mensual desde la fecha de registro del usuario (createdAt), ' +
+      'NO mes calendario. Free y Lite calculan el período a partir de createdAt; Pro/Pro Max/' +
+      'Enterprise usan el período de facturación de Stripe almacenado en Firestore. Este mismo ' +
+      'período se usa para el bloqueo de conversiones y para los emails de límite (80%, 100%, bloqueo).',
+  })
   @ApiResponse({
     status: 200,
     description: 'User limits and usage',


### PR DESCRIPTION
## Contexto

Investigación del issue #46. El bug principal que reportaba (período de uso inconsistente entre bloqueo y emails) **ya estaba resuelto** por el commit `94c1cd8`, que migró todos los call sites de `getOrCreateUsage` (mes calendario) a `getOrCreateUsageWithPeriod` + `calculateCurrentPeriod` (período por aniversario). El propio `firestore.service.ts:461` marca el método legacy como `@deprecated Sin call sites`.

Pero quedaba un **síntoma residual vivo**, introducido al añadir el plan Lite (`e3d89ee`), que reduce el mismo CTA de upgrade que motivaba el issue.

## Bug corregido

En `email.service.ts#triggerBlockedEmail` el límite mensual usaba un fallback hardcodeado:

```ts
const limit = user.planLimits?.maxPdfsPerMonth || 25;
```

Como Free pasó de 25 → **10** PDFs/mes y los usuarios Free no tienen `planLimits` personalizado, el fallback `25` se activaba. Resultado: un usuario Free bloqueado a los 10 PDFs entraba en `if (pdfsUsed < limit)` → `if (10 < 25)` → `true` → **no se enviaba el email `conversion_blocked`**, justo en el momento de mayor intención de upgrade.

Ahora usa la misma cadena que `checkAndTriggerLimitEmails`:

```ts
const limit = user.planLimits?.maxPdfsPerMonth
  || DEFAULT_PLAN_LIMITS[user.plan]?.maxPdfsPerMonth
  || DEFAULT_PLAN_LIMITS.free.maxPdfsPerMonth;
```

## Criterios de aceptación del issue

- [x] `checkAndTriggerLimitEmails` usa `calculateCurrentPeriod` (ya en `94c1cd8`).
- [x] `triggerBlockedEmail` usa `getOrCreateUsageWithPeriod`, no `getOrCreateUsage` (ya en `94c1cd8`; este PR añade el test que lo blinda).
- [x] Metadatos de emails (`pdfsUsed`, `limit`, `periodStart`, `periodEnd`) salen del mismo período que `/api/users/limits` y el bloqueo real.
- [x] Prueba que cubre un usuario Free registrado a mitad de mes: bloqueo y emails comparten `periodId`.
- [x] Swagger de `/api/users/limits` aclara que Free/Lite usan período mensual desde `createdAt` (no mes calendario) y Pro+ desde Stripe.

## Cambios

- `email.service.ts`: límite real del plan en `triggerBlockedEmail` (+ import `DEFAULT_PLAN_LIMITS`).
- `users.controller.ts`: descripción Swagger del endpoint `/limits`.
- `period-calculator.util.spec.ts` (nuevo): período Free por aniversario, determinismo de `periodId`, Lite sin Stripe, Pro con Stripe.
- `email.service.spec.ts` (nuevo): Free 10/10 sí encola `conversion_blocked`, 9/10 no, Lite respeta 25, usa el período no-legacy.

## Verificación

- `npm run build` → 0 issues.
- `npx jest` → 13/13 tests pasan (12 nuevos).

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)