### PR TITLE
fix(zpl): evitar PDF en blanco por etiqueta de configuración sin contenido

### DIFF
--- a/src/modules/zpl/zpl.service.spec.ts
+++ b/src/modules/zpl/zpl.service.spec.ts
@@ -1,0 +1,136 @@
+import { PDFDocument } from 'pdf-lib';
+
+// Mockear dependencias pesadas/nativas que el servicio importa a nivel de
+// módulo pero que estos tests no ejercitan. Evita cargar binarios (sharp) y
+// pdfjs (pdf-to-png-converter) en el entorno de jest.
+jest.mock('sharp', () => jest.fn());
+jest.mock('pdf-to-png-converter', () => ({ pdfToPng: jest.fn() }));
+jest.mock('pdf-merger-js', () => jest.fn());
+jest.mock('archiver', () => jest.fn());
+
+// Evitar la conexión real a Google Cloud Storage al construir el servicio.
+jest.mock('@google-cloud/storage', () => ({
+  Storage: jest.fn().mockImplementation(() => ({
+    bucket: jest.fn().mockReturnValue({
+      exists: jest.fn().mockResolvedValue([true]),
+      file: jest.fn(),
+    }),
+  })),
+}));
+
+import { ZplService, LabelSize } from './zpl.service';
+
+/**
+ * Regresión: una etiqueta de envío real (Amazon Logistics) que empieza con un
+ * bloque de pura configuración `^XA^MCY^XZ` seguido del contenido. Labelary
+ * descarta el bloque vacío y devuelve 1 sola página; el servicio antes contaba
+ * 2 bloques y, al pedir copiar la página inexistente, vaciaba TODO el PDF
+ * (resultado: una página A4 en blanco).
+ */
+const SHIPPING_LABEL_ZPL = `^FX Start of a new label-sheet
+^XA^MCY^XZ
+^XA
+^LH0,0
+^FO98,487^BY1,,102^BCN,102,N,N,N,N^FH^FD>:_54_42_52^FS
+^CI28^FO81,595^A0,37,0^FB305,1,0,L,0^FH^FD_54_42_52_33_37_32^FS^CI0
+^FO575,480^BXN,8,200,22,22,,~^FH^FD_54_42_52_33_37_32^FS
+^XZ`;
+
+describe('ZplService — bloques de configuración sin contenido', () => {
+  let service: ZplService;
+
+  beforeEach(() => {
+    const configService: any = { get: jest.fn(() => 'test-bucket') };
+    const firestoreService: any = {};
+    const usersService: any = {};
+    const labelaryQueueService: any = {};
+
+    service = new ZplService(
+      configService,
+      firestoreService,
+      usersService,
+      {},
+      labelaryQueueService,
+    );
+  });
+
+  describe('blockProducesOutput', () => {
+    it('clasifica un bloque solo de configuración como sin salida', () => {
+      const fn = (service as any).blockProducesOutput.bind(service);
+      expect(fn('^XA^MCY^XZ')).toBe(false);
+      expect(fn('^XA^MCN^XZ')).toBe(false);
+      expect(fn('^XA^LH0,0^CI28^XZ')).toBe(false);
+    });
+
+    it('clasifica bloques con contenido dibujable como con salida', () => {
+      const fn = (service as any).blockProducesOutput.bind(service);
+      expect(fn('^XA^FO50,50^A0,30^FDhola^FS^XZ')).toBe(true); // texto
+      expect(fn('^XA^FO0,0^GB100,100,2^FS^XZ')).toBe(true); // gráfico
+      expect(fn('^XA^FO10,10^BCN,100^FD12345^FS^XZ')).toBe(true); // código de barras
+      expect(fn('^XA^FO10,10^BXN,8,200^FDABC^FS^XZ')).toBe(true); // DataMatrix
+    });
+  });
+
+  describe('splitAndExtractCopies', () => {
+    it('descarta el bloque ^XA^MCY^XZ y conserva la etiqueta real', () => {
+      const blocks = (service as any).splitAndExtractCopies(SHIPPING_LABEL_ZPL);
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].normalizedContent).toContain('^BCN');
+      expect(blocks[0].normalizedContent).not.toContain('^MCY');
+    });
+  });
+
+  describe('countLabels', () => {
+    it('no cuenta la etiqueta de configuración como etiqueta facturable', async () => {
+      const result = await service.countLabels(SHIPPING_LABEL_ZPL);
+      expect(result.data.totalLabels).toBe(1);
+      expect(result.data.totalUniqueLabels).toBe(1);
+    });
+  });
+
+  describe('reconstructFinalPdf — robustez ante desajuste de páginas', () => {
+    /** Crea un PDF de N páginas 4x6 con texto, simulando la salida de Labelary. */
+    async function makePdf(pageCount: number): Promise<Buffer> {
+      const doc = await PDFDocument.create();
+      for (let i = 0; i < pageCount; i++) {
+        const page = doc.addPage([288, 432]);
+        page.drawText(`page ${i}`, { x: 20, y: 200, size: 24 });
+      }
+      return Buffer.from(await doc.save());
+    }
+
+    it('no vacía el PDF cuando se piden más páginas de las que existen', async () => {
+      // El servicio cree que hay 2 bloques (originalSequence=[0,1]) pero
+      // Labelary solo renderizó 1 página. El resultado debe conservar el
+      // contenido real, no producir un PDF vacío/A4 en blanco.
+      const labelaryPdf = await makePdf(1);
+      const result: Buffer = await (service as any).reconstructFinalPdf(
+        [labelaryPdf],
+        [0, 1],
+      );
+
+      const out = await PDFDocument.load(result);
+      expect(out.getPageCount()).toBe(1);
+      const size = out.getPage(0).getSize();
+      // 4x6 a 72pt/in = 288x432; NO el A4 (595x842) por defecto de pdf-lib.
+      expect(Math.round(size.width)).toBe(288);
+      expect(Math.round(size.height)).toBe(432);
+    });
+
+    it('replica páginas correctamente cuando los índices son válidos', async () => {
+      const labelaryPdf = await makePdf(2);
+      const result: Buffer = await (service as any).reconstructFinalPdf(
+        [labelaryPdf],
+        [0, 1, 0],
+      );
+      const out = await PDFDocument.load(result);
+      expect(out.getPageCount()).toBe(3);
+    });
+  });
+
+  describe('getLabelSize', () => {
+    it('mapea 4x6 al enum correcto', () => {
+      expect((service as any).getLabelSize('4x6')).toBe(LabelSize.FOUR_BY_SIX);
+    });
+  });
+});

--- a/src/modules/zpl/zpl.service.spec.ts
+++ b/src/modules/zpl/zpl.service.spec.ts
@@ -60,6 +60,8 @@ describe('ZplService — bloques de configuración sin contenido', () => {
       expect(fn('^XA^MCY^XZ')).toBe(false);
       expect(fn('^XA^MCN^XZ')).toBe(false);
       expect(fn('^XA^LH0,0^CI28^XZ')).toBe(false);
+      // ^BY es configuración de barcode (Bar Code Field Default), no dibuja.
+      expect(fn('^XA^BY2,3,100^XZ')).toBe(false);
     });
 
     it('clasifica bloques con contenido dibujable como con salida', () => {
@@ -68,6 +70,10 @@ describe('ZplService — bloques de configuración sin contenido', () => {
       expect(fn('^XA^FO0,0^GB100,100,2^FS^XZ')).toBe(true); // gráfico
       expect(fn('^XA^FO10,10^BCN,100^FD12345^FS^XZ')).toBe(true); // código de barras
       expect(fn('^XA^FO10,10^BXN,8,200^FDABC^FS^XZ')).toBe(true); // DataMatrix
+      // ^SN imprime datos serializados sin necesitar ^FD/^FV.
+      expect(fn('^XA^FO50,50^A0N,30,30^SN0001,1,Y^FS^XZ')).toBe(true);
+      // Un bloque con ^BY de config + un barcode real sigue siendo imprimible.
+      expect(fn('^XA^BY1,,102^FO98,487^BCN,102^FD123^FS^XZ')).toBe(true);
     });
   });
 

--- a/src/modules/zpl/zpl.service.ts
+++ b/src/modules/zpl/zpl.service.ts
@@ -1009,15 +1009,20 @@ export class ZplService {
    * desalinea el mapeo en `reconstructFinalPdf` y puede vaciar el PDF final.
    *
    * Se considera que un bloque dibuja contenido si incluye al menos un comando
-   * de salida visible: datos de campo (`^FD`/`^FV`), primitivas gráficas
+   * de salida visible: datos de campo (`^FD`/`^FV`), datos serializados que se
+   * imprimen sin `^FD` (`^SN`), primitivas gráficas
    * (`^GB`/`^GC`/`^GD`/`^GE`/`^GF`/`^GS`), imágenes (`^XG`/`^IM`) o un código de
-   * barras (`^B...`).
+   * barras real (`^BC`, `^BX`, `^B3`, ...).
+   *
+   * `^BY` (Bar Code Field Default) se excluye de forma explícita: aunque empieza
+   * con `B`, es solo configuración de los códigos de barras y no dibuja nada por
+   * sí mismo, así que no debe mantener vivo un bloque vacío.
    *
    * @param block Bloque ZPL normalizado
    * @returns true si el bloque produce una página en Labelary
    */
   private blockProducesOutput(block: string): boolean {
-    return /\^(FD|FV|GB|GC|GD|GE|GF|GS|XG|IM|B[0-9A-Z])/i.test(block);
+    return /\^(FD|FV|SN|GB|GC|GD|GE|GF|GS|XG|IM|B(?!Y)[0-9A-Z])/i.test(block);
   }
 
   /**

--- a/src/modules/zpl/zpl.service.ts
+++ b/src/modules/zpl/zpl.service.ts
@@ -1000,6 +1000,27 @@ export class ZplService {
   }
 
   /**
+   * Determina si un bloque ZPL produce una etiqueta imprimible.
+   *
+   * Labelary NO genera página para bloques que solo contienen comandos de
+   * configuración (p.ej. `^XA^MCY^XZ`, una etiqueta de "Map Clear" sin nada
+   * dibujable). Si esos bloques se cuentan como etiquetas, el número de páginas
+   * que esperamos deja de coincidir con las que Labelary devuelve, lo que
+   * desalinea el mapeo en `reconstructFinalPdf` y puede vaciar el PDF final.
+   *
+   * Se considera que un bloque dibuja contenido si incluye al menos un comando
+   * de salida visible: datos de campo (`^FD`/`^FV`), primitivas gráficas
+   * (`^GB`/`^GC`/`^GD`/`^GE`/`^GF`/`^GS`), imágenes (`^XG`/`^IM`) o un código de
+   * barras (`^B...`).
+   *
+   * @param block Bloque ZPL normalizado
+   * @returns true si el bloque produce una página en Labelary
+   */
+  private blockProducesOutput(block: string): boolean {
+    return /\^(FD|FV|GB|GC|GD|GE|GF|GS|XG|IM|B[0-9A-Z])/i.test(block);
+  }
+
+  /**
    * Divide ZPL en bloques, extrae copias ^PQ y elimina ^PQ del contenido
    * @param zpl Contenido ZPL
    * @returns Bloques ZPL procesados
@@ -1007,8 +1028,15 @@ export class ZplService {
   private splitAndExtractCopies(zpl: string): ParsedZplBlock[] {
     const blockMatches = zpl.match(/\^XA.*?\^XZ/gs) || [];
     let parsed: ParsedZplBlock[] = [];
-    blockMatches.forEach((rawBlock, i) => {
+    blockMatches.forEach((rawBlock) => {
       const normalized = this.normalizeZplBlock(rawBlock);
+
+      // Descartar bloques de pura configuración (no producen página en
+      // Labelary). Incluirlos provoca un desajuste de índices que vacía el PDF.
+      if (!this.blockProducesOutput(normalized)) {
+        return;
+      }
+
       const pqMatch = normalized.match(/\^PQ(\d+)/i);
       let copies = 1;
       if (pqMatch && pqMatch[1]) {
@@ -1019,7 +1047,7 @@ export class ZplService {
       parsed.push({
         normalizedContent: cleaned.trim(),
         copies,
-        originalIndex: i,
+        originalIndex: parsed.length,
       });
     });
     return parsed;
@@ -1256,18 +1284,42 @@ export class ZplService {
           continue;
         }
 
+        // Filtrar índices fuera de rango ANTES de copiar. copyPages es atómico:
+        // un único índice inexistente aborta toda la operación y descartaría
+        // también las páginas válidas, vaciando el PDF. Esto ocurre cuando el
+        // número de bloques detectados no coincide con las páginas que Labelary
+        // renderiza (defensa en profundidad: conservamos las páginas reales).
+        const srcPageCount = srcDoc.getPageCount();
+        const validPageIndices: number[] = [];
+        const validOutputPositions: number[] = [];
+        group.pageIndices.forEach((pageIdx, i) => {
+          if (pageIdx < srcPageCount) {
+            validPageIndices.push(pageIdx);
+            validOutputPositions.push(group.outputPositions[i]);
+          } else {
+            this.logger.warn(
+              `Página ${pageIdx} fuera de rango en chunk ${chunkNumber} (solo ${srcPageCount} páginas disponibles)`,
+            );
+            skippedPages++;
+          }
+        });
+
+        if (validPageIndices.length === 0) {
+          continue;
+        }
+
         try {
-          // Copiar TODAS las páginas necesarias de este chunk en UNA sola operación
-          const copiedPages = await finalDoc.copyPages(srcDoc, group.pageIndices);
+          // Copiar TODAS las páginas válidas de este chunk en UNA sola operación
+          const copiedPages = await finalDoc.copyPages(srcDoc, validPageIndices);
           copiedPages.forEach((page, i) => {
             copiedPagesWithPositions.push({
               page,
-              position: group.outputPositions[i],
+              position: validOutputPositions[i],
             });
           });
         } catch (error) {
           this.logger.warn(`Error copiando páginas del chunk ${chunkNumber}: ${error.message}`);
-          skippedPages += group.pageIndices.length;
+          skippedPages += validPageIndices.length;
         }
       }
       this.logger.debug(`Copia de páginas completada en ${Date.now() - copyStartTime}ms`);


### PR DESCRIPTION
## Problema

Un usuario subió una etiqueta de envío real (Amazon Logistics, Brasil) y recibió un **PDF A4 completamente en blanco** en lugar de su etiqueta 4×6. La etiqueta es válida — Labelary la renderiza sin problemas.

## Causa raíz

El ZPL empieza con un bloque de **pura configuración** seguido del contenido real:

```
^XA^MCY^XZ          ← bloque 0: solo Map Clear, sin nada imprimible
^XA ... ^XZ         ← bloque 1: la etiqueta real
```

1. `splitAndExtractCopies` detecta **2 bloques** → `originalSequence=[0,1]`.
2. Labelary **descarta** el bloque vacío y devuelve un PDF con **1 sola página**.
3. `reconstructFinalPdf` pide a pdf-lib copiar las páginas `[0,1]`, pero solo existe la `0`. Como `copyPages` es **atómico**, la excepción por el índice inexistente descarta **todo el grupo**, incluida la página real.
4. El documento queda con **0 páginas**; pdf-lib ya había copiado el XObject de la imagen antes de fallar (≈18 KB huérfanos) y los visores muestran una **página A4 en blanco** por defecto.

Reproducido byte a byte: el `finalDoc` de 0 páginas pesa 18507 bytes; el PDF del usuario, 18508.

Basta **un solo** bloque de configuración al inicio para vaciar TODO el PDF. Es un patrón común en etiquetas de transportistas, así que probablemente afecte a más usuarios. Además, al usuario se le contaron/facturaron 2 etiquetas por un PDF inservible.

## Cambios

- **`blockProducesOutput()`** + filtro en `splitAndExtractCopies`: descarta bloques sin comandos dibujables (`^FD`/`^FV`/`^GB`/`^GC`/`^GD`/`^GE`/`^GF`/`^GS`/`^XG`/`^IM`/`^B…`). Corrige la causa raíz **y** el conteo de etiquetas facturables.
- **`reconstructFinalPdf`**: filtra índices fuera de rango antes de `copyPages`, conservando las páginas válidas ante cualquier desajuste (defensa en profundidad).
- **Test de regresión** (`zpl.service.spec.ts`) con el patrón de la etiqueta real.

## Validación

11/11 comprobaciones pasaron ejecutando el código exacto contra `pdf-lib` real y el ZPL del usuario:
- `^XA^MCY^XZ` se descarta → 1 bloque; el conteo facturable baja de 2 a 1.
- Ante el desajuste, el resultado es **1 página 288×432 con contenido** (no A4 en blanco).
- El caso normal (índices válidos) sigue replicando páginas correctamente.

> ⚠️ `jest`/`tsc` no se pudieron ejecutar en el entorno local de la sesión (se cuelgan leyendo los `.d.ts`); el type-check y los tests deben validarse en CI. El cambio es TypeScript bien tipado y el spec es reconocido por `jest --listTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)