### PR TITLE
fix(errors): clasificar type del error según el código real

### DIFF
--- a/src/common/constants/error-codes.spec.ts
+++ b/src/common/constants/error-codes.spec.ts
@@ -1,0 +1,35 @@
+import { ErrorCodes, getErrorTypeFromCode } from './error-codes.js';
+
+describe('getErrorTypeFromCode', () => {
+  describe('códigos de cuota → LIMIT_EXCEEDED', () => {
+    it.each([
+      ErrorCodes.LABEL_LIMIT_EXCEEDED,
+      ErrorCodes.MONTHLY_LIMIT_EXCEEDED,
+      ErrorCodes.BATCH_LIMIT_EXCEEDED,
+    ])('clasifica %s como LIMIT_EXCEEDED', (code) => {
+      expect(getErrorTypeFromCode(code)).toBe('LIMIT_EXCEEDED');
+    });
+  });
+
+  describe('códigos de acceso/onboarding → ACCESS_DENIED', () => {
+    it.each([
+      'EMAIL_NOT_VERIFIED',
+      'BLOCKED_EMAIL_DOMAIN',
+      ErrorCodes.ACCESS_DENIED,
+      ErrorCodes.USER_NOT_FOUND,
+    ])('clasifica %s como ACCESS_DENIED', (code) => {
+      expect(getErrorTypeFromCode(code)).toBe('ACCESS_DENIED');
+    });
+  });
+
+  it('separa email sin verificar de la presión de cuota (regresión)', () => {
+    // Antes ambos caían bajo LIMIT_EXCEEDED, ocultando la fricción de onboarding.
+    expect(getErrorTypeFromCode('EMAIL_NOT_VERIFIED')).not.toBe(
+      getErrorTypeFromCode(ErrorCodes.MONTHLY_LIMIT_EXCEEDED),
+    );
+  });
+
+  it('usa LIMIT_EXCEEDED como fallback conservador para códigos desconocidos', () => {
+    expect(getErrorTypeFromCode('SOMETHING_UNEXPECTED')).toBe('LIMIT_EXCEEDED');
+  });
+});

--- a/src/common/constants/error-codes.ts
+++ b/src/common/constants/error-codes.ts
@@ -154,3 +154,30 @@ export const ErrorMessagesEn: Record<ErrorCode, string> = {
 export function getErrorMessage(code: ErrorCode, language: 'es' | 'en' = 'es'): string {
   return language === 'es' ? ErrorMessagesEs[code] : ErrorMessagesEn[code];
 }
+
+/**
+ * Categoría de alto nivel (campo `type`) usada para agrupar errores en el
+ * dashboard admin (`byType`). Distingue la fricción de acceso/onboarding
+ * (email sin verificar, dominio bloqueado) de la presión real de cuota, en
+ * lugar de mezclar todo bajo `LIMIT_EXCEEDED`.
+ *
+ * Acepta cualquier string porque algunos códigos (EMAIL_NOT_VERIFIED,
+ * BLOCKED_EMAIL_DOMAIN) no forman parte del enum `ErrorCodes`.
+ */
+export function getErrorTypeFromCode(code: string): string {
+  switch (code) {
+    case ErrorCodes.LABEL_LIMIT_EXCEEDED:
+    case ErrorCodes.MONTHLY_LIMIT_EXCEEDED:
+    case ErrorCodes.BATCH_LIMIT_EXCEEDED:
+      return 'LIMIT_EXCEEDED';
+    case 'EMAIL_NOT_VERIFIED':
+    case 'BLOCKED_EMAIL_DOMAIN':
+    case ErrorCodes.ACCESS_DENIED:
+    case ErrorCodes.USER_NOT_FOUND:
+      return 'ACCESS_DENIED';
+    default:
+      // Fallback conservador: mantiene el comportamiento previo para códigos
+      // no contemplados que provengan del chequeo de conversión.
+      return 'LIMIT_EXCEEDED';
+  }
+}

--- a/src/modules/zpl/zpl.service.ts
+++ b/src/modules/zpl/zpl.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, HttpException, HttpStatus, Inject, forwardRef, ForbiddenException, Optional } from '@nestjs/common';
-import { ErrorCodes } from '../../common/constants/error-codes.js';
+import { ErrorCodes, getErrorTypeFromCode } from '../../common/constants/error-codes.js';
 import axios from 'axios';
 import sharp from 'sharp';
 import { v4 as uuidv4 } from 'uuid';
@@ -244,10 +244,13 @@ export class ZplService {
       // Check user limits before processing
       const canConvert = await this.usersService.checkCanConvert(userId, labelCount);
       if (!canConvert.allowed) {
-        // Log limit exceeded error
+        // Log conversion-gate rejection. El `type` se deriva del código real
+        // (no se hardcodea LIMIT_EXCEEDED) para que el dashboard distinga
+        // fricción de acceso (email sin verificar) de presión de cuota.
+        const errorCode = canConvert.errorCode || ErrorCodes.MONTHLY_LIMIT_EXCEEDED;
         await this.logError(
-          'LIMIT_EXCEEDED',
-          canConvert.errorCode || ErrorCodes.MONTHLY_LIMIT_EXCEEDED,
+          getErrorTypeFromCode(errorCode),
+          errorCode,
           canConvert.error,
           'warning',
           { labelCount, ...canConvert.data },


### PR DESCRIPTION
## Contexto

En el dashboard admin (`/api/admin/metrics`), `errors.byType.LIMIT_EXCEEDED` aparecía inflado (256) porque mezclaba motivos muy distintos bajo una sola etiqueta. La causa: el `logError` del chequeo previo a la conversión (`zpl.service.ts`) **hardcodeaba** `type = 'LIMIT_EXCEEDED'` para *cualquier* rechazo de `checkCanConvert`, aunque el `code` real fuera `EMAIL_NOT_VERIFIED`, `BLOCKED_EMAIL_DOMAIN`, etc.

Esto producía entradas contradictorias como:
```json
{ "type": "LIMIT_EXCEEDED", "code": "EMAIL_NOT_VERIFIED" }
```
que en realidad son usuarios nuevos intentando convertir sin verificar su email (fricción de onboarding), no presión de cuota.

## Cambio

- Nuevo helper `getErrorTypeFromCode(code)` en `common/constants/error-codes.ts` que deriva el `type` del código real:
  - `LABEL/MONTHLY/BATCH_LIMIT_EXCEEDED` → `LIMIT_EXCEEDED` (presión de upgrade)
  - `EMAIL_NOT_VERIFIED` / `BLOCKED_EMAIL_DOMAIN` / `ACCESS_DENIED` / `USER_NOT_FOUND` → `ACCESS_DENIED` (fricción de acceso/onboarding)
  - fallback conservador → `LIMIT_EXCEEDED` (mantiene comportamiento previo ante códigos no contemplados)
- `zpl.service.ts` usa el helper en lugar del literal hardcodeado.
- Test unitario del helper (`error-codes.spec.ts`).

## Alcance / impacto

- Solo cambia el etiquetado de **errores nuevos**. Los históricos en Firestore conservan su `type` original (no hay migración).
- A partir del deploy, `byType` distinguirá `ACCESS_DENIED` de `LIMIT_EXCEEDED`, dando una señal fiel: onboarding vs. cuota.
- El único call site de `logError` afectado es el del gate de conversión; batch no usa `logError`.

## ⚠️ Posible seguimiento en frontend

Si el dashboard del frontend renderiza `byType` con claves hardcodeadas (esperando solo `LIMIT_EXCEEDED`/`SERVER_ERROR`), conviene revisar que muestre también la nueva categoría `ACCESS_DENIED`. De requerirse, se abrirá issue en `gustavojmarrero/zplpdf_front` según la política del proyecto.

## Verificación

- `npm test` → 22 passed (incluye `error-codes.spec.ts`)
- `npm run build` → 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)