### PR TITLE
fix(email): poblar `skipped` en los schedule* de onboarding

### DIFF
--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -36,6 +36,8 @@ import type {
   TemplateVersion,
   CreateEmailTemplateData,
   UpdateEmailTemplateData,
+  EligibleEmailUser,
+  EligibleEmailUsersResult,
 } from '../email/interfaces/email.interface.js';
 
 // ============== Daily Stats (Aggregated Metrics) ==============
@@ -5086,16 +5088,7 @@ export class FirestoreService {
     minPdfCount?: number;
     maxPdfCount?: number;
     limit?: number;
-  }): Promise<
-    Array<{
-      userId: string;
-      userEmail: string;
-      displayName?: string;
-      language: string;
-      pdfCount: number;
-      createdAt: Date;
-    }>
-  > {
+  }): Promise<EligibleEmailUsersResult> {
     const now = new Date();
     const minDate = new Date(now);
     minDate.setDate(minDate.getDate() - params.maxDaysSinceCreation);
@@ -5110,14 +5103,10 @@ export class FirestoreService {
       .limit(params.limit || 100)
       .get();
 
-    const eligibleUsers: Array<{
-      userId: string;
-      userEmail: string;
-      displayName?: string;
-      language: string;
-      pdfCount: number;
-      createdAt: Date;
-    }> = [];
+    const users: EligibleEmailUser[] = [];
+    // Los descartes se cuentan aquí porque es donde ocurren: quien llama solo
+    // recibe la lista final y no puede saber cuántos candidatos se filtraron.
+    const skipped = { alreadyReceived: 0, pdfCountOutOfRange: 0 };
 
     for (const doc of usersSnapshot.docs) {
       const userData = doc.data();
@@ -5127,7 +5116,10 @@ export class FirestoreService {
         doc.id,
         params.emailType,
       );
-      if (hasEmail) continue;
+      if (hasEmail) {
+        skipped.alreadyReceived++;
+        continue;
+      }
 
       // Get user's PDF count from usage
       const usageSnapshot = await this.firestore
@@ -5143,15 +5135,19 @@ export class FirestoreService {
       }
 
       // Check PDF count criteria
-      if (params.minPdfCount !== undefined && pdfCount < params.minPdfCount)
+      if (params.minPdfCount !== undefined && pdfCount < params.minPdfCount) {
+        skipped.pdfCountOutOfRange++;
         continue;
-      if (params.maxPdfCount !== undefined && pdfCount > params.maxPdfCount)
+      }
+      if (params.maxPdfCount !== undefined && pdfCount > params.maxPdfCount) {
+        skipped.pdfCountOutOfRange++;
         continue;
+      }
 
       // Determine language (default to 'en')
       const language = this.detectLanguageFromCountry(userData.country) || 'en';
 
-      eligibleUsers.push({
+      users.push({
         userId: doc.id,
         userEmail: userData.email,
         displayName: userData.displayName,
@@ -5161,7 +5157,7 @@ export class FirestoreService {
       });
     }
 
-    return eligibleUsers;
+    return { users, skipped };
   }
 
   /**

--- a/src/modules/email/email.service.spec.ts
+++ b/src/modules/email/email.service.spec.ts
@@ -126,3 +126,136 @@ describe('EmailService.triggerBlockedEmail', () => {
     );
   });
 });
+
+/**
+ * `skipped` reportaba siempre 0 en los schedule* de onboarding: el filtrado
+ * ocurre dentro de getUsersEligibleForEmail, que descartaba candidatos en
+ * silencio y devolvía solo los elegibles (issue #60). Sin ese dato no se puede
+ * distinguir "no había candidatos" de "todos ya habían recibido el email".
+ */
+describe('EmailService — métricas de skipped en schedule*Emails', () => {
+  let service: EmailService;
+  let firestore: {
+    getUsersEligibleForEmail: jest.Mock;
+    createEmailQueue: jest.Mock;
+  };
+
+  function eligible(count: number, prefix = 'u') {
+    return Array.from({ length: count }, (_, i) => ({
+      userId: `${prefix}${i}`,
+      userEmail: `${prefix}${i}@ejemplo.com`,
+      displayName: `User ${i}`,
+      language: 'es',
+      pdfCount: 0,
+      createdAt: new Date(2026, 0, 1),
+    }));
+  }
+
+  beforeEach(async () => {
+    firestore = {
+      getUsersEligibleForEmail: jest.fn(),
+      createEmailQueue: jest.fn().mockResolvedValue('queue-id'),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmailService,
+        PeriodCalculatorService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) =>
+              key === 'RESEND_API_KEY' ? 'test-key' : undefined,
+          },
+        },
+        { provide: FirestoreService, useValue: firestore },
+      ],
+    }).compile();
+
+    service = module.get<EmailService>(EmailService);
+  });
+
+  it('reporta los candidatos descartados por haber recibido ya el email', async () => {
+    // 8 candidatos: 3 elegibles, 5 ya lo recibieron.
+    firestore.getUsersEligibleForEmail.mockResolvedValue({
+      users: eligible(3),
+      skipped: { alreadyReceived: 5, pdfCountOutOfRange: 0 },
+    });
+
+    const result = await service.scheduleTutorialEmails();
+
+    expect(result.scheduled).toBe(3);
+    expect(result.skipped).toBe(5);
+    expect(firestore.createEmailQueue).toHaveBeenCalledTimes(3);
+  });
+
+  it('suma los descartes de todos los motivos', async () => {
+    firestore.getUsersEligibleForEmail.mockResolvedValue({
+      users: eligible(2),
+      skipped: { alreadyReceived: 4, pdfCountOutOfRange: 6 },
+    });
+
+    const result = await service.scheduleHelpEmails();
+
+    expect(result.scheduled).toBe(2);
+    expect(result.skipped).toBe(10);
+  });
+
+  it('distingue "sin candidatos" de "todos ya lo recibieron"', async () => {
+    // Ambos casos programan 0 emails; solo `skipped` los diferencia.
+    firestore.getUsersEligibleForEmail.mockResolvedValue({
+      users: [],
+      skipped: { alreadyReceived: 0, pdfCountOutOfRange: 0 },
+    });
+    const sinCandidatos = await service.scheduleTutorialEmails();
+
+    firestore.getUsersEligibleForEmail.mockResolvedValue({
+      users: [],
+      skipped: { alreadyReceived: 12, pdfCountOutOfRange: 0 },
+    });
+    const yaRecibido = await service.scheduleTutorialEmails();
+
+    expect(sinCandidatos.scheduled).toBe(0);
+    expect(yaRecibido.scheduled).toBe(0);
+    expect(sinCandidatos.skipped).toBe(0);
+    expect(yaRecibido.skipped).toBe(12);
+  });
+
+  it('en day 7 NO cuenta pdfCountOutOfRange: las dos consultas parten el mismo cohorte', async () => {
+    // success_story pide pdfCount>=1 y miss_you pide 0, así que cada usuario
+    // del cohorte cae fuera de rango en la consulta que no le toca. Contarlo
+    // marcaría como descartado a quien SÍ recibió email en la otra rama.
+    firestore.getUsersEligibleForEmail
+      .mockResolvedValueOnce({
+        users: eligible(4, 'activo'),
+        skipped: { alreadyReceived: 1, pdfCountOutOfRange: 6 },
+      })
+      .mockResolvedValueOnce({
+        users: eligible(6, 'inactivo'),
+        skipped: { alreadyReceived: 2, pdfCountOutOfRange: 4 },
+      });
+
+    const result = await service.scheduleDay7Emails();
+
+    expect(result.scheduled).toBe(10);
+    // Solo 1 + 2, nunca los 10 de pdfCountOutOfRange.
+    expect(result.skipped).toBe(3);
+  });
+
+  it('devuelve skipped 0 sin consultar nada si el servicio está deshabilitado', async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmailService,
+        PeriodCalculatorService,
+        { provide: ConfigService, useValue: { get: () => undefined } },
+        { provide: FirestoreService, useValue: firestore },
+      ],
+    }).compile();
+    const disabled = module.get<EmailService>(EmailService);
+
+    const result = await disabled.scheduleTutorialEmails();
+
+    expect(result).toMatchObject({ scheduled: 0, skipped: 0 });
+    expect(firestore.getUsersEligibleForEmail).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/email/email.service.ts
+++ b/src/modules/email/email.service.ts
@@ -12,6 +12,7 @@ import type {
   FreeReactivationResult,
   ReactivationEmailType,
   PowerUsersResponse,
+  EmailSkipReasons,
 } from './interfaces/email.interface.js';
 // Note: Hardcoded templates removed. All content now comes from Firestore with A/B support.
 
@@ -237,6 +238,17 @@ export class EmailService {
    * Select A/B variant deterministically based on userId
    * Uses simple hash to ensure same user always gets same variant
    */
+  /**
+   * Suma los candidatos descartados durante el filtrado de elegibilidad.
+   *
+   * Centralizado a propósito: si mañana se añade un motivo nuevo a
+   * `EmailSkipReasons`, basta actualizar esta función en vez de revisar cada
+   * `schedule*Emails` (que es justo cómo `skipped` acabó reportando 0).
+   */
+  private totalSkipped(skipped: EmailSkipReasons): number {
+    return skipped.alreadyReceived + skipped.pdfCountOutOfRange;
+  }
+
   selectAbVariant(userId: string): AbVariant {
     // Simple hash: sum of char codes mod 2
     const hash = userId
@@ -400,20 +412,20 @@ export class EmailService {
     }
 
     let scheduled = 0;
-    const skipped = 0;
+    let skipped = 0;
 
     try {
       // Get users created 1 day ago with 0 PDFs
-      const eligibleUsers =
-        await this.firestoreService.getUsersEligibleForEmail({
-          emailType: 'tutorial',
-          minDaysSinceCreation: 1,
-          maxDaysSinceCreation: 2,
-          maxPdfCount: 0,
-          limit: 100,
-        });
+      const eligible = await this.firestoreService.getUsersEligibleForEmail({
+        emailType: 'tutorial',
+        minDaysSinceCreation: 1,
+        maxDaysSinceCreation: 2,
+        maxPdfCount: 0,
+        limit: 100,
+      });
+      skipped = this.totalSkipped(eligible.skipped);
 
-      for (const user of eligibleUsers) {
+      for (const user of eligible.users) {
         const variant = this.selectAbVariant(user.userId);
 
         await this.firestoreService.createEmailQueue({
@@ -449,20 +461,20 @@ export class EmailService {
     }
 
     let scheduled = 0;
-    const skipped = 0;
+    let skipped = 0;
 
     try {
       // Get users created 3 days ago with 0 PDFs
-      const eligibleUsers =
-        await this.firestoreService.getUsersEligibleForEmail({
-          emailType: 'help',
-          minDaysSinceCreation: 3,
-          maxDaysSinceCreation: 4,
-          maxPdfCount: 0,
-          limit: 100,
-        });
+      const eligible = await this.firestoreService.getUsersEligibleForEmail({
+        emailType: 'help',
+        minDaysSinceCreation: 3,
+        maxDaysSinceCreation: 4,
+        maxPdfCount: 0,
+        limit: 100,
+      });
+      skipped = this.totalSkipped(eligible.skipped);
 
-      for (const user of eligibleUsers) {
+      for (const user of eligible.users) {
         const variant = this.selectAbVariant(user.userId);
 
         await this.firestoreService.createEmailQueue({
@@ -498,11 +510,11 @@ export class EmailService {
     }
 
     let scheduled = 0;
-    const skipped = 0;
+    let skipped = 0;
 
     try {
       // Get users created 7 days ago with ≥1 PDF (success_story)
-      const activeUsers = await this.firestoreService.getUsersEligibleForEmail({
+      const active = await this.firestoreService.getUsersEligibleForEmail({
         emailType: 'success_story',
         minDaysSinceCreation: 7,
         maxDaysSinceCreation: 8,
@@ -510,7 +522,7 @@ export class EmailService {
         limit: 100,
       });
 
-      for (const user of activeUsers) {
+      for (const user of active.users) {
         const variant = this.selectAbVariant(user.userId);
 
         await this.firestoreService.createEmailQueue({
@@ -527,16 +539,23 @@ export class EmailService {
       }
 
       // Get users created 7 days ago with 0 PDFs (miss_you)
-      const inactiveUsers =
-        await this.firestoreService.getUsersEligibleForEmail({
-          emailType: 'miss_you',
-          minDaysSinceCreation: 7,
-          maxDaysSinceCreation: 8,
-          maxPdfCount: 0,
-          limit: 100,
-        });
+      const inactive = await this.firestoreService.getUsersEligibleForEmail({
+        emailType: 'miss_you',
+        minDaysSinceCreation: 7,
+        maxDaysSinceCreation: 8,
+        maxPdfCount: 0,
+        limit: 100,
+      });
 
-      for (const user of inactiveUsers) {
+      // Aquí solo cuenta `alreadyReceived`, NO el total: las dos consultas
+      // parten el mismo cohorte por pdfCount (≥1 vs 0), así que cada usuario
+      // aparece como `pdfCountOutOfRange` en la consulta que no le toca.
+      // Sumarlo marcaría como descartado a todo el que sí recibió email en la
+      // otra rama.
+      skipped =
+        active.skipped.alreadyReceived + inactive.skipped.alreadyReceived;
+
+      for (const user of inactive.users) {
         const variant = this.selectAbVariant(user.userId);
 
         await this.firestoreService.createEmailQueue({
@@ -837,6 +856,13 @@ export class EmailService {
     }
 
     let scheduled = 0;
+    // Sigue en 0 a propósito, a diferencia de los schedule* de onboarding.
+    // getUsersWithHighUsage descarta por `hasUserReceivedEmailInPeriod` ANTES
+    // de evaluar el criterio de uso alto, así que ese conteo incluiría a todos
+    // los usuarios free que ya recibieron el email tengan o no uso alto ahora:
+    // un número inflado y engañoso. Contarlo bien exige reordenar los filtros,
+    // lo que haría correr la consulta de conversiones (cara) para todo free.
+    // Ver issue #60.
     const skipped = 0;
 
     try {
@@ -1158,6 +1184,10 @@ export class EmailService {
     }
 
     let scheduled = 0;
+    // Sigue en 0 porque aquí no hay nada que descartar: getPowerUsersWithPeriod
+    // es un método de reporting (top 10% por uso) y NO comprueba si el usuario
+    // ya recibió el email. Poblar `skipped` exige antes decidir la política de
+    // cadencia de este envío. Ver issue #60.
     const skipped = 0;
 
     try {

--- a/src/modules/email/interfaces/email.interface.ts
+++ b/src/modules/email/interfaces/email.interface.ts
@@ -183,6 +183,34 @@ export interface ScheduleEmailsResult {
 
 // ============== Eligibility Checks ==============
 
+/** Candidato que superó el filtrado de elegibilidad. */
+export interface EligibleEmailUser {
+  userId: string;
+  userEmail: string;
+  displayName?: string;
+  language: string;
+  pdfCount: number;
+  createdAt: Date;
+}
+
+/**
+ * Candidatos descartados durante el filtrado, desglosados por motivo. Sin este
+ * desglose no se puede distinguir "no había candidatos" de "todos ya habían
+ * recibido el email", que es justo lo que hace falta para diagnosticar un
+ * envío que programó menos correos de los esperados.
+ */
+export interface EmailSkipReasons {
+  /** Ya tenía ese tipo de email en la cola. */
+  alreadyReceived: number;
+  /** Su pdfCount quedó fuera del rango pedido. */
+  pdfCountOutOfRange: number;
+}
+
+export interface EligibleEmailUsersResult {
+  users: EligibleEmailUser[];
+  skipped: EmailSkipReasons;
+}
+
 export interface UserEmailEligibility {
   userId: string;
   userEmail: string;


### PR DESCRIPTION
Aborda #60. **Cubre 3 de los 5 métodos**; los otros dos quedan documentados en código y explicados abajo, porque arreglarlos bien exige decisiones que exceden este cambio.

## El arreglo

La causa no era un `skipped++` olvidado en el bucle — el bucle no tiene nada que saltar. El filtrado ocurre dentro de `getUsersEligibleForEmail`, que descartaba candidatos en silencio (`if (hasEmail) continue`) y devolvía solo la lista de elegibles, perdiendo esa información antes de llegar a quien la reporta.

Ahora devuelve `{ users, skipped }` con el desglose por motivo:

```ts
export interface EmailSkipReasons {
  alreadyReceived: number;      // ya tenía ese email en la cola
  pdfCountOutOfRange: number;   // su pdfCount quedó fuera del rango pedido
}
```

Lo consumen `scheduleTutorialEmails`, `scheduleHelpEmails` y `scheduleDay7Emails`. La suma se centraliza en un helper privado `totalSkipped()` para que añadir un motivo nuevo no obligue a revisar cada método — que es exactamente cómo `skipped` acabó en 0.

## Un caso que no es una suma simple: Day 7

`scheduleDay7Emails` hace **dos** consultas complementarias sobre el mismo cohorte: `success_story` pide `minPdfCount: 1` y `miss_you` pide `maxPdfCount: 0`. Cada usuario del cohorte cae por tanto en `pdfCountOutOfRange` en la consulta que no le corresponde.

Sumar el total marcaría como "descartado" a todo el que **sí** recibió email en la otra rama: con 10 usuarios atendidos daría `scheduled: 10, skipped: 10`. Por eso este método suma solo `alreadyReceived`. Hay un test que fija ese comportamiento.

## Lo que queda fuera, y por qué

**`scheduleHighUsageEmails`** — `getUsersWithHighUsage` sí descarta por `hasUserReceivedEmailInPeriod`, pero **antes** de evaluar el criterio de uso alto. Contar ahí incluiría a todos los usuarios free que ya recibieron el email tengan o no uso alto ahora: un número grande y engañoso. Contarlo bien exige mover ese filtro después de la evaluación de uso, lo que haría correr la consulta de conversiones —una por usuario— sobre todos los free. Es un cambio de rendimiento en un cron que no me parece prudente meter de rondón aquí.

**`schedulePowerUserEmails`** — aquí no hay nada que descartar: `getPowerUsersWithPeriod` es un método de reporting (top 10% por uso, paginado, también usado por admin) y **no comprueba si el usuario ya recibió el email**. Poblar `skipped` exige antes decidir la política de cadencia de este envío.

Ambos conservan `skipped = 0` pero ahora con un comentario que explica el motivo y remite al issue, para que no se lea como un descuido.

## Hallazgo colateral (no lo toco aquí)

Al revisar el punto anterior: `createEmailQueue` no deduplica —crea un documento nuevo siempre— y `schedulePowerUserEmails` no comprueba envíos previos. Cada invocación encola de nuevo el email a los mismos power users. Hoy el riesgo es acotado porque solo se dispara desde un endpoint manual (`email.controller.ts:257`), no desde un cron. Lo señalo por si merece issue propio.

## Verificación

- `npm run build` → 0 issues.
- `npm test` → **54 pruebas, 7 suites, en verde** (eran 49; +5 nuevas).
- `npm run lint` → exit 0, sin modificar archivos.

Las pruebas nuevas cubren: descartes por `alreadyReceived`, suma de varios motivos, el caso especial de Day 7, el corto­circuito con el servicio deshabilitado y —el criterio de aceptación del issue— que `scheduled: 0, skipped: 0` y `scheduled: 0, skipped: 12` sean distinguibles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
