### PR TITLE
fix(deploy): fijar --project en los scripts de despliegue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,9 +180,17 @@ Uses Firebase Auth ID tokens. Guards:
 
 ### Google Cloud Project
 
-- **Project ID:** `intranet-guatever`
+⚠️ **El proyecto NO es el mismo para todo.** Los recursos están repartidos en dos:
+
+| Recurso | Project ID |
+|---------|------------|
+| Cloud Run, Cloud Build, Container Registry | `intranet-guatever` |
+| **Firestore** | `zplpdf-guatever` |
+
 - **Cloud Run Service:** `zplpdf-service`
 - **Region:** `us-central1`
+
+Pasar SIEMPRE `--project` explícito en los comandos de `gcloud`: el proyecto activo por defecto puede ser otro distinto y los errores resultantes despistan (un build en el proyecto equivocado falla con `Permission 'artifactregistry.repositories.uploadArtifacts' denied`, que parece un problema de IAM). Ojo especialmente con `gcloud firestore ...`: contra `intranet-guatever` devuelve `NOT_FOUND: database '(default)' does not exist` porque ahí no hay Firestore.
 
 ### Environment Variables
 

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "deploy:build": "gcloud builds submit --tag gcr.io/intranet-guatever/zplpdf-service",
-    "deploy:run": "gcloud run deploy zplpdf-service --image gcr.io/intranet-guatever/zplpdf-service --platform managed --region us-central1 --max-instances=1 --allow-unauthenticated"
+    "deploy:build": "gcloud builds submit --project=intranet-guatever --tag gcr.io/intranet-guatever/zplpdf-service",
+    "deploy:run": "gcloud run deploy zplpdf-service --project=intranet-guatever --image gcr.io/intranet-guatever/zplpdf-service --platform managed --region us-central1 --max-instances=1 --allow-unauthenticated"
   },
   "dependencies": {
     "@google-cloud/firestore": "^7.11.0",


### PR DESCRIPTION
## Problema

`deploy:build` y `deploy:run` no pasaban `--project`, así que usaban el proyecto activo de `gcloud`. Cuando ese proyecto es otro (en mi máquina de trabajo era `amazon-b2b-monitor`), Cloud Build corre **ahí** e intenta pushear la imagen a `gcr.io/intranet-guatever/`, fallando con:

```
denied: Permission 'artifactregistry.repositories.uploadArtifacts' denied on resource
'//artifactregistry.googleapis.com/projects/intranet-guatever/locations/us/repositories/gcr.io'
```

El mensaje apunta a IAM y hace perder tiempo diagnosticando permisos, cuando lo que falla es el proyecto en el que se ejecuta el build. Lo confirmé viendo el build fallido listado bajo `amazon-b2b-monitor` con la imagen apuntando a `intranet-guatever`.

## Cambio

Ambos scripts llevan `--project=intranet-guatever` explícito. Son ahora **exactamente** los comandos que ejecuté a mano para desplegar la revisión `zplpdf-service-00102-jvn` (el fix del issue #56), así que están verificados contra producción hoy.

## Documentación

Aproveché para documentar en `CLAUDE.md` algo que no estaba explícito y que induce a error: **los recursos viven en dos proyectos distintos**.

| Recurso | Project ID |
|---|---|
| Cloud Run, Cloud Build, Container Registry | `intranet-guatever` |
| Firestore | `zplpdf-guatever` |

Ambos aparecían ya en el archivo pero sin explicar la separación, lo que hace pensar que uno de los dos es un typo. No lo es: verifiqué que `gcloud firestore indexes composite list --project=intranet-guatever` falla con `NOT_FOUND: database '(default)' does not exist`, porque en ese proyecto no hay Firestore. Los índices están todos en `zplpdf-guatever`.

Esto importa porque el fallo es **silencioso si se filtra la salida**: un `gcloud firestore ... | grep <algo>` contra el proyecto equivocado no devuelve nada y se lee como "no hay resultados" en vez de como un error.

## Verificación

`package.json` sigue siendo JSON válido y ambos scripts resuelven a los comandos correctos. No toqué código de aplicación, así que build y tests no se ven afectados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
