### PR TITLE
fix(admin): elimina falsos "critical" de Labelary y acota métricas de error por fecha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,8 @@ docs/*
 zplpdf-guatever-firebase-adminsdk-fbsvc-6bbd67ac4b.json.env.local
 zplpdf-guatever-firebase-adminsdk-fbsvc-6bbd67ac4b.json
 firebase-credentials.json
+
+# Artefactos de herramientas de agentes (config local con secretos, no versionar)
+.codex/
+.agents/
+AGENTS.md

--- a/src/modules/admin/admin.controller.ts
+++ b/src/modules/admin/admin.controller.ts
@@ -26,7 +26,7 @@ import { AdminAuthGuard } from '../../common/guards/admin-auth.guard.js';
 import { AdminUser } from '../../common/decorators/admin-user.decorator.js';
 import type { AdminUserData } from '../../common/decorators/admin-user.decorator.js';
 import { AdminService } from './admin.service.js';
-import { AdminMetricsResponseDto } from './dto/admin-metrics.dto.js';
+import { AdminMetricsResponseDto, GetMetricsQueryDto } from './dto/admin-metrics.dto.js';
 import {
   GetUsersQueryDto,
   AdminUsersResponseDto,
@@ -107,9 +107,12 @@ export class AdminController {
   })
   @ApiResponse({ status: 401, description: 'Unauthorized - Invalid or missing token' })
   @ApiResponse({ status: 403, description: 'Forbidden - Admin access required' })
-  async getMetrics(@AdminUser() admin: AdminUserData): Promise<AdminMetricsResponseDto> {
+  async getMetrics(
+    @Query() query: GetMetricsQueryDto,
+    @AdminUser() admin: AdminUserData,
+  ): Promise<AdminMetricsResponseDto> {
     this.logger.log(`Admin ${admin.email} requesting dashboard metrics`);
-    return this.adminService.getDashboardMetrics();
+    return this.adminService.getDashboardMetrics(query.startDate, query.endDate);
   }
 
   @Get('users')

--- a/src/modules/admin/admin.service.ts
+++ b/src/modules/admin/admin.service.ts
@@ -5,6 +5,10 @@ import { Storage } from '@google-cloud/storage';
 import { FirestoreService } from '../cache/firestore.service.js';
 import { BillingService } from '../billing/billing.service.js';
 import { toISOString, ensureISOString } from '../../utils/date.util.js';
+import {
+  getStartOfDateInTimezone,
+  getEndOfDateInTimezone,
+} from '../../utils/timezone.util.js';
 import { PeriodCalculatorService } from '../../common/services/period-calculator.service.js';
 import { LabelaryAnalyticsService } from '../zpl/services/labelary-analytics.service.js';
 import { DEFAULT_PLAN_LIMITS, PLAN_ORDER } from '../../common/interfaces/user.interface.js';
@@ -46,8 +50,11 @@ export class AdminService {
   private readonly logger = new Logger(AdminService.name);
   private stripe: Stripe | null = null;
 
-  // Caché de métricas del dashboard (5 minutos)
-  private metricsCache: { data: AdminMetricsResponseDto; timestamp: number } | null = null;
+  // Caché de métricas del dashboard (5 minutos), por rango de fechas solicitado
+  private metricsCache = new Map<
+    string,
+    { data: AdminMetricsResponseDto; timestamp: number }
+  >();
   private readonly CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutos
 
   constructor(
@@ -69,11 +76,22 @@ export class AdminService {
     }
   }
 
-  async getDashboardMetrics(): Promise<AdminMetricsResponseDto> {
-    // Verificar caché
-    if (this.metricsCache && Date.now() - this.metricsCache.timestamp < this.CACHE_TTL_MS) {
+  async getDashboardMetrics(
+    startDate?: string,
+    endDate?: string,
+  ): Promise<AdminMetricsResponseDto> {
+    // Rango de fechas opcional: acota errors.byType y errors.criticalCount.
+    // Se interpretan como días completos en GMT-6 (coherente con el resto
+    // de métricas diarias del dashboard).
+    const errorsStart = startDate ? getStartOfDateInTimezone(startDate) : undefined;
+    const errorsEnd = endDate ? getEndOfDateInTimezone(endDate) : undefined;
+
+    // Verificar caché (por rango solicitado)
+    const cacheKey = `${startDate ?? '_'}|${endDate ?? '_'}`;
+    const cached = this.metricsCache.get(cacheKey);
+    if (cached && Date.now() - cached.timestamp < this.CACHE_TTL_MS) {
       this.logger.log('Returning cached dashboard metrics');
-      return this.metricsCache.data;
+      return cached.data;
     }
 
     this.logger.log('Fetching dashboard metrics (cache miss)');
@@ -107,7 +125,7 @@ export class AdminService {
         this.firestoreService.getConversionStats('week'),
         this.firestoreService.getConversionStats('month'),
         this.firestoreService.getConversionTrend(8),
-        this.firestoreService.getErrorStats(),
+        this.firestoreService.getErrorStats(errorsStart, errorsEnd),
         this.firestoreService.getUsersNearLimit(80),
         this.firestoreService.getPlanDistribution(),
         this.firestoreService.getUpgradeOpportunities(),
@@ -200,8 +218,8 @@ export class AdminService {
         generatedAt: new Date(),
       };
 
-      // Guardar en caché
-      this.metricsCache = { data: result, timestamp: Date.now() };
+      // Guardar en caché (por rango solicitado)
+      this.metricsCache.set(cacheKey, { data: result, timestamp: Date.now() });
 
       return result;
     } catch (error) {

--- a/src/modules/admin/dto/admin-metrics.dto.ts
+++ b/src/modules/admin/dto/admin-metrics.dto.ts
@@ -1,4 +1,23 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsDateString } from 'class-validator';
+
+export class GetMetricsQueryDto {
+  @ApiPropertyOptional({
+    description:
+      'Fecha de inicio (ISO 8601, ej. 2026-06-11). Acota errors.byType y errors.criticalCount a la ventana. Interpretada como día en GMT-6.',
+  })
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Fecha de fin (ISO 8601, ej. 2026-06-11). Inclusiva hasta el final del día en GMT-6.',
+  })
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+}
 
 class RecentRegistrationDto {
   @ApiProperty()

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -1331,7 +1331,10 @@ export class FirestoreService {
     }
   }
 
-  async getErrorStats(): Promise<{
+  async getErrorStats(
+    startDate?: Date,
+    endDate?: Date,
+  ): Promise<{
     recentErrors: ErrorLog[];
     byType: Record<string, number>;
     criticalCount: number;
@@ -1357,10 +1360,19 @@ export class FirestoreService {
         } as ErrorLog;
       });
 
-      // Get all error stats
-      const allErrorsSnapshot = await this.firestore
-        .collection(this.errorLogsCollection)
-        .get();
+      // Get error stats. Si se provee rango de fechas se acotan byType y
+      // criticalCount a esa ventana (solo where sobre createdAt: usa el índice
+      // single-field, no requiere índice compuesto). Sin rango, totales históricos.
+      let statsQuery: FirebaseFirestore.Query = this.firestore.collection(
+        this.errorLogsCollection,
+      );
+      if (startDate) {
+        statsQuery = statsQuery.where('createdAt', '>=', startDate);
+      }
+      if (endDate) {
+        statsQuery = statsQuery.where('createdAt', '<=', endDate);
+      }
+      const allErrorsSnapshot = await statsQuery.get();
 
       const byType: Record<string, number> = {};
       let criticalCount = 0;

--- a/src/modules/zpl/zpl.service.spec.ts
+++ b/src/modules/zpl/zpl.service.spec.ts
@@ -186,4 +186,25 @@ describe('ZplService — registro de errores de Labelary', () => {
       }),
     );
   });
+
+  it('no marca la excepción si el registro del error falló (deja actuar al fallback)', async () => {
+    const saveErrorLog = jest.fn().mockRejectedValue(new Error('Firestore down'));
+    const enqueue = jest.fn().mockRejectedValue(new Error('Labelary 503'));
+    const service = buildService(saveErrorLog, enqueue);
+
+    const err = await (service as any)
+      .callLabelary(
+        '^XA^FO50,50^A0,30^FDtest^FS^XZ',
+        LabelSize.FOUR_BY_SIX,
+        'job1',
+        'user1',
+        'free',
+        1,
+      )
+      .catch((e: any) => e);
+
+    // Sin confirmación de guardado, la excepción NO se marca: processZplConversion
+    // hará el registro de respaldo en lugar de omitirlo silenciosamente.
+    expect(err.loggedToDashboard).toBeUndefined();
+  });
 });

--- a/src/modules/zpl/zpl.service.spec.ts
+++ b/src/modules/zpl/zpl.service.spec.ts
@@ -140,3 +140,50 @@ describe('ZplService — bloques de configuración sin contenido', () => {
     });
   });
 });
+
+/**
+ * Regresión: un fallo de la API de Labelary debe registrarse UNA sola vez y con
+ * severidad "error" (no "critical"). callLabelary marca la excepción con
+ * `loggedToDashboard` para que el catch genérico de processZplConversion no la
+ * vuelva a guardar como SERVER_ERROR/critical (evita doble conteo y falsos
+ * "critical" en el dashboard de admin).
+ */
+describe('ZplService — registro de errores de Labelary', () => {
+  function buildService(saveErrorLog: jest.Mock, enqueue: jest.Mock) {
+    const configService: any = { get: jest.fn(() => 'test-bucket') };
+    return new ZplService(
+      configService,
+      { saveErrorLog } as any,
+      {} as any,
+      {} as any,
+      { enqueue } as any,
+    );
+  }
+
+  it('registra el fallo de Labelary una vez con severidad "error" y marca la excepción', async () => {
+    const saveErrorLog = jest.fn().mockResolvedValue({ id: 'x', errorId: 'ERR-1' });
+    const enqueue = jest.fn().mockRejectedValue(new Error('Labelary 503'));
+    const service = buildService(saveErrorLog, enqueue);
+
+    await expect(
+      (service as any).callLabelary(
+        '^XA^FO50,50^A0,30^FDtest^FS^XZ',
+        LabelSize.FOUR_BY_SIX,
+        'job1',
+        'user1',
+        'free',
+        1,
+      ),
+    ).rejects.toMatchObject({ loggedToDashboard: true });
+
+    // Un único registro, con severidad "error" (no "critical").
+    expect(saveErrorLog).toHaveBeenCalledTimes(1);
+    expect(saveErrorLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'SERVER_ERROR',
+        code: 'LABELARY_API_ERROR',
+        severity: 'error',
+      }),
+    );
+  });
+});

--- a/src/modules/zpl/zpl.service.ts
+++ b/src/modules/zpl/zpl.service.ts
@@ -142,6 +142,17 @@ export class ZplService {
   }
 
   /**
+   * Marca una excepción como ya registrada en error_logs para que el catch
+   * genérico de processZplConversion no la vuelva a guardar. Evita el doble
+   * registro y los falsos "critical" provenientes de fallos ya clasificados
+   * en capas inferiores (p. ej. errores de la API de Labelary).
+   */
+  private markAsLogged<T>(error: T): T {
+    (error as any).loggedToDashboard = true;
+    return error;
+  }
+
+  /**
    * Registra un error en el log de errores de admin
    */
   private async logError(
@@ -521,19 +532,23 @@ export class ZplService {
     } catch (error) {
       this.logger.error(`Error al procesar conversión ZPL: ${error.message}`);
 
-      // Log error for admin dashboard
-      const errorType = error.message?.includes('ZPL') ? 'INVALID_ZPL' : 'SERVER_ERROR';
-      const severity = errorType === 'SERVER_ERROR' ? 'critical' : 'error';
-      await this.logError(
-        errorType,
-        errorType,
-        error.message,
-        severity,
-        { labelSize, outputFormat },
-        undefined,
-        undefined,
-        jobId,
-      );
+      // Log error for admin dashboard. Si el error ya fue registrado en una
+      // capa inferior (p. ej. fallo de Labelary guardado como LABELARY_API_ERROR),
+      // no lo duplicamos aquí: evita el doble conteo y los falsos "critical".
+      if (!(error as any)?.loggedToDashboard) {
+        const errorType = error.message?.includes('ZPL') ? 'INVALID_ZPL' : 'SERVER_ERROR';
+        const severity = errorType === 'SERVER_ERROR' ? 'critical' : 'error';
+        await this.logError(
+          errorType,
+          errorType,
+          error.message,
+          severity,
+          { labelSize, outputFormat },
+          undefined,
+          undefined,
+          jobId,
+        );
+      }
 
       // Actualizar estado a fallido
       job.status = 'failed';
@@ -1181,13 +1196,16 @@ export class ZplService {
           'error',
           { labelSize },
         );
-        throw new HttpException(
-          'El número de etiquetas excede el límite permitido (50 etiquetas por solicitud)',
-          HttpStatus.PAYLOAD_TOO_LARGE,
+        throw this.markAsLogged(
+          new HttpException(
+            'El número de etiquetas excede el límite permitido (50 etiquetas por solicitud)',
+            HttpStatus.PAYLOAD_TOO_LARGE,
+          ),
         );
       }
 
-      // Log generic Labelary error
+      // Log generic Labelary error (severidad "error": es un fallo de la
+      // dependencia externa, no un error crítico del propio servidor).
       this.logError(
         'SERVER_ERROR',
         'LABELARY_API_ERROR',
@@ -1195,9 +1213,11 @@ export class ZplService {
         'error',
         { status: error.response?.status },
       );
-      throw new HttpException(
-        'Error in Labelary API conversion',
-        HttpStatus.INTERNAL_SERVER_ERROR,
+      throw this.markAsLogged(
+        new HttpException(
+          'Error in Labelary API conversion',
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        ),
       );
     }
   }

--- a/src/modules/zpl/zpl.service.ts
+++ b/src/modules/zpl/zpl.service.ts
@@ -153,7 +153,10 @@ export class ZplService {
   }
 
   /**
-   * Registra un error en el log de errores de admin
+   * Registra un error en el log de errores de admin.
+   * @returns `true` si el registro se guardó, `false` si el write falló.
+   *   Permite a quien lo llama decidir si confiar en que el error quedó
+   *   registrado (p. ej. para no omitir un fallback de logging).
    */
   private async logError(
     type: string,
@@ -164,7 +167,7 @@ export class ZplService {
     userId?: string,
     userEmail?: string,
     jobId?: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
       await this.firestoreService.saveErrorLog({
         type,
@@ -176,8 +179,10 @@ export class ZplService {
         userEmail,
         jobId,
       });
+      return true;
     } catch (error) {
       this.logger.error(`Error logging to error_logs: ${error.message}`);
+      return false;
     }
   }
 
@@ -1189,36 +1194,40 @@ export class ZplService {
       }
 
       if (error.response?.status === 413) {
-        this.logError(
+        const logged = await this.logError(
           'LABEL_LIMIT_EXCEEDED',
           'LABELARY_PAYLOAD_TOO_LARGE',
           'Labels exceed 50 per request limit',
           'error',
           { labelSize },
         );
-        throw this.markAsLogged(
-          new HttpException(
-            'El número de etiquetas excede el límite permitido (50 etiquetas por solicitud)',
-            HttpStatus.PAYLOAD_TOO_LARGE,
-          ),
+        const httpError = new HttpException(
+          'El número de etiquetas excede el límite permitido (50 etiquetas por solicitud)',
+          HttpStatus.PAYLOAD_TOO_LARGE,
         );
+        // Solo omitimos el fallback de processZplConversion si el registro se
+        // confirmó; si el write falló, dejamos que el catch superior lo guarde.
+        if (logged) this.markAsLogged(httpError);
+        throw httpError;
       }
 
       // Log generic Labelary error (severidad "error": es un fallo de la
       // dependencia externa, no un error crítico del propio servidor).
-      this.logError(
+      const logged = await this.logError(
         'SERVER_ERROR',
         'LABELARY_API_ERROR',
         `Labelary API error: ${error.message}`,
         'error',
         { status: error.response?.status },
       );
-      throw this.markAsLogged(
-        new HttpException(
-          'Error in Labelary API conversion',
-          HttpStatus.INTERNAL_SERVER_ERROR,
-        ),
+      const httpError = new HttpException(
+        'Error in Labelary API conversion',
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
+      // Solo omitimos el fallback de processZplConversion si el registro se
+      // confirmó; si el write falló, dejamos que el catch superior lo guarde.
+      if (logged) this.markAsLogged(httpError);
+      throw httpError;
     }
   }
 

--- a/src/utils/timezone.util.spec.ts
+++ b/src/utils/timezone.util.spec.ts
@@ -1,0 +1,51 @@
+import {
+  getStartOfDateInTimezone,
+  getEndOfDateInTimezone,
+} from './timezone.util';
+
+/**
+ * El dashboard opera en GMT-6 (Mérida). Estos helpers convierten un string de
+ * fecha (YYYY-MM-DD) en los límites de ese día en GMT-6 para acotar métricas
+ * de error_logs. El riesgo principal es un off-by-one al cruzar el offset.
+ */
+describe('timezone.util — límites de día en GMT-6', () => {
+  describe('getStartOfDateInTimezone', () => {
+    it('inicio del día = 06:00:00 UTC (00:00 GMT-6)', () => {
+      expect(getStartOfDateInTimezone('2026-06-11').toISOString()).toBe(
+        '2026-06-11T06:00:00.000Z',
+      );
+    });
+
+    it('ignora la parte horaria si viene un ISO completo', () => {
+      expect(
+        getStartOfDateInTimezone('2026-06-11T15:30:00Z').toISOString(),
+      ).toBe('2026-06-11T06:00:00.000Z');
+    });
+  });
+
+  describe('getEndOfDateInTimezone', () => {
+    it('fin del día = 05:59:59.999 UTC del día siguiente (23:59:59.999 GMT-6)', () => {
+      expect(getEndOfDateInTimezone('2026-06-11').toISOString()).toBe(
+        '2026-06-12T05:59:59.999Z',
+      );
+    });
+
+    it('normaliza correctamente el cruce de mes', () => {
+      expect(getEndOfDateInTimezone('2026-06-30').toISOString()).toBe(
+        '2026-07-01T05:59:59.999Z',
+      );
+    });
+
+    it('normaliza correctamente el cruce de año', () => {
+      expect(getEndOfDateInTimezone('2026-12-31').toISOString()).toBe(
+        '2027-01-01T05:59:59.999Z',
+      );
+    });
+  });
+
+  it('un rango de un solo día cubre 24h exactas', () => {
+    const start = getStartOfDateInTimezone('2026-06-11');
+    const end = getEndOfDateInTimezone('2026-06-11');
+    expect(end.getTime() - start.getTime()).toBe(24 * 60 * 60 * 1000 - 1);
+  });
+});

--- a/src/utils/timezone.util.ts
+++ b/src/utils/timezone.util.ts
@@ -71,6 +71,26 @@ export function getDateStringInTimezone(date: Date = new Date()): string {
 }
 
 /**
+ * Convierte un string de fecha (YYYY-MM-DD, o ISO con hora) al instante de
+ * inicio de ese día en GMT-6.
+ * Ej: "2026-06-11" → 2026-06-11T06:00:00.000Z (= 00:00:00 GMT-6)
+ */
+export function getStartOfDateInTimezone(dateStr: string): Date {
+  const [year, month, day] = dateStr.slice(0, 10).split('-').map(Number);
+  return new Date(Date.UTC(year, month - 1, day, GMT_OFFSET_HOURS, 0, 0, 0));
+}
+
+/**
+ * Convierte un string de fecha (YYYY-MM-DD, o ISO con hora) al instante de
+ * fin de ese día en GMT-6.
+ * Ej: "2026-06-11" → 2026-06-12T05:59:59.999Z (= 23:59:59.999 GMT-6)
+ */
+export function getEndOfDateInTimezone(dateStr: string): Date {
+  const [year, month, day] = dateStr.slice(0, 10).split('-').map(Number);
+  return new Date(Date.UTC(year, month - 1, day, GMT_OFFSET_HOURS + 23, 59, 59, 999));
+}
+
+/**
  * Obtiene el mes actual en GMT-6 (YYYY-MM)
  * Ejemplo: Si son las 03:00 UTC del 1 de febrero, en GMT-6 todavía es enero
  */


### PR DESCRIPTION
## Contexto

El dashboard de admin mostraba `criticalCount: 7` en `GET /api/admin/metrics`. La investigación reveló que **ninguno** de esos críticos es un bug del servidor: son fallos transitorios de la API externa de **Labelary** (5 de ellos en un brote de ~3 min el 29-may-2026), mal clasificados y contados de forma histórica.

Tres defectos detectados:
1. **Doble registro**: cada fallo de Labelary creaba dos entradas en `error_logs` — `LABELARY_API_ERROR` (`error`) y, al burbujear la excepción, `SERVER_ERROR` (`critical`).
2. **Severidad incorrecta**: un fallo de dependencia externa quedaba como `critical` (falsa alarma).
3. **`criticalCount`/`byType` ignoraban el rango de fechas**: el endpoint `/metrics` ni siquiera leía `startDate`/`endDate`, y `getErrorStats()` contaba toda la colección histórica.

## Cambios

**Puntos 1 y 2 — `zpl.service.ts`**
- Nuevo helper `markAsLogged()` que marca la excepción con `loggedToDashboard`.
- `callLabelary` marca las excepciones que ya registró (fallo genérico de Labelary y payload 413).
- El `catch` de `processZplConversion` solo registra `SERVER_ERROR`/`critical` si el error **no** venía ya logueado. Cada fallo de Labelary deja un **único** registro de severidad `error`. Los errores genuinos del servidor (GCS, signed URL…) siguen como `critical`.

**Punto 3 — `admin.controller.ts`, `admin.service.ts`, `firestore.service.ts`, `timezone.util.ts`**
- `GET /metrics` ahora lee `startDate`/`endDate` (nuevo `GetMetricsQueryDto`) y los propaga a `getErrorStats`, que acota `byType` y `criticalCount` a la ventana (solo `where` sobre `createdAt` → índice single-field, **sin índice compuesto**).
- Fechas interpretadas como días completos en **GMT-6**, con helpers `getStartOfDateInTimezone`/`getEndOfDateInTimezone`.
- El caché del dashboard pasa a indexarse por rango.

## Compatibilidad

- Sin rango de fechas, `criticalCount` mantiene el comportamiento histórico (no rompe llamadas existentes).
- Frontend: ya envía `startDate`/`endDate`, por lo que ahora se respetan. Para que la carga por defecto deje de mostrar el histórico, el front debería mandar un rango por defecto (issue aparte en `zplpdf_front`, no incluido aquí).

## Pruebas

- `npm test`: 6 suites / 36 tests en verde (7 nuevos: límites de día GMT-6 con cruce de mes/año, y registro único de errores de Labelary).
- `npm run build`: limpio.
- `npm run lint`: error **preexistente** ajeno a este PR (`.eslintrc.js` con `module.exports` en proyecto ESM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)