### PR TITLE
feat(feedback): módulo de encuesta mensual de satisfacción

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { CronModule } from './modules/cron/cron.module.js';
 import { AdminModule } from './modules/admin/admin.module.js';
 import { ErrorsModule } from './modules/errors/errors.module.js';
 import { EmailModule } from './modules/email/email.module.js';
+import { FeedbackModule } from './modules/feedback/feedback.module.js';
 import appConfig from './config/app.config.js';
 import { GoogleAuthProvider } from './config/google-auth.provider.js';
 
@@ -46,6 +47,7 @@ import { GoogleAuthProvider } from './config/google-auth.provider.js';
     AdminModule,
     ErrorsModule,
     EmailModule,
+    FeedbackModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/common/interfaces/feedback.interface.ts
+++ b/src/common/interfaces/feedback.interface.ts
@@ -1,0 +1,64 @@
+export type FeedbackSentiment = 'bad' | 'neutral' | 'good';
+
+/**
+ * Documento de la colección `feedback` (encuesta mensual de satisfacción).
+ */
+export interface Feedback {
+  id: string;
+  userId: string;
+  userEmail: string | null;
+  plan: string;
+  sentiment: FeedbackSentiment;
+  message: string | null;
+  locale: string | null;
+  createdAt: Date;
+}
+
+/** Datos para crear un feedback (sin id ni createdAt; los pone el servicio). */
+export interface CreateFeedbackData {
+  userId: string;
+  userEmail: string | null;
+  plan: string;
+  sentiment: FeedbackSentiment;
+  message: string | null;
+  locale: string | null;
+}
+
+export interface FeedbackFilters {
+  page?: number;
+  limit?: number;
+  sentiment?: FeedbackSentiment;
+  plan?: string;
+  startDate?: Date;
+  endDate?: Date;
+  search?: string;
+}
+
+export interface FeedbackSummary {
+  total: number;
+  bad: number;
+  neutral: number;
+  good: number;
+  /** Porcentaje de respuestas "good" sobre el total (0-100). */
+  satisfactionRate: number;
+}
+
+export interface FeedbackListResult {
+  items: Feedback[];
+  summary: FeedbackSummary;
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+export interface FeedbackStatus {
+  /** Si debe mostrarse la encuesta ahora (cadencia 30 días rolling). */
+  shouldShow: boolean;
+  /** ISO del último feedback del usuario, o null si nunca. */
+  lastSubmittedAt: string | null;
+  /** Días transcurridos desde el último feedback, o null si nunca. */
+  daysSinceLast: number | null;
+}

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -3,6 +3,13 @@ import { Firestore, FieldValue } from '@google-cloud/firestore';
 import { ConfigService } from '@nestjs/config';
 import { DEFAULT_PLAN_LIMITS, PLAN_ORDER } from '../../common/interfaces/user.interface.js';
 import type { User, PlanType } from '../../common/interfaces/user.interface.js';
+import type {
+  Feedback,
+  CreateFeedbackData,
+  FeedbackFilters,
+  FeedbackListResult,
+  FeedbackSummary,
+} from '../../common/interfaces/feedback.interface.js';
 import type { Usage } from '../../common/interfaces/usage.interface.js';
 import type { ConversionHistory } from '../../common/interfaces/conversion-history.interface.js';
 import type { BatchJob } from '../zpl/interfaces/batch.interface.js';
@@ -217,6 +224,7 @@ export class FirestoreService {
   private readonly expensesCollection = 'expenses';
   private readonly goalsCollection = 'monthly_goals';
   private readonly subscriptionEventsCollection = 'subscription_events';
+  private readonly feedbackCollection = 'feedback';
 
   constructor(private configService: ConfigService) {
     let credentials: any = null;
@@ -358,6 +366,141 @@ export class FirestoreService {
       } as User;
     } catch (error) {
       this.logger.error(`Error al obtener usuario: ${error.message}`);
+      throw error;
+    }
+  }
+
+  // ============== Feedback (encuesta mensual de satisfacción) ==============
+
+  async createFeedback(data: CreateFeedbackData): Promise<Feedback> {
+    try {
+      const createdAt = new Date();
+      const ref = await this.firestore
+        .collection(this.feedbackCollection)
+        .add({ ...data, createdAt });
+      this.logger.log(`Feedback creado: ${ref.id} (${data.sentiment})`);
+      return { id: ref.id, ...data, createdAt };
+    } catch (error) {
+      this.logger.error(`Error al crear feedback: ${error.message}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Último feedback del usuario. Usa un where de un solo campo (sin índice
+   * compuesto) y ordena en memoria; cada usuario tiene pocos registros.
+   */
+  async getLastFeedbackByUser(userId: string): Promise<Feedback | null> {
+    try {
+      const snapshot = await this.firestore
+        .collection(this.feedbackCollection)
+        .where('userId', '==', userId)
+        .get();
+
+      if (snapshot.empty) {
+        return null;
+      }
+
+      const items = snapshot.docs.map((doc) => {
+        const d = doc.data();
+        return {
+          id: doc.id,
+          userId: d.userId,
+          userEmail: d.userEmail ?? null,
+          plan: d.plan,
+          sentiment: d.sentiment,
+          message: d.message ?? null,
+          locale: d.locale ?? null,
+          createdAt: d.createdAt?.toDate?.() || d.createdAt,
+        } as Feedback;
+      });
+
+      items.sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
+      return items[0];
+    } catch (error) {
+      this.logger.error(`Error al obtener último feedback: ${error.message}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Listado de feedback para admin. Filtra por fecha en la query y el resto en
+   * memoria (mismo patrón que getErrorLogs: evita índices compuestos).
+   */
+  async getFeedbackList(filters: FeedbackFilters): Promise<FeedbackListResult> {
+    try {
+      const { page = 1, limit = 20, sentiment, plan, startDate, endDate, search } = filters;
+
+      let query: FirebaseFirestore.Query = this.firestore
+        .collection(this.feedbackCollection)
+        .orderBy('createdAt', 'desc');
+
+      if (startDate) {
+        query = query.where('createdAt', '>=', startDate);
+      }
+      if (endDate) {
+        query = query.where('createdAt', '<=', endDate);
+      }
+
+      const snapshot = await query.get();
+
+      let all: Feedback[] = snapshot.docs.map((doc) => {
+        const d = doc.data();
+        return {
+          id: doc.id,
+          userId: d.userId,
+          userEmail: d.userEmail ?? null,
+          plan: d.plan,
+          sentiment: d.sentiment,
+          message: d.message ?? null,
+          locale: d.locale ?? null,
+          createdAt: d.createdAt?.toDate?.() || d.createdAt,
+        } as Feedback;
+      });
+
+      // Filtros en memoria (evita índices compuestos)
+      if (plan) {
+        all = all.filter((f) => f.plan === plan);
+      }
+      if (search) {
+        const q = search.toLowerCase();
+        all = all.filter(
+          (f) =>
+            (f.message || '').toLowerCase().includes(q) ||
+            (f.userEmail || '').toLowerCase().includes(q),
+        );
+      }
+      if (sentiment) {
+        all = all.filter((f) => f.sentiment === sentiment);
+      }
+
+      const good = all.filter((f) => f.sentiment === 'good').length;
+      const summary: FeedbackSummary = {
+        total: all.length,
+        bad: all.filter((f) => f.sentiment === 'bad').length,
+        neutral: all.filter((f) => f.sentiment === 'neutral').length,
+        good,
+        satisfactionRate: all.length ? Math.round((good / all.length) * 100) : 0,
+      };
+
+      const total = all.length;
+      const offset = (page - 1) * limit;
+      const items = all.slice(offset, offset + limit);
+
+      return {
+        items,
+        summary,
+        pagination: {
+          page,
+          limit,
+          total,
+          totalPages: Math.ceil(total / limit),
+        },
+      };
+    } catch (error) {
+      this.logger.error(`Error al obtener feedback list: ${error.message}`);
       throw error;
     }
   }

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -460,7 +460,8 @@ export class FirestoreService {
         } as Feedback;
       });
 
-      // Filtros en memoria (evita índices compuestos)
+      // Filtros en memoria (evita índices compuestos). El filtro de sentimiento
+      // se aplica aparte (abajo) para no sesgar el resumen.
       if (plan) {
         all = all.filter((f) => f.plan === plan);
       }
@@ -472,10 +473,10 @@ export class FirestoreService {
             (f.userEmail || '').toLowerCase().includes(q),
         );
       }
-      if (sentiment) {
-        all = all.filter((f) => f.sentiment === sentiment);
-      }
 
+      // El resumen se calcula ANTES de filtrar por sentiment, para que el
+      // desglose (bad/neutral/good/satisfactionRate) siga siendo representativo
+      // aunque la lista se filtre por un sentimiento concreto.
       const good = all.filter((f) => f.sentiment === 'good').length;
       const summary: FeedbackSummary = {
         total: all.length,
@@ -485,9 +486,12 @@ export class FirestoreService {
         satisfactionRate: all.length ? Math.round((good / all.length) * 100) : 0,
       };
 
-      const total = all.length;
+      // El filtro de sentimiento solo afecta a la lista paginada.
+      const filtered = sentiment ? all.filter((f) => f.sentiment === sentiment) : all;
+
+      const total = filtered.length;
       const offset = (page - 1) * limit;
-      const items = all.slice(offset, offset + limit);
+      const items = filtered.slice(offset, offset + limit);
 
       return {
         items,

--- a/src/modules/feedback/dto/create-feedback.dto.ts
+++ b/src/modules/feedback/dto/create-feedback.dto.ts
@@ -1,0 +1,28 @@
+import { IsIn, IsOptional, IsString, MaxLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateFeedbackDto {
+  @ApiProperty({
+    enum: ['bad', 'neutral', 'good'],
+    description: 'Sentimiento del usuario respecto a la experiencia',
+  })
+  @IsIn(['bad', 'neutral', 'good'])
+  sentiment: 'bad' | 'neutral' | 'good';
+
+  @ApiPropertyOptional({
+    description: 'Texto libre opcional (sugerencia / qué mejorar o agregar)',
+    maxLength: 1000,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  message?: string;
+
+  @ApiPropertyOptional({
+    enum: ['en', 'es', 'zh', 'pt'],
+    description: 'Idioma de la interfaz al enviar el feedback',
+  })
+  @IsOptional()
+  @IsIn(['en', 'es', 'zh', 'pt'])
+  locale?: string;
+}

--- a/src/modules/feedback/dto/query-feedback.dto.ts
+++ b/src/modules/feedback/dto/query-feedback.dto.ts
@@ -1,0 +1,42 @@
+import { IsIn, IsOptional, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class QueryFeedbackDto {
+  @ApiPropertyOptional({ description: 'Número de página', default: 1 })
+  @IsOptional()
+  @IsString()
+  page?: string;
+
+  @ApiPropertyOptional({ description: 'Resultados por página', default: 20 })
+  @IsOptional()
+  @IsString()
+  limit?: string;
+
+  @ApiPropertyOptional({ enum: ['bad', 'neutral', 'good'], description: 'Filtrar por sentimiento' })
+  @IsOptional()
+  @IsIn(['bad', 'neutral', 'good'])
+  sentiment?: 'bad' | 'neutral' | 'good';
+
+  @ApiPropertyOptional({
+    enum: ['free', 'lite', 'pro', 'promax', 'enterprise'],
+    description: 'Filtrar por plan',
+  })
+  @IsOptional()
+  @IsIn(['free', 'lite', 'pro', 'promax', 'enterprise'])
+  plan?: string;
+
+  @ApiPropertyOptional({ description: 'Fecha de inicio (ISO 8601)' })
+  @IsOptional()
+  @IsString()
+  startDate?: string;
+
+  @ApiPropertyOptional({ description: 'Fecha de fin (ISO 8601)' })
+  @IsOptional()
+  @IsString()
+  endDate?: string;
+
+  @ApiPropertyOptional({ description: 'Buscar en el mensaje o el email del usuario' })
+  @IsOptional()
+  @IsString()
+  search?: string;
+}

--- a/src/modules/feedback/dto/query-feedback.dto.ts
+++ b/src/modules/feedback/dto/query-feedback.dto.ts
@@ -1,16 +1,22 @@
-import { IsIn, IsOptional, IsString } from 'class-validator';
+import { IsIn, IsOptional, IsString, IsNumber, IsDateString, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class QueryFeedbackDto {
   @ApiPropertyOptional({ description: 'Número de página', default: 1 })
   @IsOptional()
-  @IsString()
-  page?: string;
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  page?: number = 1;
 
-  @ApiPropertyOptional({ description: 'Resultados por página', default: 20 })
+  @ApiPropertyOptional({ description: 'Resultados por página', default: 20, maximum: 100 })
   @IsOptional()
-  @IsString()
-  limit?: string;
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
 
   @ApiPropertyOptional({ enum: ['bad', 'neutral', 'good'], description: 'Filtrar por sentimiento' })
   @IsOptional()
@@ -27,12 +33,12 @@ export class QueryFeedbackDto {
 
   @ApiPropertyOptional({ description: 'Fecha de inicio (ISO 8601)' })
   @IsOptional()
-  @IsString()
+  @IsDateString()
   startDate?: string;
 
   @ApiPropertyOptional({ description: 'Fecha de fin (ISO 8601)' })
   @IsOptional()
-  @IsString()
+  @IsDateString()
   endDate?: string;
 
   @ApiPropertyOptional({ description: 'Buscar en el mensaje o el email del usuario' })

--- a/src/modules/feedback/feedback-admin.controller.ts
+++ b/src/modules/feedback/feedback-admin.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { AdminAuthGuard } from '../../common/guards/admin-auth.guard.js';
+import { FeedbackService } from './feedback.service.js';
+import { QueryFeedbackDto } from './dto/query-feedback.dto.js';
+
+@ApiTags('admin')
+@Controller('admin/feedback')
+export class FeedbackAdminController {
+  constructor(private readonly feedbackService: FeedbackService) {}
+
+  @Get()
+  @UseGuards(AdminAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Listado de feedback (admin)',
+    description: 'Devuelve respuestas paginadas, filtros y resumen por sentimiento.',
+  })
+  list(@Query() query: QueryFeedbackDto) {
+    return this.feedbackService.getAdminList(query);
+  }
+}

--- a/src/modules/feedback/feedback.controller.ts
+++ b/src/modules/feedback/feedback.controller.ts
@@ -1,0 +1,33 @@
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { FirebaseAuthGuard } from '../../common/guards/firebase-auth.guard.js';
+import { CurrentUser } from '../../common/decorators/current-user.decorator.js';
+import type { FirebaseUser } from '../../common/decorators/current-user.decorator.js';
+import { FeedbackService } from './feedback.service.js';
+import { CreateFeedbackDto } from './dto/create-feedback.dto.js';
+
+@ApiTags('feedback')
+@Controller('feedback')
+export class FeedbackController {
+  constructor(private readonly feedbackService: FeedbackService) {}
+
+  @Get('status')
+  @UseGuards(FirebaseAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Estado de la encuesta mensual',
+    description: 'Indica si debe mostrarse la encuesta (cadencia 30 días rolling).',
+  })
+  getStatus(@CurrentUser() user: FirebaseUser) {
+    return this.feedbackService.getStatus(user.uid);
+  }
+
+  @Post()
+  @UseGuards(FirebaseAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Enviar una respuesta de feedback' })
+  @ApiResponse({ status: 201, description: 'Feedback registrado correctamente' })
+  submit(@CurrentUser() user: FirebaseUser, @Body() dto: CreateFeedbackDto) {
+    return this.feedbackService.submit(user.uid, user.email, dto);
+  }
+}

--- a/src/modules/feedback/feedback.module.ts
+++ b/src/modules/feedback/feedback.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { FeedbackController } from './feedback.controller.js';
+import { FeedbackAdminController } from './feedback-admin.controller.js';
+import { FeedbackService } from './feedback.service.js';
+import { CacheModule } from '../cache/cache.module.js';
+
+@Module({
+  imports: [CacheModule],
+  controllers: [FeedbackController, FeedbackAdminController],
+  providers: [FeedbackService],
+  exports: [FeedbackService],
+})
+export class FeedbackModule {}

--- a/src/modules/feedback/feedback.service.ts
+++ b/src/modules/feedback/feedback.service.ts
@@ -1,0 +1,80 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { FirestoreService } from '../cache/firestore.service.js';
+import type { CreateFeedbackDto } from './dto/create-feedback.dto.js';
+import type { QueryFeedbackDto } from './dto/query-feedback.dto.js';
+import type {
+  FeedbackStatus,
+  FeedbackListResult,
+  FeedbackFilters,
+} from '../../common/interfaces/feedback.interface.js';
+
+/** Cadencia de la encuesta: 30 días rolling desde el último envío. */
+const ROLLING_DAYS = 30;
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+@Injectable()
+export class FeedbackService {
+  private readonly logger = new Logger(FeedbackService.name);
+
+  constructor(private readonly firestoreService: FirestoreService) {}
+
+  /**
+   * Decide si mostrar la encuesta al usuario (cadencia 30 días rolling).
+   */
+  async getStatus(userId: string): Promise<FeedbackStatus> {
+    const last = await this.firestoreService.getLastFeedbackByUser(userId);
+
+    if (!last) {
+      return { shouldShow: true, lastSubmittedAt: null, daysSinceLast: null };
+    }
+
+    const lastDate = new Date(last.createdAt);
+    const daysSinceLast = Math.floor((Date.now() - lastDate.getTime()) / DAY_MS);
+
+    return {
+      shouldShow: daysSinceLast >= ROLLING_DAYS,
+      lastSubmittedAt: lastDate.toISOString(),
+      daysSinceLast,
+    };
+  }
+
+  /**
+   * Registra la respuesta del usuario. El plan y el email se toman del perfil
+   * (fuente de verdad), no del cliente.
+   */
+  async submit(
+    userId: string,
+    tokenEmail: string | undefined,
+    dto: CreateFeedbackDto,
+  ): Promise<{ success: boolean }> {
+    const user = await this.firestoreService.getUserById(userId);
+
+    await this.firestoreService.createFeedback({
+      userId,
+      userEmail: user?.email || tokenEmail || null,
+      plan: user?.plan || 'free',
+      sentiment: dto.sentiment,
+      message: dto.message?.trim() || null,
+      locale: dto.locale || null,
+    });
+
+    return { success: true };
+  }
+
+  /**
+   * Listado paginado + resumen para el panel admin.
+   */
+  async getAdminList(query: QueryFeedbackDto): Promise<FeedbackListResult> {
+    const filters: FeedbackFilters = {
+      page: query.page ? Number(query.page) : 1,
+      limit: query.limit ? Number(query.limit) : 20,
+      sentiment: query.sentiment,
+      plan: query.plan,
+      search: query.search,
+      startDate: query.startDate ? new Date(query.startDate) : undefined,
+      endDate: query.endDate ? new Date(query.endDate) : undefined,
+    };
+
+    return this.firestoreService.getFeedbackList(filters);
+  }
+}

--- a/src/modules/feedback/feedback.service.ts
+++ b/src/modules/feedback/feedback.service.ts
@@ -46,7 +46,24 @@ export class FeedbackService {
     userId: string,
     tokenEmail: string | undefined,
     dto: CreateFeedbackDto,
-  ): Promise<{ success: boolean }> {
+  ): Promise<{ success: boolean; skipped?: boolean }> {
+    // Defense-in-depth: la cadencia se valida también en el servidor, no solo
+    // en el cliente (status.shouldShow). Evita que un doble envío o un POST
+    // directo creen registros duplicados que sesguen las métricas. Idempotente:
+    // si ya hay feedback reciente, se ignora silenciosamente (success: true).
+    const last = await this.firestoreService.getLastFeedbackByUser(userId);
+    if (last) {
+      const daysSinceLast = Math.floor(
+        (Date.now() - new Date(last.createdAt).getTime()) / DAY_MS,
+      );
+      if (daysSinceLast < ROLLING_DAYS) {
+        this.logger.warn(
+          `Feedback ignorado para ${userId}: último hace ${daysSinceLast}d (< ${ROLLING_DAYS}d)`,
+        );
+        return { success: true, skipped: true };
+      }
+    }
+
     const user = await this.firestoreService.getUserById(userId);
 
     await this.firestoreService.createFeedback({
@@ -66,8 +83,8 @@ export class FeedbackService {
    */
   async getAdminList(query: QueryFeedbackDto): Promise<FeedbackListResult> {
     const filters: FeedbackFilters = {
-      page: query.page ? Number(query.page) : 1,
-      limit: query.limit ? Number(query.limit) : 20,
+      page: query.page ?? 1,
+      limit: query.limit ?? 20,
       sentiment: query.sentiment,
       plan: query.plan,
       search: query.search,


### PR DESCRIPTION
## Resumen

Módulo `feedback` para la encuesta mensual de satisfacción. El frontend ya está implementado y consume estos endpoints.

## Endpoints
- **Usuario** (`FirebaseAuthGuard` + `@CurrentUser`):
  - `GET /api/feedback/status` — ¿mostrar encuesta? (cadencia **30 días rolling**)
  - `POST /api/feedback` — `{ sentiment: bad|neutral|good, message?, locale? }`
- **Admin** (`AdminAuthGuard`):
  - `GET /api/admin/feedback` — paginado + filtros (sentiment/plan/startDate/endDate/search) + `summary` (% satisfacción)

## Implementación
- Colección Firestore `feedback` (doc autogenerado: `userId, userEmail, plan, sentiment, message?, locale?, createdAt`).
- `FirestoreService`: `createFeedback`, `getLastFeedbackByUser`, `getFeedbackList`.
- Filtros / summary / paginación **en memoria** (sin índices compuestos), siguiendo el patrón de `getErrorLogs`. El status usa un `where` de un solo campo.
- `plan` y `userEmail` se toman del perfil del usuario, no del cliente.
- DTOs con `class-validator` + Swagger.

## Verificación
- `npm run build`: **TSC 0 issues** (147 archivos).
- El servidor levanta y mapea las rutas (`/api/feedback/status`, `/api/feedback`, `/api/admin/feedback`); responden `401` sin token.
- Nota: el lint del repo (`.eslintrc.js` con `module.exports`) es incompatible con `"type":"module"` (preexistente, no introducido aquí).

## Frontend
`gustavojmarrero/zplpdf_front`, rama `feat/monthly-feedback-survey`.

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)
