### PR TITLE
feat(billing): facturación fiscal — CFDI 4.0 para México y datos fiscales en el PDF de Stripe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,11 @@ GA4_API_SECRET=your_api_secret_here
 RESEND_API_KEY=re_xxxxx
 RESEND_FROM_EMAIL=ZPLPDF <noreply@zplpdf.com>
 RESEND_WEBHOOK_SECRET=whsec_xxxxx
+# Facturama (CFDI 4.0 para clientes mexicanos)
+# Misma cuenta que usa la intranet: el emisor (RFC, régimen y CSD) es el del
+# certificado cargado ahí, no se pasa en el payload.
+FACTURAMA_USERNAME=
+FACTURAMA_PASSWORD=
+FACTURAMA_URL_BASE=https://api.facturama.mx
+# CP del lugar de expedición del emisor.
+FACTURAMA_EXPEDITION_PLACE=97308

--- a/src/common/interfaces/cfdi.interface.ts
+++ b/src/common/interfaces/cfdi.interface.ts
@@ -1,0 +1,46 @@
+import type { CfdiErrorCode } from '../../modules/facturama/facturama.constants.js';
+
+/**
+ * Estado del CFDI tal como lo pinta la UI.
+ *
+ * `not_applicable` y `null` se tratan igual en el frontend, pero se distinguen
+ * en el backend: `not_applicable` es «este cobro no lleva CFDI y ya se evaluó»,
+ * mientras que `null` es «no hay registro».
+ */
+export type CfdiStatus = 'pending' | 'stamped' | 'failed' | 'canceled';
+
+/**
+ * Documento de la colección `cfdis`.
+ *
+ * El docId es el `stripeInvoiceId`, y ahí está la idempotencia: Stripe reintenta
+ * los webhooks, y un CFDI duplicado no se borra, se cancela a mano ante el SAT.
+ * Con el id de la factura como clave del documento, el segundo intento choca
+ * contra el propio Firestore en vez de contra una comprobación de aplicación que
+ * dos webhooks simultáneos podrían pasar a la vez.
+ */
+export interface Cfdi {
+  stripeInvoiceId: string;
+  userId: string;
+  status: CfdiStatus;
+
+  /** Folio fiscal que asigna el SAT. Solo cuando `status: 'stamped'`. */
+  uuid?: string | null;
+  /** Id del comprobante dentro de Facturama, necesario para descargar y cancelar. */
+  facturamaId?: string | null;
+
+  /** Rutas en Cloud Storage. Las URLs firmadas se generan al leer. */
+  pdfPath?: string | null;
+  xmlPath?: string | null;
+
+  /** Total cobrado, en la unidad de la moneda (no centavos). */
+  amount: number;
+  currency: string;
+
+  error?: { code: CfdiErrorCode; message: string } | null;
+  /** Intentos de timbrado, incluidos los reintentos manuales del usuario. */
+  attempts: number;
+
+  stampedAt?: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/common/interfaces/cfdi.interface.ts
+++ b/src/common/interfaces/cfdi.interface.ts
@@ -44,3 +44,18 @@ export interface Cfdi {
   createdAt: Date;
   updatedAt: Date;
 }
+
+/**
+ * Resultado de tomar un CFDI para timbrarlo.
+ *
+ * Lleva los intentos acumulados para que quien lo obtiene no tenga que releer el
+ * documento: en ese momento ya está en `pending`, y un fallo de lectura posterior
+ * lo dejaría clavado ahí, bloqueando cualquier reintento futuro.
+ *
+ * El discriminante es texto y no un booleano porque el proyecto compila con
+ * `strictNullChecks: false`, y sin esa opción TypeScript no estrecha uniones
+ * discriminadas por literales booleanos.
+ */
+export type CfdiClaim =
+  | { outcome: 'granted'; attempts: number }
+  | { outcome: 'blocked'; blockedBy: CfdiStatus };

--- a/src/common/interfaces/tax-profile.interface.ts
+++ b/src/common/interfaces/tax-profile.interface.ts
@@ -1,0 +1,276 @@
+/**
+ * Perfil fiscal del usuario.
+ *
+ * Sostiene dos flujos distintos según el país:
+ *
+ * - **México (`mx`)** — datos del receptor de un CFDI 4.0. Alimentan el timbrado
+ *   automático tras cada cobro.
+ * - **Resto del mundo (`international`)** — datos que se propagan al customer de
+ *   Stripe para que salgan impresos en el PDF que Stripe ya genera. No hay
+ *   timbrado ni PAC involucrado.
+ *
+ * El `type` lo decide el backend a partir de `user.country`, nunca el cliente:
+ * si el frontend pudiera elegirlo, un usuario mexicano podría saltarse el CFDI
+ * declarándose internacional.
+ */
+
+export type TaxProfileType = 'mx' | 'international';
+
+/** Persona física (RFC de 13) o moral (RFC de 12), según el catálogo del SAT. */
+export type SatPersonType = 'natural' | 'moral';
+
+export interface TaxProfileAddress {
+  line1: string;
+  line2?: string | null;
+  city: string;
+  state?: string | null;
+  postalCode: string;
+  /** ISO 3166-1 alpha-2 */
+  country: string;
+}
+
+/**
+ * Documento de la colección `tax_profiles` (docId = userId).
+ *
+ * Vive aparte de `users` porque el doc de usuario se lee en casi cada request y
+ * el perfil fiscal solo hace falta en billing y al timbrar.
+ */
+export interface TaxProfile {
+  userId: string;
+  type: TaxProfileType;
+  /** País que dio origen al `type`. Se guarda para detectar cambios posteriores. */
+  country: string;
+
+  // ---- México ----
+  /** 12 caracteres (moral) o 13 (física). Siempre en mayúsculas. */
+  rfc?: string;
+  /** Clave de c_RegimenFiscal. */
+  taxRegime?: string;
+  /** Clave de c_UsoCFDI. */
+  cfdiUse?: string;
+
+  // ---- Comunes ----
+  /** Razón social SIN régimen de capital (lo exige CFDI 4.0). */
+  legalName?: string;
+  /** Domicilio fiscal del receptor. En MX son los 5 dígitos del CP. */
+  postalCode?: string;
+  billingEmail?: string;
+
+  // ---- Internacional ----
+  /** Tipo de tax ID de Stripe: 'eu_vat', 'br_cnpj', 'gb_vat', ... */
+  taxIdType?: string | null;
+  taxIdValue?: string | null;
+  address?: TaxProfileAddress | null;
+
+  // ---- Trazabilidad ----
+  /** Id del cliente en Facturama, una vez dado de alta. Solo perfiles MX. */
+  facturamaClientId?: string;
+  /** Id del tax ID creado en Stripe, para poder reemplazarlo al cambiar. */
+  stripeTaxIdId?: string | null;
+  isComplete: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * RFC según el SAT: 3 letras (moral) o 4 (física), fecha AAMMDD y homoclave.
+ * La Ñ y el & son válidos en la raíz.
+ */
+export const RFC_REGEX = /^[A-ZÑ&]{3,4}[0-9]{6}[A-Z0-9]{3}$/;
+
+/** RFC genérico para operaciones con público en general. No factura a un cliente. */
+export const RFC_PUBLICO_GENERAL = 'XAXX010101000';
+
+/** RFC genérico para residentes en el extranjero. */
+export const RFC_EXTRANJERO = 'XEXX010101000';
+
+/**
+ * c_RegimenFiscal, con la aplicabilidad por tipo de persona que publica el SAT.
+ *
+ * Se lleva embebido en vez de consultarlo al PAC en cada `PUT`: es un catálogo
+ * que cambia como mucho una vez al año y no justifica una llamada de red —ni un
+ * fallo de validación cuando Facturama esté caído— en la ruta de guardado.
+ */
+export const SAT_FISCAL_REGIMES: Record<
+  string,
+  { name: string; natural: boolean; moral: boolean }
+> = {
+  '601': {
+    name: 'General de Ley Personas Morales',
+    natural: false,
+    moral: true,
+  },
+  '603': {
+    name: 'Personas Morales con Fines no Lucrativos',
+    natural: false,
+    moral: true,
+  },
+  '605': {
+    name: 'Sueldos y Salarios e Ingresos Asimilados a Salarios',
+    natural: true,
+    moral: false,
+  },
+  '606': { name: 'Arrendamiento', natural: true, moral: false },
+  '607': {
+    name: 'Régimen de Enajenación o Adquisición de Bienes',
+    natural: true,
+    moral: false,
+  },
+  '608': { name: 'Demás ingresos', natural: true, moral: false },
+  '610': {
+    name: 'Residentes en el Extranjero sin Establecimiento Permanente en México',
+    natural: true,
+    moral: true,
+  },
+  '611': {
+    name: 'Ingresos por Dividendos (socios y accionistas)',
+    natural: true,
+    moral: false,
+  },
+  '612': {
+    name: 'Personas Físicas con Actividades Empresariales y Profesionales',
+    natural: true,
+    moral: false,
+  },
+  '614': { name: 'Ingresos por intereses', natural: true, moral: false },
+  '615': {
+    name: 'Régimen de los ingresos por obtención de premios',
+    natural: true,
+    moral: false,
+  },
+  '616': { name: 'Sin obligaciones fiscales', natural: true, moral: false },
+  '620': {
+    name: 'Sociedades Cooperativas de Producción que optan por diferir sus ingresos',
+    natural: false,
+    moral: true,
+  },
+  '621': { name: 'Incorporación Fiscal', natural: true, moral: false },
+  '622': {
+    name: 'Actividades Agrícolas, Ganaderas, Silvícolas y Pesqueras',
+    natural: false,
+    moral: true,
+  },
+  '623': {
+    name: 'Opcional para Grupos de Sociedades',
+    natural: false,
+    moral: true,
+  },
+  '624': { name: 'Coordinados', natural: false, moral: true },
+  '625': {
+    name: 'Régimen de las Actividades Empresariales con ingresos a través de Plataformas Tecnológicas',
+    natural: true,
+    moral: false,
+  },
+  '626': {
+    name: 'Régimen Simplificado de Confianza',
+    natural: true,
+    moral: true,
+  },
+};
+
+/**
+ * c_UsoCFDI, con la aplicabilidad por tipo de persona.
+ *
+ * Los deducibles personales (D01–D10) y la nómina (CN01) solo los puede usar una
+ * persona física; el resto sirve a ambas.
+ */
+export const SAT_CFDI_USES: Record<
+  string,
+  { name: string; natural: boolean; moral: boolean }
+> = {
+  G01: { name: 'Adquisición de mercancías', natural: true, moral: true },
+  G02: {
+    name: 'Devoluciones, descuentos o bonificaciones',
+    natural: true,
+    moral: true,
+  },
+  G03: { name: 'Gastos en general', natural: true, moral: true },
+  I01: { name: 'Construcciones', natural: true, moral: true },
+  I02: {
+    name: 'Mobiliario y equipo de oficina por inversiones',
+    natural: true,
+    moral: true,
+  },
+  I03: { name: 'Equipo de transporte', natural: true, moral: true },
+  I04: { name: 'Equipo de cómputo y accesorios', natural: true, moral: true },
+  I05: {
+    name: 'Dados, troqueles, moldes, matrices y herramental',
+    natural: true,
+    moral: true,
+  },
+  I06: { name: 'Comunicaciones telefónicas', natural: true, moral: true },
+  I07: { name: 'Comunicaciones satelitales', natural: true, moral: true },
+  I08: { name: 'Otra maquinaria y equipo', natural: true, moral: true },
+  D01: {
+    name: 'Honorarios médicos, dentales y gastos hospitalarios',
+    natural: true,
+    moral: false,
+  },
+  D02: {
+    name: 'Gastos médicos por incapacidad o discapacidad',
+    natural: true,
+    moral: false,
+  },
+  D03: { name: 'Gastos funerales', natural: true, moral: false },
+  D04: { name: 'Donativos', natural: true, moral: false },
+  D05: {
+    name: 'Intereses reales efectivamente pagados por créditos hipotecarios',
+    natural: true,
+    moral: false,
+  },
+  D06: { name: 'Aportaciones voluntarias al SAR', natural: true, moral: false },
+  D07: {
+    name: 'Primas por seguros de gastos médicos',
+    natural: true,
+    moral: false,
+  },
+  D08: {
+    name: 'Gastos de transportación escolar obligatoria',
+    natural: true,
+    moral: false,
+  },
+  D09: {
+    name: 'Depósitos en cuentas para el ahorro, primas que tengan como base planes de pensiones',
+    natural: true,
+    moral: false,
+  },
+  D10: {
+    name: 'Pagos por servicios educativos (colegiaturas)',
+    natural: true,
+    moral: false,
+  },
+  S01: { name: 'Sin efectos fiscales', natural: true, moral: true },
+  CP01: { name: 'Pagos', natural: true, moral: true },
+  CN01: { name: 'Nómina', natural: true, moral: false },
+};
+
+/**
+ * Deriva el tipo de persona de la longitud del RFC: 12 es moral, 13 es física.
+ * Devuelve `null` si el RFC no tiene un largo válido.
+ */
+export function getSatPersonType(rfc: string): SatPersonType | null {
+  const normalized = rfc?.trim().toUpperCase() ?? '';
+  if (normalized.length === 12) return 'moral';
+  if (normalized.length === 13) return 'natural';
+  return null;
+}
+
+/** ¿El régimen aplica al tipo de persona que denota el RFC? */
+export function isRegimeValidForPerson(
+  taxRegime: string,
+  person: SatPersonType,
+): boolean {
+  const regime = SAT_FISCAL_REGIMES[taxRegime];
+  if (!regime) return false;
+  return person === 'moral' ? regime.moral : regime.natural;
+}
+
+/** ¿El uso de CFDI aplica al tipo de persona que denota el RFC? */
+export function isCfdiUseValidForPerson(
+  cfdiUse: string,
+  person: SatPersonType,
+): boolean {
+  const use = SAT_CFDI_USES[cfdiUse];
+  if (!use) return false;
+  return person === 'moral' ? use.moral : use.natural;
+}

--- a/src/modules/billing/billing.controller.ts
+++ b/src/modules/billing/billing.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Get, Put, Query, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Put,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
@@ -11,6 +20,7 @@ import { FirebaseAuthGuard } from '../../common/guards/firebase-auth.guard.js';
 import { CurrentUser } from '../../common/decorators/current-user.decorator.js';
 import type { FirebaseUser } from '../../common/decorators/current-user.decorator.js';
 import {
+  CfdiRetryResponseDto,
   InvoicesResponseDto,
   PaymentMethodsResponseDto,
   SubscriptionResponseDto,
@@ -112,5 +122,39 @@ export class BillingController {
     @Body() dto: UpdateTaxProfileDto,
   ): Promise<TaxProfileResponseDto> {
     return this.billingService.updateTaxProfile(user.uid, dto);
+  }
+
+  @Post('invoices/:invoiceId/cfdi/retry')
+  @ApiOperation({
+    summary: 'Retry stamping a failed CFDI',
+    description:
+      'Salida del usuario cuando corrige su RFC o su código postal. Solo aplica a un CFDI en `failed`: reintentar uno ya timbrado emitiría un duplicado que hay que cancelar a mano ante el SAT.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'CFDI stamped',
+    type: CfdiRetryResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description:
+      'El CFDI no está en `failed`, o el perfil fiscal está incompleto',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'La factura no pertenece al usuario',
+  })
+  @ApiResponse({ status: 404, description: 'La factura no existe' })
+  @ApiResponse({
+    status: 422,
+    description:
+      'El PAC volvió a rechazar el timbrado. El body incluye `data.cfdiError.code`, el mismo código estable del fallo original.',
+  })
+  async retryCfdi(
+    @CurrentUser() user: FirebaseUser,
+    @Param('invoiceId') invoiceId: string,
+  ): Promise<CfdiRetryResponseDto> {
+    const cfdi = await this.billingService.retryCfdi(user.uid, invoiceId);
+    return { success: true, cfdi };
   }
 }

--- a/src/modules/billing/billing.controller.ts
+++ b/src/modules/billing/billing.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Put, Query, UseGuards } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
@@ -15,6 +15,10 @@ import {
   PaymentMethodsResponseDto,
   SubscriptionResponseDto,
 } from './dto/billing.dto.js';
+import {
+  TaxProfileResponseDto,
+  UpdateTaxProfileDto,
+} from './dto/tax-profile.dto.js';
 
 @ApiTags('billing')
 @ApiBearerAuth()
@@ -68,5 +72,45 @@ export class BillingController {
     @CurrentUser() user: FirebaseUser,
   ): Promise<SubscriptionResponseDto | null> {
     return this.billingService.getSubscription(user.uid);
+  }
+
+  @Get('tax-profile')
+  @ApiOperation({
+    summary: 'Get the tax profile of the authenticated user',
+    description:
+      'Devuelve `isComplete: false` en lugar de 404 cuando el usuario todavía no ha cargado sus datos. El campo `type` lo deriva el backend de `user.country`.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Tax profile (may be empty)',
+    type: TaxProfileResponseDto,
+  })
+  async getTaxProfile(
+    @CurrentUser() user: FirebaseUser,
+  ): Promise<TaxProfileResponseDto> {
+    return this.billingService.getTaxProfile(user.uid);
+  }
+
+  @Put('tax-profile')
+  @ApiOperation({
+    summary: 'Create or update the tax profile',
+    description:
+      'Persiste el perfil y lo propaga al customer de Stripe (name, address y tax ID) para que el PDF que genera Stripe salga con los datos fiscales del cliente.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Saved tax profile',
+    type: TaxProfileResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Validación fallida. El detalle por campo llega en `data.errors` como códigos estables (p. ej. `rfc_invalid_format`) que el frontend traduce.',
+  })
+  async updateTaxProfile(
+    @CurrentUser() user: FirebaseUser,
+    @Body() dto: UpdateTaxProfileDto,
+  ): Promise<TaxProfileResponseDto> {
+    return this.billingService.updateTaxProfile(user.uid, dto);
   }
 }

--- a/src/modules/billing/billing.module.ts
+++ b/src/modules/billing/billing.module.ts
@@ -1,12 +1,15 @@
 import { Module } from '@nestjs/common';
 import { BillingController } from './billing.controller.js';
 import { BillingService } from './billing.service.js';
+import { CfdiService } from './cfdi.service.js';
 import { CacheModule } from '../cache/cache.module.js';
+import { FacturamaModule } from '../facturama/facturama.module.js';
+import { StorageModule } from '../storage/storage.module.js';
 
 @Module({
-  imports: [CacheModule],
+  imports: [CacheModule, FacturamaModule, StorageModule],
   controllers: [BillingController],
-  providers: [BillingService],
-  exports: [BillingService],
+  providers: [BillingService, CfdiService],
+  exports: [BillingService, CfdiService],
 })
 export class BillingModule {}

--- a/src/modules/billing/billing.service.spec.ts
+++ b/src/modules/billing/billing.service.spec.ts
@@ -463,6 +463,12 @@ describe('BillingService — perfil fiscal', () => {
       const deleteTaxId = jest.fn().mockResolvedValue({});
       const createTaxId = jest.fn().mockResolvedValue({ id: 'txi_nuevo' });
       const { service } = buildService({
+        profile: {
+          type: 'mx',
+          rfc: 'XYZ010101AB1',
+          isComplete: true,
+          stripeTaxIdId: 'txi_viejo',
+        },
         listTaxIds: jest.fn().mockResolvedValue({
           data: [{ id: 'txi_viejo', type: 'mx_rfc', value: 'XYZ010101AB1' }],
         }),
@@ -476,6 +482,86 @@ describe('BillingService — perfil fiscal', () => {
       // PDF sale con dos.
       expect(deleteTaxId).toHaveBeenCalledWith('cus_123', 'txi_viejo');
       expect(createTaxId).toHaveBeenCalled();
+    });
+
+    it('no borra tax IDs que no gestiona este perfil', async () => {
+      const deleteTaxId = jest.fn().mockResolvedValue({});
+      const { service } = buildService({
+        profile: {
+          type: 'mx',
+          rfc: 'XYZ010101AB1',
+          isComplete: true,
+          stripeTaxIdId: 'txi_gestionado',
+        },
+        listTaxIds: jest.fn().mockResolvedValue({
+          data: [
+            { id: 'txi_gestionado', type: 'mx_rfc', value: 'XYZ010101AB1' },
+            // Dado de alta a mano desde el dashboard, u otra jurisdicción.
+            { id: 'txi_ajeno', type: 'eu_vat', value: 'ESB12345678' },
+          ],
+        }),
+        deleteTaxId,
+      });
+
+      await service.updateTaxProfile('uid-1', mxDto());
+
+      expect(deleteTaxId).toHaveBeenCalledWith('cus_123', 'txi_gestionado');
+      expect(deleteTaxId).not.toHaveBeenCalledWith('cus_123', 'txi_ajeno');
+    });
+
+    it('adopta un tax ID que ya coincide en vez de duplicarlo', async () => {
+      const createTaxId = jest.fn();
+      const deleteTaxId = jest.fn();
+      const { service, saved } = buildService({
+        listTaxIds: jest.fn().mockResolvedValue({
+          data: [{ id: 'txi_del_portal', type: 'mx_rfc', value: RFC_MORAL }],
+        }),
+        createTaxId,
+        deleteTaxId,
+      });
+
+      // Puede haberlo creado el propio usuario desde el portal de Stripe.
+      await service.updateTaxProfile('uid-1', mxDto());
+
+      expect(createTaxId).not.toHaveBeenCalled();
+      expect(deleteTaxId).not.toHaveBeenCalled();
+      expect(saved.some((s) => s.stripeTaxIdId === 'txi_del_portal')).toBe(
+        true,
+      );
+    });
+
+    it('borra el tax ID en Stripe cuando el usuario lo deja vacío', async () => {
+      const deleteTaxId = jest.fn().mockResolvedValue({});
+      const { service, saved } = buildService({
+        user: { id: 'uid-1', country: 'ES', stripeCustomerId: 'cus_123' },
+        profile: {
+          type: 'international',
+          isComplete: true,
+          taxIdType: 'eu_vat',
+          taxIdValue: 'ESB12345678',
+          stripeTaxIdId: 'txi_viejo',
+        },
+        deleteTaxId,
+      });
+
+      await service.updateTaxProfile('uid-1', {
+        type: 'international',
+        legalName: 'Acme S.L.',
+        billingEmail: 'billing@acme.com',
+        taxIdType: null,
+        taxIdValue: null,
+        address: {
+          line1: 'Calle Mayor 1',
+          city: 'Madrid',
+          postalCode: '28001',
+          country: 'ES',
+        },
+      } as UpdateTaxProfileDto);
+
+      // Si no se borra, las facturas siguientes seguirían imprimiendo un dato
+      // que el usuario ya quitó de su perfil.
+      expect(deleteTaxId).toHaveBeenCalledWith('cus_123', 'txi_viejo');
+      expect(saved.some((s) => s.stripeTaxIdId === null)).toBe(true);
     });
 
     it('guarda el perfil aunque Stripe falle', async () => {
@@ -530,6 +616,7 @@ describe('BillingService — perfil fiscal', () => {
       cfdi?: Record<string, unknown> | null;
       retry?: jest.Mock;
       profile?: Record<string, unknown> | null;
+      claim?: jest.Mock;
     }) {
       const retrieve = overrides.retrieveError
         ? jest.fn().mockRejectedValue(overrides.retrieveError)
@@ -554,6 +641,17 @@ describe('BillingService — perfil fiscal', () => {
           getCfdiByInvoiceId: jest
             .fn()
             .mockResolvedValue(overrides.cfdi ?? null),
+          // El candado devuelve null cuando concede el reintento, o el estado
+          // que lo impide.
+          claimCfdiForRetry:
+            overrides.claim ??
+            jest
+              .fn()
+              .mockResolvedValue(
+                overrides.cfdi && overrides.cfdi.status !== 'failed'
+                  ? { blockedBy: overrides.cfdi.status }
+                  : null,
+              ),
           getTaxProfile: jest
             .fn()
             .mockResolvedValue(
@@ -684,6 +782,47 @@ describe('BillingService — perfil fiscal', () => {
         },
       );
     });
+
+    it('toma el CFDI de forma atómica antes de timbrar', async () => {
+      const claim = jest.fn().mockResolvedValue(null);
+      const service = buildRetryService({ cfdi: { status: 'failed' }, claim });
+
+      await service.retryCfdi('uid-1', 'in_123');
+
+      // Comprobar el estado con una lectura previa no sería candado: un doble
+      // clic bastaría para que dos peticiones vieran `failed` y ambas timbraran.
+      expect(claim).toHaveBeenCalledWith(
+        'in_123',
+        expect.objectContaining({ userId: 'uid-1' }),
+      );
+    });
+
+    it('rechaza el reintento que pierde la carrera por el candado', async () => {
+      // El ganador ya lo dejó en `pending`; este llega tarde.
+      const service = buildRetryService({
+        cfdi: { status: 'failed' },
+        claim: jest.fn().mockResolvedValue({ blockedBy: 'pending' }),
+      });
+
+      await expect(service.retryCfdi('uid-1', 'in_123')).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('no llega al candado si la factura es ajena', async () => {
+      const claim = jest.fn();
+      const service = buildRetryService({
+        invoice: { id: 'in_123', customer: 'cus_de_otro' },
+        claim,
+      });
+
+      await expect(service.retryCfdi('uid-1', 'in_123')).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+      // Tomar el CFDI de otro lo dejaría en `pending` y bloquearía su reintento
+      // legítimo.
+      expect(claim).not.toHaveBeenCalled();
+    });
   });
 
   /**
@@ -734,6 +873,34 @@ describe('BillingService — perfil fiscal', () => {
 
       // Es como el frontend sabe que no debe pintar la columna.
       expect(invoices.every((invoice) => invoice.cfdi === null)).toBe(true);
+    });
+
+    it('conserva los CFDI emitidos aunque el usuario cambie de país', async () => {
+      const service = buildInvoicesService({
+        country: 'ES',
+        cfdis: new Map([
+          [
+            'in_1',
+            {
+              status: 'stamped',
+              uuid: 'UUID-1',
+              pdfPath: 'cfdis/uid-1/in_1.pdf',
+            },
+          ],
+        ]),
+      });
+
+      const { invoices } = await service.getInvoices('uid-1');
+
+      // Un comprobante fiscal se conserva cinco años y esta es la única vía de
+      // descarga: mudarse de país no puede dejar al usuario sin sus facturas.
+      expect(invoices[0].cfdi).toMatchObject({
+        status: 'stamped',
+        uuid: 'UUID-1',
+        pdfUrl: 'https://signed.example/file',
+      });
+      // Las facturas sin CFDI sí siguen el país actual.
+      expect(invoices[1].cfdi).toBeNull();
     });
 
     it('marca not_applicable una factura mexicana sin registro', async () => {

--- a/src/modules/billing/billing.service.spec.ts
+++ b/src/modules/billing/billing.service.spec.ts
@@ -1,9 +1,16 @@
 // Evitar la conexión real a Stripe al cargar el módulo.
 jest.mock('stripe', () => jest.fn());
 
-import { BadRequestException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
 import { BillingService } from './billing.service.js';
 import type { UpdateTaxProfileDto } from './dto/tax-profile.dto.js';
+import { CfdiErrorCodes } from '../facturama/facturama.constants.js';
+import { FacturamaError } from '../facturama/interfaces/facturama.interface.js';
 
 /**
  * El perfil fiscal es la entrada de datos que después se timbra ante el SAT.
@@ -507,6 +514,266 @@ describe('BillingService — perfil fiscal', () => {
       await service.syncTaxProfileToStripe('uid-1');
 
       expect(customersUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * El reintento toca un documento fiscal ya emitido y por eso vigila dos
+   * cosas: que la factura sea de quien la pide, y que no se timbre lo que ya
+   * está timbrado —un CFDI duplicado solo se deshace cancelándolo ante el SAT.
+   */
+  describe('retryCfdi', () => {
+    function buildRetryService(overrides: {
+      user?: Record<string, unknown> | null;
+      invoice?: Record<string, unknown>;
+      retrieveError?: unknown;
+      cfdi?: Record<string, unknown> | null;
+      retry?: jest.Mock;
+    }) {
+      const retrieve = overrides.retrieveError
+        ? jest.fn().mockRejectedValue(overrides.retrieveError)
+        : jest
+            .fn()
+            .mockResolvedValue(
+              overrides.invoice ?? { id: 'in_123', customer: 'cus_123' },
+            );
+
+      const service = Object.create(BillingService.prototype) as BillingService;
+      Object.assign(service, {
+        logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+        stripe: { invoices: { retrieve } },
+        firestoreService: {
+          getUserById: jest
+            .fn()
+            .mockResolvedValue(
+              overrides.user === undefined
+                ? { id: 'uid-1', country: 'MX', stripeCustomerId: 'cus_123' }
+                : overrides.user,
+            ),
+          getCfdiByInvoiceId: jest
+            .fn()
+            .mockResolvedValue(overrides.cfdi ?? null),
+        },
+        storageService: {
+          generateSignedUrlForPath: jest
+            .fn()
+            .mockResolvedValue('https://signed.example/file'),
+        },
+        cfdiService: {
+          retry:
+            overrides.retry ??
+            jest.fn().mockResolvedValue({
+              status: 'stamped',
+              uuid: 'UUID-1',
+              stampedAt: new Date('2026-08-04T12:00:00.000Z'),
+              pdfPath: 'cfdis/uid-1/in_123.pdf',
+              xmlPath: 'cfdis/uid-1/in_123.xml',
+            }),
+        },
+      });
+
+      return service;
+    }
+
+    it('403 si la factura es de otro cliente', async () => {
+      const service = buildRetryService({
+        invoice: { id: 'in_123', customer: 'cus_de_otro' },
+      });
+
+      await expect(service.retryCfdi('uid-1', 'in_123')).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+    });
+
+    it('403 si el usuario no tiene customer en Stripe', async () => {
+      const service = buildRetryService({
+        user: { id: 'uid-1', country: 'MX' },
+      });
+
+      await expect(service.retryCfdi('uid-1', 'in_123')).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+    });
+
+    it('404 si la factura no existe en Stripe', async () => {
+      const service = buildRetryService({
+        retrieveError: { code: 'resource_missing' },
+      });
+
+      await expect(service.retryCfdi('uid-1', 'in_123')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('400 si el CFDI ya está timbrado', async () => {
+      const service = buildRetryService({
+        cfdi: { status: 'stamped', uuid: 'UUID-1' },
+      });
+
+      // Reintentarlo emitiría un duplicado.
+      await expect(service.retryCfdi('uid-1', 'in_123')).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('422 con el mismo código estable cuando el PAC vuelve a rechazar', async () => {
+      const service = buildRetryService({
+        cfdi: { status: 'failed' },
+        retry: jest
+          .fn()
+          .mockRejectedValue(
+            new FacturamaError(CfdiErrorCodes.RFC_NOT_FOUND, 'RFC no inscrito'),
+          ),
+      });
+
+      try {
+        await service.retryCfdi('uid-1', 'in_123');
+        throw new Error('Se esperaba un UnprocessableEntityException');
+      } catch (error) {
+        expect(error).toBeInstanceOf(UnprocessableEntityException);
+        const body = (error as UnprocessableEntityException).getResponse() as {
+          cfdiError: { code: string };
+        };
+        // El reintento fallido se explica con el mismo diccionario que el fallo
+        // original.
+        expect(body.cfdiError.code).toBe(CfdiErrorCodes.RFC_NOT_FOUND);
+      }
+    });
+
+    it('devuelve el CFDI con URLs firmadas al timbrar bien', async () => {
+      const service = buildRetryService({ cfdi: { status: 'failed' } });
+
+      const result = await service.retryCfdi('uid-1', 'in_123');
+
+      expect(result.status).toBe('stamped');
+      expect(result.uuid).toBe('UUID-1');
+      expect(result.pdfUrl).toBe('https://signed.example/file');
+      expect(result.xmlUrl).toBe('https://signed.example/file');
+    });
+
+    it('permite reintentar cuando no hay registro previo de CFDI', async () => {
+      const service = buildRetryService({ cfdi: null });
+
+      // Una factura de antes de que el usuario cargara su perfil fiscal no tiene
+      // documento, y debe poder facturarse.
+      await expect(service.retryCfdi('uid-1', 'in_123')).resolves.toMatchObject(
+        {
+          status: 'stamped',
+        },
+      );
+    });
+  });
+
+  /**
+   * El listado de facturas es la pantalla donde el usuario descubre si tiene
+   * factura o no, así que el estado que devuelve tiene que distinguir «no te
+   * toca» de «falló».
+   */
+  describe('getInvoices — bloque cfdi', () => {
+    function buildInvoicesService(overrides: {
+      country?: string;
+      cfdis?: Map<string, unknown>;
+    }) {
+      const service = Object.create(BillingService.prototype) as BillingService;
+      Object.assign(service, {
+        logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+        stripe: {
+          invoices: {
+            list: jest.fn().mockResolvedValue({
+              data: [{ id: 'in_1' }, { id: 'in_2' }],
+              has_more: false,
+            }),
+          },
+        },
+        firestoreService: {
+          getUserById: jest.fn().mockResolvedValue({
+            id: 'uid-1',
+            country: overrides.country ?? 'MX',
+            stripeCustomerId: 'cus_123',
+          }),
+          getCfdisByInvoiceIds: jest
+            .fn()
+            .mockResolvedValue(overrides.cfdis ?? new Map()),
+        },
+        storageService: {
+          generateSignedUrlForPath: jest
+            .fn()
+            .mockResolvedValue('https://signed.example/file'),
+        },
+      });
+
+      return service;
+    }
+
+    it('devuelve cfdi null para un usuario no mexicano', async () => {
+      const service = buildInvoicesService({ country: 'ES' });
+
+      const { invoices } = await service.getInvoices('uid-1');
+
+      // Es como el frontend sabe que no debe pintar la columna.
+      expect(invoices.every((invoice) => invoice.cfdi === null)).toBe(true);
+    });
+
+    it('marca not_applicable una factura mexicana sin registro', async () => {
+      const service = buildInvoicesService({ country: 'MX' });
+
+      const { invoices } = await service.getInvoices('uid-1');
+
+      // Típicamente una factura anterior a que cargara su perfil fiscal.
+      expect(invoices[0].cfdi.status).toBe('not_applicable');
+      expect(invoices[0].cfdi.uuid).toBeNull();
+    });
+
+    it('expone el estado real y las descargas de un CFDI timbrado', async () => {
+      const service = buildInvoicesService({
+        country: 'MX',
+        cfdis: new Map([
+          [
+            'in_1',
+            {
+              status: 'stamped',
+              uuid: 'UUID-1',
+              stampedAt: new Date('2026-08-04T12:00:00.000Z'),
+              pdfPath: 'cfdis/uid-1/in_1.pdf',
+              xmlPath: 'cfdis/uid-1/in_1.xml',
+            },
+          ],
+        ]),
+      });
+
+      const { invoices } = await service.getInvoices('uid-1');
+
+      expect(invoices[0].cfdi).toMatchObject({
+        status: 'stamped',
+        uuid: 'UUID-1',
+        stampedAt: '2026-08-04T12:00:00.000Z',
+        pdfUrl: 'https://signed.example/file',
+      });
+      // La segunda factura no tiene CFDI y no debe heredar el de la primera.
+      expect(invoices[1].cfdi.status).toBe('not_applicable');
+    });
+
+    it('expone el código de error de un CFDI fallido', async () => {
+      const service = buildInvoicesService({
+        country: 'MX',
+        cfdis: new Map([
+          [
+            'in_1',
+            {
+              status: 'failed',
+              error: { code: 'rfc_not_found', message: 'RFC no inscrito' },
+            },
+          ],
+        ]),
+      });
+
+      const { invoices } = await service.getInvoices('uid-1');
+
+      expect(invoices[0].cfdi).toMatchObject({
+        status: 'failed',
+        error: { code: 'rfc_not_found' },
+        pdfUrl: null,
+      });
     });
   });
 });

--- a/src/modules/billing/billing.service.spec.ts
+++ b/src/modules/billing/billing.service.spec.ts
@@ -529,6 +529,7 @@ describe('BillingService — perfil fiscal', () => {
       retrieveError?: unknown;
       cfdi?: Record<string, unknown> | null;
       retry?: jest.Mock;
+      profile?: Record<string, unknown> | null;
     }) {
       const retrieve = overrides.retrieveError
         ? jest.fn().mockRejectedValue(overrides.retrieveError)
@@ -553,6 +554,13 @@ describe('BillingService — perfil fiscal', () => {
           getCfdiByInvoiceId: jest
             .fn()
             .mockResolvedValue(overrides.cfdi ?? null),
+          getTaxProfile: jest
+            .fn()
+            .mockResolvedValue(
+              overrides.profile === undefined
+                ? { type: 'mx', isComplete: true }
+                : overrides.profile,
+            ),
         },
         storageService: {
           generateSignedUrlForPath: jest
@@ -611,6 +619,20 @@ describe('BillingService — perfil fiscal', () => {
       });
 
       // Reintentarlo emitiría un duplicado.
+      await expect(service.retryCfdi('uid-1', 'in_123')).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('400, no 422, si el perfil fiscal está incompleto', async () => {
+      const service = buildRetryService({
+        cfdi: { status: 'failed' },
+        profile: null,
+      });
+
+      // Es una precondición que el usuario no ha cumplido, no un rechazo del
+      // PAC: un 422 le diría que su RFC está mal cuando lo que falta es
+      // cargarlo.
       await expect(service.retryCfdi('uid-1', 'in_123')).rejects.toBeInstanceOf(
         BadRequestException,
       );

--- a/src/modules/billing/billing.service.spec.ts
+++ b/src/modules/billing/billing.service.spec.ts
@@ -649,8 +649,8 @@ describe('BillingService — perfil fiscal', () => {
               .fn()
               .mockResolvedValue(
                 overrides.cfdi && overrides.cfdi.status !== 'failed'
-                  ? { blockedBy: overrides.cfdi.status }
-                  : null,
+                  ? { outcome: 'blocked', blockedBy: overrides.cfdi.status }
+                  : { outcome: 'granted', attempts: 0 },
               ),
           getTaxProfile: jest
             .fn()
@@ -784,7 +784,9 @@ describe('BillingService — perfil fiscal', () => {
     });
 
     it('toma el CFDI de forma atómica antes de timbrar', async () => {
-      const claim = jest.fn().mockResolvedValue(null);
+      const claim = jest
+        .fn()
+        .mockResolvedValue({ outcome: 'granted', attempts: 0 });
       const service = buildRetryService({ cfdi: { status: 'failed' }, claim });
 
       await service.retryCfdi('uid-1', 'in_123');
@@ -801,7 +803,9 @@ describe('BillingService — perfil fiscal', () => {
       // El ganador ya lo dejó en `pending`; este llega tarde.
       const service = buildRetryService({
         cfdi: { status: 'failed' },
-        claim: jest.fn().mockResolvedValue({ blockedBy: 'pending' }),
+        claim: jest
+          .fn()
+          .mockResolvedValue({ outcome: 'blocked', blockedBy: 'pending' }),
       });
 
       await expect(service.retryCfdi('uid-1', 'in_123')).rejects.toBeInstanceOf(

--- a/src/modules/billing/billing.service.spec.ts
+++ b/src/modules/billing/billing.service.spec.ts
@@ -1,0 +1,512 @@
+// Evitar la conexión real a Stripe al cargar el módulo.
+jest.mock('stripe', () => jest.fn());
+
+import { BadRequestException } from '@nestjs/common';
+import { BillingService } from './billing.service.js';
+import type { UpdateTaxProfileDto } from './dto/tax-profile.dto.js';
+
+/**
+ * El perfil fiscal es la entrada de datos que después se timbra ante el SAT.
+ * Un régimen incompatible con el tipo de persona, o un uso de CFDI que solo
+ * aplica a personas físicas, no fallan al guardar: fallan un mes más tarde, al
+ * emitir el CFDI, cuando el cobro ya se hizo y el plazo fiscal corre.
+ *
+ * Por eso la validación es del backend aunque el frontend ya filtre los
+ * catálogos: el catálogo del cliente es una ayuda de UX, no una garantía.
+ */
+describe('BillingService — perfil fiscal', () => {
+  const RFC_MORAL = 'ABC010101AB1'; // 12 caracteres
+  const RFC_FISICA = 'ABCD010101AB1'; // 13 caracteres
+
+  /**
+   * El constructor de BillingService abre la conexión con Stripe, que estos
+   * tests no ejercitan. Se instancia por prototipo y se inyectan solo las
+   * dependencias que toca cada método.
+   */
+  function buildService(overrides: {
+    user?: Record<string, unknown> | null;
+    profile?: Record<string, unknown> | null;
+    customersUpdate?: jest.Mock;
+    listTaxIds?: jest.Mock;
+    createTaxId?: jest.Mock;
+    deleteTaxId?: jest.Mock;
+    withoutStripe?: boolean;
+  }) {
+    const saved: Record<string, unknown>[] = [];
+    let storedProfile = overrides.profile ?? null;
+
+    const firestoreService = {
+      getUserById: jest
+        .fn()
+        .mockResolvedValue(
+          overrides.user === undefined
+            ? { id: 'uid-1', country: 'MX', stripeCustomerId: 'cus_123' }
+            : overrides.user,
+        ),
+      getTaxProfile: jest.fn().mockImplementation(() => storedProfile),
+      saveTaxProfile: jest
+        .fn()
+        .mockImplementation(
+          (_userId: string, data: Record<string, unknown>) => {
+            saved.push(data);
+            storedProfile = {
+              ...(storedProfile ?? {}),
+              ...data,
+              updatedAt: new Date('2026-08-04T12:00:00.000Z'),
+            };
+            return Promise.resolve();
+          },
+        ),
+    };
+
+    const stripe = overrides.withoutStripe
+      ? undefined
+      : {
+          customers: {
+            update:
+              overrides.customersUpdate ?? jest.fn().mockResolvedValue({}),
+            listTaxIds:
+              overrides.listTaxIds ?? jest.fn().mockResolvedValue({ data: [] }),
+            createTaxId:
+              overrides.createTaxId ??
+              jest.fn().mockResolvedValue({ id: 'txi_123' }),
+            deleteTaxId:
+              overrides.deleteTaxId ?? jest.fn().mockResolvedValue({}),
+          },
+        };
+
+    const service = Object.create(BillingService.prototype) as BillingService;
+    Object.assign(service, {
+      logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+      firestoreService,
+      stripe,
+    });
+
+    return { service, firestoreService, stripe, saved };
+  }
+
+  function mxDto(overrides: Partial<UpdateTaxProfileDto> = {}) {
+    return {
+      type: 'mx',
+      rfc: RFC_MORAL,
+      legalName: 'EMPRESA DEMO',
+      taxRegime: '601',
+      postalCode: '97000',
+      cfdiUse: 'G03',
+      billingEmail: 'facturas@empresa.com',
+      ...overrides,
+    } as UpdateTaxProfileDto;
+  }
+
+  /** Extrae el mapa `errors` de la excepción, que es lo que pinta el frontend. */
+  function fieldErrors(error: unknown): Record<string, string> {
+    const response = (error as BadRequestException).getResponse() as {
+      errors: Record<string, string>;
+    };
+    return response.errors;
+  }
+
+  async function expectFieldError(
+    service: BillingService,
+    dto: UpdateTaxProfileDto,
+    field: string,
+    code: string,
+  ) {
+    await expect(service.updateTaxProfile('uid-1', dto)).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+
+    try {
+      await service.updateTaxProfile('uid-1', dto);
+      throw new Error('Se esperaba un BadRequestException');
+    } catch (error) {
+      expect(fieldErrors(error)).toMatchObject({ [field]: code });
+    }
+  }
+
+  describe('GET — nunca 404', () => {
+    it('devuelve isComplete:false y el type derivado del país cuando no hay perfil', async () => {
+      const { service } = buildService({ profile: null });
+
+      const result = await service.getTaxProfile('uid-1');
+
+      expect(result).toEqual({ type: 'mx', country: 'MX', isComplete: false });
+    });
+
+    it('trata como internacional al usuario sin país conocido', async () => {
+      const { service } = buildService({
+        user: { id: 'uid-1', country: undefined },
+        profile: null,
+      });
+
+      const result = await service.getTaxProfile('uid-1');
+
+      // Por defecto NO se timbra: es preferible una factura de Stripe de más que
+      // un CFDI emitido a quien no lo necesita.
+      expect(result.type).toBe('international');
+    });
+
+    it('pide recargar el perfil si el usuario cambió de país', async () => {
+      const { service } = buildService({
+        user: { id: 'uid-1', country: 'ES' },
+        profile: { type: 'mx', rfc: RFC_MORAL, isComplete: true },
+      });
+
+      const result = await service.getTaxProfile('uid-1');
+
+      expect(result).toEqual({
+        type: 'international',
+        country: 'ES',
+        isComplete: false,
+      });
+      // El RFC guardado no debe filtrarse a un formulario internacional.
+      expect(result).not.toHaveProperty('rfc');
+    });
+  });
+
+  describe('PUT — validación de México', () => {
+    it('rechaza un RFC con formato inválido', async () => {
+      const { service } = buildService({});
+      await expectFieldError(
+        service,
+        mxDto({ rfc: 'NO-ES-UN-RFC' }),
+        'rfc',
+        'rfc_invalid_format',
+      );
+    });
+
+    it('rechaza el RFC genérico de público en general', async () => {
+      const { service } = buildService({});
+      // Tiene formato válido, pero una factura contra él no le sirve al usuario
+      // para deducir: es siempre un error de captura.
+      await expectFieldError(
+        service,
+        mxDto({ rfc: 'XAXX010101000', taxRegime: '616', cfdiUse: 'S01' }),
+        'rfc',
+        'rfc_generic_not_allowed',
+      );
+    });
+
+    it('rechaza un régimen de persona moral en un RFC de persona física', async () => {
+      const { service } = buildService({});
+      // 601 es "General de Ley Personas Morales" y el RFC de 13 es de física.
+      await expectFieldError(
+        service,
+        mxDto({ rfc: RFC_FISICA, taxRegime: '601' }),
+        'taxRegime',
+        'tax_regime_not_valid_for_person_type',
+      );
+    });
+
+    it('rechaza un régimen de persona física en un RFC de persona moral', async () => {
+      const { service } = buildService({});
+      // 612 es "Personas Físicas con Actividades Empresariales".
+      await expectFieldError(
+        service,
+        mxDto({ rfc: RFC_MORAL, taxRegime: '612' }),
+        'taxRegime',
+        'tax_regime_not_valid_for_person_type',
+      );
+    });
+
+    it('distingue un régimen inexistente de uno que no aplica a la persona', async () => {
+      const { service } = buildService({});
+      // La acción del usuario es distinta en cada caso: elegir otro valor del
+      // catálogo, o revisar el RFC que capturó.
+      await expectFieldError(
+        service,
+        mxDto({ taxRegime: '999' }),
+        'taxRegime',
+        'tax_regime_unknown',
+      );
+    });
+
+    it('rechaza un uso de CFDI inexistente en el catálogo', async () => {
+      const { service } = buildService({});
+      await expectFieldError(
+        service,
+        mxDto({ cfdiUse: 'ZZ99' }),
+        'cfdiUse',
+        'cfdi_use_unknown',
+      );
+    });
+
+    it('rechaza un uso de CFDI deducible personal en una persona moral', async () => {
+      const { service } = buildService({});
+      // D10 (colegiaturas) solo lo puede usar una persona física.
+      await expectFieldError(
+        service,
+        mxDto({ rfc: RFC_MORAL, cfdiUse: 'D10' }),
+        'cfdiUse',
+        'cfdi_use_not_valid_for_person_type',
+      );
+    });
+
+    it('rechaza un código postal que no son 5 dígitos', async () => {
+      const { service } = buildService({});
+      await expectFieldError(
+        service,
+        mxDto({ postalCode: '9700' }),
+        'postalCode',
+        'postal_code_invalid',
+      );
+    });
+
+    it('acepta el régimen 626 (RESICO) tanto en física como en moral', async () => {
+      const { service } = buildService({});
+
+      await expect(
+        service.updateTaxProfile('uid-1', mxDto({ taxRegime: '626' })),
+      ).resolves.toBeDefined();
+      await expect(
+        service.updateTaxProfile(
+          'uid-1',
+          mxDto({ rfc: RFC_FISICA, taxRegime: '626' }),
+        ),
+      ).resolves.toBeDefined();
+    });
+
+    it('rechaza el perfil cuyo type no coincide con el país del usuario', async () => {
+      const { service } = buildService({
+        user: { id: 'uid-1', country: 'ES' },
+      });
+      // Si el cliente pudiera elegir el type, un usuario mexicano se saltaría el
+      // CFDI declarándose internacional.
+      await expectFieldError(
+        service,
+        mxDto(),
+        'type',
+        'type_does_not_match_country',
+      );
+    });
+
+    it('normaliza la razón social a mayúsculas y sin acentos', async () => {
+      const { service, saved } = buildService({});
+
+      await service.updateTaxProfile(
+        'uid-1',
+        mxDto({ legalName: '  Construcción   Peña  ' }),
+      );
+
+      // El SAT guarda la razón social en mayúsculas y sin acentos; normalizarla
+      // evita un rechazo por una diferencia puramente ortográfica.
+      expect(saved[0].legalName).toBe('CONSTRUCCION PENA');
+    });
+
+    it('invalida el cliente de Facturama cuando cambia el RFC', async () => {
+      const { service, saved } = buildService({
+        profile: {
+          type: 'mx',
+          rfc: 'XYZ010101AB1',
+          facturamaClientId: 'client_viejo',
+          isComplete: true,
+        },
+      });
+
+      await service.updateTaxProfile('uid-1', mxDto({ rfc: RFC_MORAL }));
+
+      // El cliente dado de alta en Facturama pertenece al RFC anterior.
+      expect(saved[0].facturamaClientId).toBeNull();
+    });
+  });
+
+  describe('PUT — validación internacional', () => {
+    function intlDto(overrides: Partial<UpdateTaxProfileDto> = {}) {
+      return {
+        type: 'international',
+        legalName: 'Acme S.L.',
+        billingEmail: 'billing@acme.com',
+        taxIdType: 'eu_vat',
+        taxIdValue: 'ESB12345678',
+        address: {
+          line1: 'Calle Mayor 1',
+          city: 'Madrid',
+          postalCode: '28001',
+          country: 'ES',
+        },
+        ...overrides,
+      } as UpdateTaxProfileDto;
+    }
+
+    it('rechaza un tax ID con tipo pero sin valor', async () => {
+      const { service } = buildService({
+        user: { id: 'uid-1', country: 'ES' },
+      });
+      await expectFieldError(
+        service,
+        intlDto({ taxIdValue: null }),
+        'taxIdValue',
+        'tax_id_value_required',
+      );
+    });
+
+    it('rechaza un tax ID con valor pero sin tipo', async () => {
+      const { service } = buildService({
+        user: { id: 'uid-1', country: 'ES' },
+      });
+      await expectFieldError(
+        service,
+        intlDto({ taxIdType: null }),
+        'taxIdType',
+        'tax_id_type_required',
+      );
+    });
+
+    it('acepta un perfil sin tax ID', async () => {
+      const { service } = buildService({
+        user: { id: 'uid-1', country: 'ES' },
+      });
+
+      // No todos los países emiten un tax ID al consumidor final.
+      await expect(
+        service.updateTaxProfile(
+          'uid-1',
+          intlDto({ taxIdType: null, taxIdValue: null }),
+        ),
+      ).resolves.toBeDefined();
+    });
+
+    it('rechaza un país que no es ISO alpha-2', async () => {
+      const { service } = buildService({
+        user: { id: 'uid-1', country: 'ES' },
+      });
+      await expectFieldError(
+        service,
+        intlDto({
+          address: {
+            line1: 'Calle Mayor 1',
+            city: 'Madrid',
+            postalCode: '28001',
+            country: 'ESP',
+          },
+        }),
+        'address',
+        'address_country_invalid',
+      );
+    });
+  });
+
+  describe('propagación a Stripe', () => {
+    it('manda razón social, email y domicilio al customer', async () => {
+      const customersUpdate = jest.fn().mockResolvedValue({});
+      const { service } = buildService({
+        user: { id: 'uid-1', country: 'ES', stripeCustomerId: 'cus_123' },
+        customersUpdate,
+      });
+
+      await service.updateTaxProfile('uid-1', {
+        type: 'international',
+        legalName: 'Acme S.L.',
+        billingEmail: 'billing@acme.com',
+        taxIdType: 'eu_vat',
+        taxIdValue: 'ESB12345678',
+        address: {
+          line1: 'Calle Mayor 1',
+          city: 'Madrid',
+          postalCode: '28001',
+          country: 'ES',
+        },
+      } as UpdateTaxProfileDto);
+
+      expect(customersUpdate).toHaveBeenCalledWith(
+        'cus_123',
+        expect.objectContaining({
+          name: 'Acme S.L.',
+          email: 'billing@acme.com',
+          address: expect.objectContaining({
+            line1: 'Calle Mayor 1',
+            city: 'Madrid',
+            postal_code: '28001',
+            country: 'ES',
+          }),
+        }),
+      );
+    });
+
+    it('registra el RFC como tax ID mx_rfc', async () => {
+      const createTaxId = jest.fn().mockResolvedValue({ id: 'txi_123' });
+      const { service } = buildService({ createTaxId });
+
+      await service.updateTaxProfile('uid-1', mxDto());
+
+      expect(createTaxId).toHaveBeenCalledWith('cus_123', {
+        type: 'mx_rfc',
+        value: RFC_MORAL,
+      });
+    });
+
+    it('no duplica el tax ID si ya está registrado con el mismo valor', async () => {
+      const createTaxId = jest.fn();
+      const deleteTaxId = jest.fn();
+      const { service } = buildService({
+        listTaxIds: jest.fn().mockResolvedValue({
+          data: [{ id: 'txi_existente', type: 'mx_rfc', value: RFC_MORAL }],
+        }),
+        createTaxId,
+        deleteTaxId,
+      });
+
+      await service.updateTaxProfile('uid-1', mxDto());
+
+      expect(createTaxId).not.toHaveBeenCalled();
+      expect(deleteTaxId).not.toHaveBeenCalled();
+    });
+
+    it('borra el tax ID anterior cuando cambia el RFC', async () => {
+      const deleteTaxId = jest.fn().mockResolvedValue({});
+      const createTaxId = jest.fn().mockResolvedValue({ id: 'txi_nuevo' });
+      const { service } = buildService({
+        listTaxIds: jest.fn().mockResolvedValue({
+          data: [{ id: 'txi_viejo', type: 'mx_rfc', value: 'XYZ010101AB1' }],
+        }),
+        deleteTaxId,
+        createTaxId,
+      });
+
+      await service.updateTaxProfile('uid-1', mxDto());
+
+      // Stripe no permite modificar un tax ID: si no se borra el anterior, el
+      // PDF sale con dos.
+      expect(deleteTaxId).toHaveBeenCalledWith('cus_123', 'txi_viejo');
+      expect(createTaxId).toHaveBeenCalled();
+    });
+
+    it('guarda el perfil aunque Stripe falle', async () => {
+      const { service, saved } = buildService({
+        customersUpdate: jest.fn().mockRejectedValue(new Error('Stripe caído')),
+      });
+
+      // El dato que el usuario acaba de escribir no se pierde por un fallo en un
+      // paso que solo afecta a cómo se imprime el PDF de Stripe.
+      await expect(
+        service.updateTaxProfile('uid-1', mxDto()),
+      ).resolves.toBeDefined();
+      expect(saved[0].isComplete).toBe(true);
+    });
+
+    it('no llama a Stripe si el usuario todavía no tiene customer', async () => {
+      const customersUpdate = jest.fn();
+      const { service } = buildService({
+        user: { id: 'uid-1', country: 'MX', stripeCustomerId: undefined },
+        customersUpdate,
+      });
+
+      await service.updateTaxProfile('uid-1', mxDto());
+
+      // Se propagará al completarse el checkout, cuando el customer exista.
+      expect(customersUpdate).not.toHaveBeenCalled();
+    });
+
+    it('syncTaxProfileToStripe no hace nada con un perfil incompleto', async () => {
+      const customersUpdate = jest.fn();
+      const { service } = buildService({
+        profile: { type: 'mx', isComplete: false },
+        customersUpdate,
+      });
+
+      await service.syncTaxProfileToStripe('uid-1');
+
+      expect(customersUpdate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/billing/billing.service.ts
+++ b/src/modules/billing/billing.service.ts
@@ -269,21 +269,25 @@ export class BillingService {
     // Tomar el CFDI es lo que autoriza a timbrar, y es atómico. Comprobar el
     // estado con una lectura previa no serviría de candado: un doble clic
     // bastaría para que dos peticiones vieran `failed` y ambas llamaran al PAC.
-    const blocked = await this.firestoreService.claimCfdiForRetry(invoiceId, {
+    const claim = await this.firestoreService.claimCfdiForRetry(invoiceId, {
       userId,
       amount: (invoice.amount_paid ?? 0) / 100,
       currency: (invoice.currency || 'mxn').toLowerCase(),
     });
 
-    if (blocked) {
+    if (claim.outcome === 'blocked') {
       throw new BadRequestException({
         error: ErrorCodes.INVALID_INPUT,
-        message: `CFDI is not in a retryable state (${blocked.blockedBy})`,
+        message: `CFDI is not in a retryable state (${claim.blockedBy})`,
       });
     }
 
     try {
-      const updated = await this.cfdiService.retry(invoice, user);
+      const updated = await this.cfdiService.retry(
+        invoice,
+        user,
+        claim.attempts,
+      );
       return this.toCfdiDto(updated);
     } catch (error) {
       const code =
@@ -519,13 +523,22 @@ export class BillingService {
   }
 
   /**
-   * Propaga el perfil fiscal al customer de Stripe. Idempotente y silenciosa.
+   * Propaga el perfil fiscal al customer de Stripe. Idempotente.
    *
-   * Se invoca al guardar el perfil y también al completarse un checkout, porque
-   * un usuario puede cargar sus datos fiscales antes de tener customer: sin el
-   * segundo disparo, su primera factura saldría sin ellos.
+   * Tiene dos modos porque las consecuencias de fallar no son las mismas:
+   *
+   * - **Silencioso** (por defecto), al guardar el perfil. El dato ya está en
+   *   Firestore y solo queda pendiente cómo se imprime el PDF; tumbar el guardado
+   *   haría perder lo que el usuario acaba de escribir.
+   * - **Estricto** (`throwOnError`), antes de abrir un checkout. Ahí el fallo no
+   *   es recuperable después: Stripe copia nombre, domicilio y tax IDs a la
+   *   factura al finalizarla y ya no vuelve a tocarlos, así que seguir adelante
+   *   produciría un comprobante fiscalmente incompleto para siempre.
    */
-  async syncTaxProfileToStripe(userId: string): Promise<void> {
+  async syncTaxProfileToStripe(
+    userId: string,
+    options: { throwOnError?: boolean } = {},
+  ): Promise<void> {
     if (!this.stripe) {
       return;
     }
@@ -569,11 +582,13 @@ export class BillingService {
 
       this.logger.log(`Perfil fiscal propagado a Stripe: ${userId}`);
     } catch (error) {
-      // No relanzamos: el perfil ya está persistido y este paso solo afecta a
-      // cómo se imprime el PDF de Stripe, no a la validez del dato.
       this.logger.error(
         `Error propagando el perfil fiscal de ${userId} a Stripe: ${error.message}`,
       );
+
+      if (options.throwOnError) {
+        throw error;
+      }
     }
   }
 
@@ -620,6 +635,12 @@ export class BillingService {
       // Puede haberlo creado el propio usuario desde el portal de Stripe: se
       // adopta como el gestionado en vez de duplicarlo.
       if (managedId !== alreadyRegistered.id) {
+        // Antes de adoptarlo hay que retirar el que veníamos gestionando, o el
+        // customer se queda con los dos y las facturas siguientes imprimirían
+        // también el RFC viejo.
+        if (managedId) {
+          await this.deleteStripeTaxId(customerId, managedId);
+        }
         await this.firestoreService.saveTaxProfile(userId, {
           stripeTaxIdId: alreadyRegistered.id,
         });

--- a/src/modules/billing/billing.service.ts
+++ b/src/modules/billing/billing.service.ts
@@ -257,6 +257,22 @@ export class BillingService {
       });
     }
 
+    // El perfil incompleto se comprueba aquí y no dentro del reintento para que
+    // salga como 400: es una precondición que el usuario no ha cumplido, no un
+    // rechazo del PAC. Si se dejara caer al catch se devolvería un 422, que le
+    // diría que su RFC está mal cuando lo que falta es cargarlo.
+    const profile = await this.firestoreService.getTaxProfile(userId);
+    if (!profile?.isComplete || profile.type !== 'mx') {
+      throw new BadRequestException({
+        error: ErrorCodes.INVALID_INPUT,
+        message: 'Tax profile is incomplete',
+        cfdiError: {
+          code: CfdiErrorCodes.INVOICE_NOT_STAMPABLE,
+          message: 'Tax profile is incomplete',
+        },
+      });
+    }
+
     try {
       const updated = await this.cfdiService.retry(invoice, user);
       return this.toCfdiDto(updated);

--- a/src/modules/billing/billing.service.ts
+++ b/src/modules/billing/billing.service.ts
@@ -7,6 +7,48 @@ import {
   PaymentMethodsResponseDto,
   SubscriptionResponseDto,
 } from './dto/billing.dto.js';
+import {
+  TaxProfileResponseDto,
+  UpdateTaxProfileDto,
+} from './dto/tax-profile.dto.js';
+import {
+  RFC_EXTRANJERO,
+  RFC_PUBLICO_GENERAL,
+  RFC_REGEX,
+  SAT_CFDI_USES,
+  SAT_FISCAL_REGIMES,
+  getSatPersonType,
+  isCfdiUseValidForPerson,
+  isRegimeValidForPerson,
+} from '../../common/interfaces/tax-profile.interface.js';
+import type {
+  TaxProfile,
+  TaxProfileType,
+} from '../../common/interfaces/tax-profile.interface.js';
+import { ErrorCodes } from '../../common/constants/error-codes.js';
+
+/**
+ * Errores de validación por campo del perfil fiscal.
+ *
+ * El valor es un **código estable**, no una frase: la app sirve en cuatro
+ * idiomas y el backend no conoce el del receptor. La traducción vive en el
+ * frontend, igual que se acordó para `cfdi.error.code`.
+ */
+type TaxProfileFieldErrors = Partial<
+  Record<
+    | 'type'
+    | 'rfc'
+    | 'legalName'
+    | 'taxRegime'
+    | 'postalCode'
+    | 'cfdiUse'
+    | 'billingEmail'
+    | 'taxIdType'
+    | 'taxIdValue'
+    | 'address',
+    string
+  >
+>;
 
 @Injectable()
 export class BillingService {
@@ -173,5 +215,365 @@ export class BillingService {
       }
       throw new BadRequestException('Failed to fetch subscription');
     }
+  }
+
+  // ============== Perfil fiscal ==============
+
+  /**
+   * Devuelve el perfil fiscal del usuario.
+   *
+   * Nunca 404: un perfil vacío es un estado válido, y el frontend necesita el
+   * `type` para saber qué formulario renderizar antes de que haya datos.
+   */
+  async getTaxProfile(userId: string): Promise<TaxProfileResponseDto> {
+    const user = await this.firestoreService.getUserById(userId);
+    const country = user?.country || '';
+    const type = this.resolveProfileType(country);
+
+    const profile = await this.firestoreService.getTaxProfile(userId);
+
+    if (!profile) {
+      return { type, country, isComplete: false };
+    }
+
+    // El país manda sobre lo guardado: si el usuario se mudó, el formulario que
+    // toca es el del país actual, aunque el perfil viejo siga en Firestore.
+    if (profile.type !== type) {
+      this.logger.warn(
+        `Perfil fiscal de ${userId} es '${profile.type}' pero el país es '${country}' ('${type}'). Se pide recargar el perfil.`,
+      );
+      return { type, country, isComplete: false };
+    }
+
+    return this.toResponse(profile, type, country);
+  }
+
+  /**
+   * Crea o actualiza el perfil fiscal y lo propaga al customer de Stripe.
+   *
+   * La propagación a Stripe es lo que hace que el PDF que Stripe ya genera salga
+   * con la razón social, el domicilio y el tax ID del cliente — todo el alcance
+   * del flujo internacional.
+   */
+  async updateTaxProfile(
+    userId: string,
+    dto: UpdateTaxProfileDto,
+  ): Promise<TaxProfileResponseDto> {
+    const user = await this.firestoreService.getUserById(userId);
+    const country = user?.country || '';
+    const type = this.resolveProfileType(country);
+
+    // El `type` lo decide el país, no el cliente: si el body pudiera elegirlo,
+    // un usuario mexicano se saltaría el CFDI declarándose internacional.
+    if (dto.type !== type) {
+      this.throwFieldErrors({ type: 'type_does_not_match_country' });
+    }
+
+    const errors =
+      type === 'mx'
+        ? this.validateMxProfile(dto)
+        : this.validateInternationalProfile(dto);
+
+    if (Object.keys(errors).length > 0) {
+      this.throwFieldErrors(errors);
+    }
+
+    const existing = await this.firestoreService.getTaxProfile(userId);
+
+    const profile: Partial<TaxProfile> =
+      type === 'mx'
+        ? {
+            type,
+            country,
+            rfc: dto.rfc.trim().toUpperCase(),
+            legalName: this.normalizeLegalName(dto.legalName),
+            taxRegime: dto.taxRegime.trim(),
+            postalCode: dto.postalCode.trim(),
+            cfdiUse: dto.cfdiUse.trim(),
+            billingEmail: dto.billingEmail.trim(),
+            isComplete: true,
+          }
+        : {
+            type,
+            country,
+            legalName: dto.legalName.trim(),
+            billingEmail: dto.billingEmail.trim(),
+            taxIdType: dto.taxIdType?.trim() || null,
+            taxIdValue: dto.taxIdValue?.trim() || null,
+            address: {
+              line1: dto.address.line1.trim(),
+              line2: dto.address.line2?.trim() || null,
+              city: dto.address.city.trim(),
+              state: dto.address.state?.trim() || null,
+              postalCode: dto.address.postalCode.trim(),
+              country: dto.address.country.trim().toUpperCase(),
+            },
+            postalCode: dto.address.postalCode.trim(),
+            isComplete: true,
+          };
+
+    // Si cambia el RFC, el cliente dado de alta en Facturama deja de valer.
+    if (type === 'mx' && existing?.rfc && existing.rfc !== profile.rfc) {
+      profile.facturamaClientId = null;
+    }
+
+    await this.firestoreService.saveTaxProfile(userId, profile);
+
+    // Un fallo propagando a Stripe no debe perder los datos que el usuario acaba
+    // de escribir: el perfil ya está guardado y la sincronización se reintenta
+    // sola en el siguiente guardado o al completarse un checkout.
+    await this.syncTaxProfileToStripe(userId);
+
+    const saved = await this.firestoreService.getTaxProfile(userId);
+    return this.toResponse(saved, type, country);
+  }
+
+  /**
+   * Propaga el perfil fiscal al customer de Stripe. Idempotente y silenciosa.
+   *
+   * Se invoca al guardar el perfil y también al completarse un checkout, porque
+   * un usuario puede cargar sus datos fiscales antes de tener customer: sin el
+   * segundo disparo, su primera factura saldría sin ellos.
+   */
+  async syncTaxProfileToStripe(userId: string): Promise<void> {
+    if (!this.stripe) {
+      return;
+    }
+
+    try {
+      const [user, profile] = await Promise.all([
+        this.firestoreService.getUserById(userId),
+        this.firestoreService.getTaxProfile(userId),
+      ]);
+
+      if (!profile?.isComplete) {
+        return;
+      }
+
+      if (!user?.stripeCustomerId) {
+        this.logger.log(
+          `Perfil fiscal de ${userId} sin customer de Stripe todavía; se propagará al completar el checkout.`,
+        );
+        return;
+      }
+
+      const address =
+        profile.type === 'mx'
+          ? { postal_code: profile.postalCode, country: 'MX' }
+          : {
+              line1: profile.address?.line1,
+              line2: profile.address?.line2 || undefined,
+              city: profile.address?.city,
+              state: profile.address?.state || undefined,
+              postal_code: profile.address?.postalCode,
+              country: profile.address?.country,
+            };
+
+      await this.stripe.customers.update(user.stripeCustomerId, {
+        name: profile.legalName,
+        email: profile.billingEmail,
+        address,
+      });
+
+      await this.syncStripeTaxId(userId, user.stripeCustomerId, profile);
+
+      this.logger.log(`Perfil fiscal propagado a Stripe: ${userId}`);
+    } catch (error) {
+      // No relanzamos: el perfil ya está persistido y este paso solo afecta a
+      // cómo se imprime el PDF de Stripe, no a la validez del dato.
+      this.logger.error(
+        `Error propagando el perfil fiscal de ${userId} a Stripe: ${error.message}`,
+      );
+    }
+  }
+
+  /**
+   * Registra el tax ID en Stripe.
+   *
+   * Stripe no permite modificar un tax ID existente, así que el cambio de valor
+   * obliga a borrar el anterior y crear uno nuevo.
+   */
+  private async syncStripeTaxId(
+    userId: string,
+    customerId: string,
+    profile: TaxProfile,
+  ): Promise<void> {
+    const type = profile.type === 'mx' ? 'mx_rfc' : profile.taxIdType;
+    const value = profile.type === 'mx' ? profile.rfc : profile.taxIdValue;
+
+    if (!type || !value) {
+      return;
+    }
+
+    const existingTaxIds = await this.stripe.customers.listTaxIds(customerId, {
+      limit: 100,
+    });
+    const alreadyRegistered = existingTaxIds.data.find(
+      (taxId) => taxId.type === type && taxId.value === value,
+    );
+
+    if (alreadyRegistered) {
+      if (profile.stripeTaxIdId !== alreadyRegistered.id) {
+        await this.firestoreService.saveTaxProfile(userId, {
+          stripeTaxIdId: alreadyRegistered.id,
+        });
+      }
+      return;
+    }
+
+    // Los tax IDs obsoletos se borran para que Stripe no imprima dos en el PDF.
+    for (const stale of existingTaxIds.data) {
+      await this.stripe.customers.deleteTaxId(customerId, stale.id);
+    }
+
+    const created = await this.stripe.customers.createTaxId(customerId, {
+      type: type as Stripe.TaxIdCreateParams.Type,
+      value,
+    });
+
+    await this.firestoreService.saveTaxProfile(userId, {
+      stripeTaxIdId: created.id,
+    });
+  }
+
+  /** México usa CFDI; cualquier otro país (o país desconocido) va por Stripe. */
+  private resolveProfileType(country: string): TaxProfileType {
+    return country?.toUpperCase() === 'MX' ? 'mx' : 'international';
+  }
+
+  /**
+   * Reglas fiscales que no caben en decoradores de class-validator.
+   *
+   * No se valida contra el SAT aquí —no hay un endpoint fiable para eso— sino la
+   * coherencia interna del perfil, que es lo que causa la mayoría de los rechazos
+   * al timbrar: un régimen de persona moral con un RFC de persona física, o un
+   * uso de CFDI deducible personal en una empresa.
+   */
+  private validateMxProfile(dto: UpdateTaxProfileDto): TaxProfileFieldErrors {
+    const errors: TaxProfileFieldErrors = {};
+
+    const rfc = dto.rfc?.trim().toUpperCase() ?? '';
+    const person = getSatPersonType(rfc);
+
+    if (!RFC_REGEX.test(rfc) || !person) {
+      errors.rfc = 'rfc_invalid_format';
+    } else if (rfc === RFC_PUBLICO_GENERAL || rfc === RFC_EXTRANJERO) {
+      // Los RFC genéricos no identifican a un contribuyente: una factura contra
+      // ellos no le sirve al usuario para deducir.
+      errors.rfc = 'rfc_generic_not_allowed';
+    }
+
+    if (!/^[0-9]{5}$/.test(dto.postalCode?.trim() ?? '')) {
+      errors.postalCode = 'postal_code_invalid';
+    }
+
+    // Se distingue "no existe en el catálogo" de "existe pero no aplica a este
+    // tipo de persona": el frontend pinta mensajes distintos y la acción del
+    // usuario también lo es (elegir otro valor vs. revisar su RFC).
+    const taxRegime = dto.taxRegime?.trim() ?? '';
+    if (!SAT_FISCAL_REGIMES[taxRegime]) {
+      errors.taxRegime = 'tax_regime_unknown';
+    } else if (person && !isRegimeValidForPerson(taxRegime, person)) {
+      errors.taxRegime = 'tax_regime_not_valid_for_person_type';
+    }
+
+    const cfdiUse = dto.cfdiUse?.trim() ?? '';
+    if (!SAT_CFDI_USES[cfdiUse]) {
+      errors.cfdiUse = 'cfdi_use_unknown';
+    } else if (person && !isCfdiUseValidForPerson(cfdiUse, person)) {
+      errors.cfdiUse = 'cfdi_use_not_valid_for_person_type';
+    }
+
+    if (!dto.legalName?.trim()) {
+      errors.legalName = 'legal_name_required';
+    }
+
+    return errors;
+  }
+
+  private validateInternationalProfile(
+    dto: UpdateTaxProfileDto,
+  ): TaxProfileFieldErrors {
+    const errors: TaxProfileFieldErrors = {};
+
+    if (!dto.legalName?.trim()) {
+      errors.legalName = 'legal_name_required';
+    }
+
+    if (!dto.address?.line1?.trim() || !dto.address?.city?.trim()) {
+      errors.address = 'address_incomplete';
+    } else if (!/^[A-Z]{2}$/.test(dto.address.country?.trim().toUpperCase())) {
+      errors.address = 'address_country_invalid';
+    }
+
+    // Un tipo sin valor (o al revés) deja un tax ID a medias que Stripe rechaza.
+    const hasType = Boolean(dto.taxIdType?.trim());
+    const hasValue = Boolean(dto.taxIdValue?.trim());
+    if (hasType !== hasValue) {
+      if (hasType) {
+        errors.taxIdValue = 'tax_id_value_required';
+      } else {
+        errors.taxIdType = 'tax_id_type_required';
+      }
+    }
+
+    return errors;
+  }
+
+  /**
+   * CFDI 4.0 exige la razón social tal como está registrada ante el SAT, que la
+   * guarda en mayúsculas y sin acentos. Normalizarlo aquí evita rechazos por una
+   * diferencia puramente ortográfica.
+   */
+  private normalizeLegalName(legalName: string): string {
+    return legalName
+      .trim()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/\s+/g, ' ')
+      .toUpperCase();
+  }
+
+  private throwFieldErrors(errors: TaxProfileFieldErrors): never {
+    throw new BadRequestException({
+      error: ErrorCodes.INVALID_INPUT,
+      message: 'Tax profile validation failed',
+      errors,
+    });
+  }
+
+  private toResponse(
+    profile: TaxProfile,
+    type: TaxProfileType,
+    country: string,
+  ): TaxProfileResponseDto {
+    const base = {
+      type,
+      country,
+      isComplete: profile.isComplete === true,
+      legalName: profile.legalName,
+      billingEmail: profile.billingEmail,
+      updatedAt:
+        profile.updatedAt instanceof Date
+          ? profile.updatedAt.toISOString()
+          : profile.updatedAt,
+    };
+
+    if (type === 'mx') {
+      return {
+        ...base,
+        rfc: profile.rfc,
+        taxRegime: profile.taxRegime,
+        postalCode: profile.postalCode,
+        cfdiUse: profile.cfdiUse,
+      };
+    }
+
+    return {
+      ...base,
+      taxIdType: profile.taxIdType ?? null,
+      taxIdValue: profile.taxIdValue ?? null,
+      address: profile.address ?? null,
+    };
   }
 }

--- a/src/modules/billing/billing.service.ts
+++ b/src/modules/billing/billing.service.ts
@@ -135,20 +135,22 @@ export class BillingService {
   /**
    * Resuelve el bloque `cfdi` de cada factura en una sola lectura.
    *
-   * Los usuarios no mexicanos reciben un mapa vacío y el campo queda a `null`,
-   * que es como el frontend sabe que no debe pintar la columna. Para los
-   * mexicanos, una factura sin registro es `not_applicable`: normalmente una
-   * anterior a que cargaran su perfil fiscal.
+   * Los CFDI ya emitidos se devuelven SIEMPRE, viva donde viva el usuario hoy:
+   * un comprobante fiscal se conserva cinco años y esta es la única vía de
+   * descarga. Si alguien que facturó en México cambia de país, seguiría teniendo
+   * derecho a bajarse lo que ya se le emitió.
+   *
+   * El país actual solo decide qué se responde para las facturas SIN registro:
+   * `not_applicable` a un mexicano —normalmente una factura anterior a que
+   * cargara su perfil fiscal— y `null` a los demás, que es como el frontend sabe
+   * que no debe pintar la columna.
    */
   private async resolveCfdis(
     user: User,
     invoices: Stripe.Invoice[],
   ): Promise<Map<string, CfdiDto>> {
     const result = new Map<string, CfdiDto>();
-
-    if (user.country?.toUpperCase() !== 'MX') {
-      return result;
-    }
+    const isMexican = user.country?.toUpperCase() === 'MX';
 
     const records = await this.firestoreService.getCfdisByInvoiceIds(
       invoices.map((invoice) => invoice.id),
@@ -157,7 +159,12 @@ export class BillingService {
     for (const invoice of invoices) {
       const record = records.get(invoice.id);
 
-      if (!record) {
+      if (record) {
+        result.set(invoice.id, await this.toCfdiDto(record));
+        continue;
+      }
+
+      if (isMexican) {
         result.set(invoice.id, {
           status: 'not_applicable',
           uuid: null,
@@ -166,10 +173,7 @@ export class BillingService {
           stampedAt: null,
           error: null,
         });
-        continue;
       }
-
-      result.set(invoice.id, await this.toCfdiDto(record));
     }
 
     return result;
@@ -246,17 +250,6 @@ export class BillingService {
       throw new ForbiddenException('Invoice does not belong to this user');
     }
 
-    const record = await this.firestoreService.getCfdiByInvoiceId(invoiceId);
-
-    // Reintentar uno ya timbrado emitiría un duplicado, que solo se deshace
-    // cancelándolo a mano ante el SAT.
-    if (record && record.status !== 'failed') {
-      throw new BadRequestException({
-        error: ErrorCodes.INVALID_INPUT,
-        message: `CFDI is not in a retryable state (${record.status})`,
-      });
-    }
-
     // El perfil incompleto se comprueba aquí y no dentro del reintento para que
     // salga como 400: es una precondición que el usuario no ha cumplido, no un
     // rechazo del PAC. Si se dejara caer al catch se devolvería un 422, que le
@@ -270,6 +263,22 @@ export class BillingService {
           code: CfdiErrorCodes.INVOICE_NOT_STAMPABLE,
           message: 'Tax profile is incomplete',
         },
+      });
+    }
+
+    // Tomar el CFDI es lo que autoriza a timbrar, y es atómico. Comprobar el
+    // estado con una lectura previa no serviría de candado: un doble clic
+    // bastaría para que dos peticiones vieran `failed` y ambas llamaran al PAC.
+    const blocked = await this.firestoreService.claimCfdiForRetry(invoiceId, {
+      userId,
+      amount: (invoice.amount_paid ?? 0) / 100,
+      currency: (invoice.currency || 'mxn').toLowerCase(),
+    });
+
+    if (blocked) {
+      throw new BadRequestException({
+        error: ErrorCodes.INVALID_INPUT,
+        message: `CFDI is not in a retryable state (${blocked.blockedBy})`,
       });
     }
 
@@ -569,10 +578,14 @@ export class BillingService {
   }
 
   /**
-   * Registra el tax ID en Stripe.
+   * Sincroniza en Stripe el tax ID que gestiona ZPLPDF.
    *
-   * Stripe no permite modificar un tax ID existente, así que el cambio de valor
-   * obliga a borrar el anterior y crear uno nuevo.
+   * Solo toca el suyo, el que quedó apuntado en `stripeTaxIdId`. Un customer de
+   * Stripe admite varios tax IDs —de otras jurisdicciones, o dados de alta a
+   * mano desde el dashboard— y barrerlos todos borraría datos que este perfil no
+   * puso ahí.
+   *
+   * Stripe no permite modificar un tax ID: cambiar de valor es borrar y crear.
    */
   private async syncStripeTaxId(
     userId: string,
@@ -581,8 +594,18 @@ export class BillingService {
   ): Promise<void> {
     const type = profile.type === 'mx' ? 'mx_rfc' : profile.taxIdType;
     const value = profile.type === 'mx' ? profile.rfc : profile.taxIdValue;
+    const managedId = profile.stripeTaxIdId;
 
+    // El usuario declaró no tener identificación fiscal. Dejar el anterior en
+    // Stripe haría que sus próximas facturas siguieran imprimiendo un dato que
+    // él ya borró de su perfil.
     if (!type || !value) {
+      if (managedId) {
+        await this.deleteStripeTaxId(customerId, managedId);
+        await this.firestoreService.saveTaxProfile(userId, {
+          stripeTaxIdId: null,
+        });
+      }
       return;
     }
 
@@ -594,7 +617,9 @@ export class BillingService {
     );
 
     if (alreadyRegistered) {
-      if (profile.stripeTaxIdId !== alreadyRegistered.id) {
+      // Puede haberlo creado el propio usuario desde el portal de Stripe: se
+      // adopta como el gestionado en vez de duplicarlo.
+      if (managedId !== alreadyRegistered.id) {
         await this.firestoreService.saveTaxProfile(userId, {
           stripeTaxIdId: alreadyRegistered.id,
         });
@@ -602,9 +627,8 @@ export class BillingService {
       return;
     }
 
-    // Los tax IDs obsoletos se borran para que Stripe no imprima dos en el PDF.
-    for (const stale of existingTaxIds.data) {
-      await this.stripe.customers.deleteTaxId(customerId, stale.id);
+    if (managedId) {
+      await this.deleteStripeTaxId(customerId, managedId);
     }
 
     const created = await this.stripe.customers.createTaxId(customerId, {
@@ -615,6 +639,24 @@ export class BillingService {
     await this.firestoreService.saveTaxProfile(userId, {
       stripeTaxIdId: created.id,
     });
+  }
+
+  /**
+   * Borra un tax ID tolerando que ya no exista: pudo eliminarlo el usuario desde
+   * el portal de Stripe, y ese 404 no debe frenar el alta del nuevo.
+   */
+  private async deleteStripeTaxId(
+    customerId: string,
+    taxIdId: string,
+  ): Promise<void> {
+    try {
+      await this.stripe.customers.deleteTaxId(customerId, taxIdId);
+    } catch (error) {
+      if (error?.code === 'resource_missing') {
+        return;
+      }
+      throw error;
+    }
   }
 
   /** México usa CFDI; cualquier otro país (o país desconocido) va por Stripe. */

--- a/src/modules/billing/billing.service.ts
+++ b/src/modules/billing/billing.service.ts
@@ -283,9 +283,13 @@ export class BillingService {
     }
 
     try {
+      // El perfil viaja ya validado desde arriba: releerlo dentro del reintento
+      // metería una operación que puede fallar entre el candado y el PAC, con el
+      // documento ya en `pending`.
       const updated = await this.cfdiService.retry(
         invoice,
         user,
+        profile,
         claim.attempts,
       );
       return this.toCfdiDto(updated);

--- a/src/modules/billing/billing.service.ts
+++ b/src/modules/billing/billing.service.ts
@@ -1,8 +1,22 @@
-import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import Stripe from 'stripe';
 import { FirestoreService } from '../cache/firestore.service.js';
+import { StorageService } from '../storage/storage.service.js';
+import { CfdiService } from './cfdi.service.js';
+import { CfdiErrorCodes } from '../facturama/facturama.constants.js';
+import { FacturamaError } from '../facturama/interfaces/facturama.interface.js';
+import type { Cfdi } from '../../common/interfaces/cfdi.interface.js';
+import type { User } from '../../common/interfaces/user.interface.js';
 import {
+  CfdiDto,
   InvoicesResponseDto,
   PaymentMethodsResponseDto,
   SubscriptionResponseDto,
@@ -58,6 +72,8 @@ export class BillingService {
   constructor(
     private readonly configService: ConfigService,
     private readonly firestoreService: FirestoreService,
+    private readonly storageService: StorageService,
+    private readonly cfdiService: CfdiService,
   ) {
     const stripeSecretKey = this.configService.get<string>('STRIPE_SECRET_KEY');
 
@@ -88,6 +104,8 @@ export class BillingService {
         limit,
       });
 
+      const cfdis = await this.resolveCfdis(user, invoices.data);
+
       return {
         invoices: invoices.data.map((inv) => ({
           id: inv.id,
@@ -102,6 +120,7 @@ export class BillingService {
           hostedInvoiceUrl: inv.hosted_invoice_url,
           invoicePdf: inv.invoice_pdf,
           description: inv.description,
+          cfdi: cfdis.get(inv.id) ?? null,
         })),
         hasMore: invoices.has_more,
       };
@@ -110,6 +129,152 @@ export class BillingService {
         `Error fetching invoices for user ${userId}: ${error.message}`,
       );
       throw new BadRequestException('Failed to fetch invoices');
+    }
+  }
+
+  /**
+   * Resuelve el bloque `cfdi` de cada factura en una sola lectura.
+   *
+   * Los usuarios no mexicanos reciben un mapa vacío y el campo queda a `null`,
+   * que es como el frontend sabe que no debe pintar la columna. Para los
+   * mexicanos, una factura sin registro es `not_applicable`: normalmente una
+   * anterior a que cargaran su perfil fiscal.
+   */
+  private async resolveCfdis(
+    user: User,
+    invoices: Stripe.Invoice[],
+  ): Promise<Map<string, CfdiDto>> {
+    const result = new Map<string, CfdiDto>();
+
+    if (user.country?.toUpperCase() !== 'MX') {
+      return result;
+    }
+
+    const records = await this.firestoreService.getCfdisByInvoiceIds(
+      invoices.map((invoice) => invoice.id),
+    );
+
+    for (const invoice of invoices) {
+      const record = records.get(invoice.id);
+
+      if (!record) {
+        result.set(invoice.id, {
+          status: 'not_applicable',
+          uuid: null,
+          pdfUrl: null,
+          xmlUrl: null,
+          stampedAt: null,
+          error: null,
+        });
+        continue;
+      }
+
+      result.set(invoice.id, await this.toCfdiDto(record));
+    }
+
+    return result;
+  }
+
+  /**
+   * Las URLs de descarga se firman al leer y caducan en 15 minutos: el CFDI es
+   * un documento fiscal con el RFC y el domicilio del cliente, así que un enlace
+   * permanente en el bucket sería un enlace permanente a sus datos.
+   */
+  private async toCfdiDto(record: Cfdi): Promise<CfdiDto> {
+    const [pdfUrl, xmlUrl] = await Promise.all([
+      this.signCfdiFile(record.pdfPath, `CFDI-${record.uuid}.pdf`),
+      this.signCfdiFile(record.xmlPath, `CFDI-${record.uuid}.xml`),
+    ]);
+
+    return {
+      status: record.status,
+      uuid: record.uuid ?? null,
+      pdfUrl,
+      xmlUrl,
+      stampedAt:
+        record.stampedAt instanceof Date
+          ? record.stampedAt.toISOString()
+          : (record.stampedAt ?? null),
+      error: record.error ?? null,
+    };
+  }
+
+  private async signCfdiFile(
+    path: string | null | undefined,
+    filename: string,
+  ): Promise<string | null> {
+    if (!path) {
+      return null;
+    }
+
+    try {
+      return await this.storageService.generateSignedUrlForPath(path, filename);
+    } catch (error) {
+      // Un enlace que no se pudo firmar no debe tumbar el listado de facturas.
+      this.logger.error(`Error firmando ${path}: ${error.message}`);
+      return null;
+    }
+  }
+
+  /**
+   * Reintenta el timbrado de un CFDI que quedó en `failed`.
+   *
+   * Es la salida del usuario cuando corrige su RFC o su código postal: sin esto
+   * dependería de soporte para recuperar una factura que ya pagó.
+   */
+  async retryCfdi(userId: string, invoiceId: string): Promise<CfdiDto> {
+    if (!this.stripe) {
+      throw new BadRequestException('Billing system not configured');
+    }
+
+    const user = await this.firestoreService.getUserById(userId);
+
+    let invoice: Stripe.Invoice;
+    try {
+      invoice = await this.stripe.invoices.retrieve(invoiceId);
+    } catch (error) {
+      if (error?.code === 'resource_missing') {
+        throw new NotFoundException('Invoice not found');
+      }
+      throw error;
+    }
+
+    if (
+      !user?.stripeCustomerId ||
+      (invoice.customer as string) !== user.stripeCustomerId
+    ) {
+      throw new ForbiddenException('Invoice does not belong to this user');
+    }
+
+    const record = await this.firestoreService.getCfdiByInvoiceId(invoiceId);
+
+    // Reintentar uno ya timbrado emitiría un duplicado, que solo se deshace
+    // cancelándolo a mano ante el SAT.
+    if (record && record.status !== 'failed') {
+      throw new BadRequestException({
+        error: ErrorCodes.INVALID_INPUT,
+        message: `CFDI is not in a retryable state (${record.status})`,
+      });
+    }
+
+    try {
+      const updated = await this.cfdiService.retry(invoice, user);
+      return this.toCfdiDto(updated);
+    } catch (error) {
+      const code =
+        error instanceof FacturamaError ? error.code : CfdiErrorCodes.UNKNOWN;
+
+      // 422: la petición era válida, pero el PAC volvió a rechazar el contenido.
+      // El `code` viaja igual que en el fallo original para que el frontend lo
+      // explique con el mismo diccionario.
+      throw new UnprocessableEntityException({
+        error: ErrorCodes.INVALID_INPUT,
+        message: error?.message ?? 'CFDI stamping failed',
+        cfdiError: {
+          code,
+          message: error?.message ?? 'CFDI stamping failed',
+        },
+      });
     }
   }
 

--- a/src/modules/billing/cfdi.service.spec.ts
+++ b/src/modules/billing/cfdi.service.spec.ts
@@ -21,6 +21,8 @@ describe('CfdiService', () => {
       downloadPdf?: jest.Mock;
       downloadXml?: jest.Mock;
       paymentIntentsRetrieve?: jest.Mock;
+      invoicePaymentsList?: jest.Mock;
+      previousAttempts?: number;
     } = {},
   ) {
     const updates: Record<string, unknown>[] = [];
@@ -35,7 +37,9 @@ describe('CfdiService', () => {
     const reserveCfdi = jest
       .fn()
       .mockResolvedValue(
-        overrides.reserved === false ? null : { status: 'pending' },
+        overrides.reserved === false
+          ? null
+          : { status: 'pending', attempts: overrides.previousAttempts ?? 0 },
       );
 
     const firestoreService = {
@@ -87,6 +91,9 @@ describe('CfdiService', () => {
 
     const paymentIntentsRetrieve =
       overrides.paymentIntentsRetrieve ?? jest.fn().mockResolvedValue({});
+    const invoicePaymentsList =
+      overrides.invoicePaymentsList ??
+      jest.fn().mockResolvedValue({ data: [] });
 
     const service = Object.create(CfdiService.prototype) as CfdiService;
     Object.assign(service, {
@@ -94,7 +101,10 @@ describe('CfdiService', () => {
       firestoreService,
       facturamaService,
       storageService,
-      stripe: { paymentIntents: { retrieve: paymentIntentsRetrieve } },
+      stripe: {
+        paymentIntents: { retrieve: paymentIntentsRetrieve },
+        invoicePayments: { list: invoicePaymentsList },
+      },
     });
 
     return {
@@ -105,6 +115,7 @@ describe('CfdiService', () => {
       stampSubscription,
       reserveCfdi,
       paymentIntentsRetrieve,
+      invoicePaymentsList,
       updates,
     };
   }
@@ -276,7 +287,7 @@ describe('CfdiService', () => {
 
     it('cuenta los intentos acumulados sobre un CFDI ya fallido', async () => {
       const { service, updates } = buildService({
-        existingCfdi: { attempts: 2, status: 'failed' },
+        previousAttempts: 2,
         stampSubscription: jest
           .fn()
           .mockRejectedValue(
@@ -396,36 +407,82 @@ describe('CfdiService', () => {
       expect(description).toContain('periodo');
     });
 
-    it('usa la forma de pago de débito cuando Stripe la informa', async () => {
+    /**
+     * Desde la API `2025-03-31.basil`, `Invoice` ya no lleva `payment_intent` en
+     * el nivel superior: los cobros viven en `payments`, una lista de
+     * InvoicePayment. Leer el campo viejo devolvía `undefined` siempre y toda
+     * tarjeta de débito se habría timbrado como crédito.
+     */
+    function invoiceWithPayments(payments: unknown[]): Partial<Stripe.Invoice> {
+      return {
+        payments: { data: payments },
+      } as unknown as Partial<Stripe.Invoice>;
+    }
+
+    function paymentEntry(
+      intent: unknown,
+      status = 'paid',
+    ): Record<string, unknown> {
+      return {
+        status,
+        payment: { type: 'payment_intent', payment_intent: intent },
+      };
+    }
+
+    it('lee el intent expandido dentro de invoice.payments', async () => {
       const { service, stampSubscription } = buildService();
 
       await service.stampForInvoice(
-        invoice({
-          payment_intent: {
-            payment_method: { card: { funding: 'debit' } },
-          },
-        } as unknown as Partial<Stripe.Invoice>),
+        invoice(
+          invoiceWithPayments([
+            paymentEntry({
+              id: 'pi_123',
+              payment_method: { card: { funding: 'debit' } },
+            }),
+          ]),
+        ),
       );
 
       expect(stampSubscription.mock.calls[0][0].paymentForm).toBe('28');
     });
 
-    it('recupera el intent de Stripe cuando llega como id', async () => {
+    it('ignora los intentos fallidos y usa el cobro que sí pasó', async () => {
       const retrieve = jest.fn().mockResolvedValue({
         payment_method: { card: { funding: 'debit' } },
       });
-      const { service, stampSubscription } = buildService({
-        paymentIntentsRetrieve: retrieve,
-      });
+      const { service } = buildService({ paymentIntentsRetrieve: retrieve });
 
-      // En el webhook `payment_intent` llega SIEMPRE como id sin expandir. Sin
-      // esta llamada, todo cobro con débito se timbraría con FormaPago 04.
       await service.stampForInvoice(
-        invoice({
-          payment_intent: 'pi_123',
-        } as unknown as Partial<Stripe.Invoice>),
+        invoice(
+          invoiceWithPayments([
+            paymentEntry('pi_fallido', 'canceled'),
+            paymentEntry('pi_bueno', 'paid'),
+          ]),
+        ),
       );
 
+      // El que describe fiscalmente la operación es el que cobró.
+      expect(retrieve).toHaveBeenCalledWith('pi_bueno', {
+        expand: ['payment_method'],
+      });
+    });
+
+    it('lista los pagos cuando la factura del webhook no los trae', async () => {
+      const retrieve = jest.fn().mockResolvedValue({
+        payment_method: { card: { funding: 'debit' } },
+      });
+      const list = jest
+        .fn()
+        .mockResolvedValue({ data: [paymentEntry('pi_123')] });
+      const { service, stampSubscription } = buildService({
+        paymentIntentsRetrieve: retrieve,
+        invoicePaymentsList: list,
+      });
+
+      // El evento del webhook no expande `payments`.
+      await service.stampForInvoice(invoice());
+
+      expect(list).toHaveBeenCalledWith({ invoice: 'in_123', limit: 10 });
       expect(retrieve).toHaveBeenCalledWith('pi_123', {
         expand: ['payment_method'],
       });
@@ -440,9 +497,7 @@ describe('CfdiService', () => {
       });
 
       await service.stampForInvoice(
-        invoice({
-          payment_intent: 'pi_123',
-        } as unknown as Partial<Stripe.Invoice>),
+        invoice(invoiceWithPayments([paymentEntry('pi_123')])),
       );
 
       expect(stampSubscription.mock.calls[0][0].paymentForm).toBe('04');
@@ -457,9 +512,7 @@ describe('CfdiService', () => {
 
       // No saber el tipo de tarjeta no puede impedir la emisión del CFDI.
       await service.stampForInvoice(
-        invoice({
-          payment_intent: 'pi_123',
-        } as unknown as Partial<Stripe.Invoice>),
+        invoice(invoiceWithPayments([paymentEntry('pi_123')])),
       );
 
       expect(stampSubscription.mock.calls[0][0].paymentForm).toBe('04');
@@ -477,7 +530,7 @@ describe('CfdiService', () => {
       });
 
       await expect(
-        service.retry(invoice(), { id: 'uid-1', country: 'MX' } as never),
+        service.retry(invoice(), { id: 'uid-1', country: 'MX' } as never, 0),
       ).rejects.toThrow(FacturamaError);
     });
 
@@ -485,7 +538,7 @@ describe('CfdiService', () => {
       const { service } = buildService({ profile: null });
 
       await expect(
-        service.retry(invoice(), { id: 'uid-1', country: 'MX' } as never),
+        service.retry(invoice(), { id: 'uid-1', country: 'MX' } as never, 0),
       ).rejects.toMatchObject({ code: CfdiErrorCodes.INVOICE_NOT_STAMPABLE });
     });
   });

--- a/src/modules/billing/cfdi.service.spec.ts
+++ b/src/modules/billing/cfdi.service.spec.ts
@@ -20,6 +20,7 @@ describe('CfdiService', () => {
       saveFile?: jest.Mock;
       downloadPdf?: jest.Mock;
       downloadXml?: jest.Mock;
+      paymentIntentsRetrieve?: jest.Mock;
     } = {},
   ) {
     const updates: Record<string, unknown>[] = [];
@@ -84,12 +85,16 @@ describe('CfdiService', () => {
       saveFile: overrides.saveFile ?? jest.fn().mockResolvedValue(undefined),
     };
 
+    const paymentIntentsRetrieve =
+      overrides.paymentIntentsRetrieve ?? jest.fn().mockResolvedValue({});
+
     const service = Object.create(CfdiService.prototype) as CfdiService;
     Object.assign(service, {
       logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
       firestoreService,
       facturamaService,
       storageService,
+      stripe: { paymentIntents: { retrieve: paymentIntentsRetrieve } },
     });
 
     return {
@@ -99,6 +104,7 @@ describe('CfdiService', () => {
       storageService,
       stampSubscription,
       reserveCfdi,
+      paymentIntentsRetrieve,
       updates,
     };
   }
@@ -301,9 +307,11 @@ describe('CfdiService', () => {
         expect.any(Buffer),
         'application/xml',
       );
-      expect(updates[0]).toMatchObject({
-        status: 'stamped',
-        uuid: 'UUID-1',
+
+      // El estado timbrado se escribe ANTES de archivar, y las rutas después:
+      // así el UUID pasa el menor tiempo posible viviendo solo en memoria.
+      expect(updates[0]).toMatchObject({ status: 'stamped', uuid: 'UUID-1' });
+      expect(updates[1]).toEqual({
         pdfPath: 'cfdis/uid-1/in_123.pdf',
         xmlPath: 'cfdis/uid-1/in_123.xml',
       });
@@ -319,7 +327,61 @@ describe('CfdiService', () => {
       // El comprobante ya existe ante el SAT. Marcarlo failed llevaría a emitir
       // un duplicado al reintentar; solo se pierden los enlaces de descarga.
       expect(updates[0]).toMatchObject({ status: 'stamped', uuid: 'UUID-1' });
-      expect(updates[0].pdfPath).toBeUndefined();
+      expect(updates).toHaveLength(1);
+    });
+  });
+
+  /**
+   * Un fallo posterior al timbrado ocurre con un comprobante que YA existe ante
+   * el SAT. Marcarlo `failed` sería mentir de la peor forma: habilita un
+   * reintento que emitiría un duplicado, y un duplicado no se borra.
+   */
+  describe('fallo parcial: timbrado bien, persistencia mal', () => {
+    function buildFlakyService(updateBehaviour: jest.Mock) {
+      const base = buildService();
+      Object.assign(base.service, {
+        firestoreService: {
+          ...base.firestoreService,
+          updateCfdi: updateBehaviour,
+        },
+      });
+      return base;
+    }
+
+    it('nunca marca failed si el PAC ya timbró', async () => {
+      const updateCfdi = jest
+        .fn()
+        .mockRejectedValue(new Error('Firestore no disponible'));
+      const { service } = buildFlakyService(updateCfdi);
+
+      await service.stampForInvoice(invoice());
+
+      const escrituras = updateCfdi.mock.calls.map((call) => call[1]);
+      expect(escrituras.every((data) => data.status !== 'failed')).toBe(true);
+    });
+
+    it('reintenta la escritura del UUID antes de rendirse', async () => {
+      const updateCfdi = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('transitorio'))
+        .mockResolvedValue(undefined);
+      const { service } = buildFlakyService(updateCfdi);
+
+      await service.stampForInvoice(invoice());
+
+      // Perder el UUID es lo único con consecuencia fiscal irreversible.
+      expect(updateCfdi.mock.calls[1][1]).toMatchObject({
+        status: 'stamped',
+        uuid: 'UUID-1',
+      });
+    });
+
+    it('no propaga el fallo de persistencia al webhook', async () => {
+      const { service } = buildFlakyService(
+        jest.fn().mockRejectedValue(new Error('Firestore no disponible')),
+      );
+
+      await expect(service.stampForInvoice(invoice())).resolves.toBeUndefined();
     });
   });
 
@@ -348,10 +410,52 @@ describe('CfdiService', () => {
       expect(stampSubscription.mock.calls[0][0].paymentForm).toBe('28');
     });
 
-    it('cae a tarjeta de crédito cuando no puede saberlo', async () => {
-      const { service, stampSubscription } = buildService();
+    it('recupera el intent de Stripe cuando llega como id', async () => {
+      const retrieve = jest.fn().mockResolvedValue({
+        payment_method: { card: { funding: 'debit' } },
+      });
+      const { service, stampSubscription } = buildService({
+        paymentIntentsRetrieve: retrieve,
+      });
 
-      // En el webhook `payment_intent` llega como id sin expandir.
+      // En el webhook `payment_intent` llega SIEMPRE como id sin expandir. Sin
+      // esta llamada, todo cobro con débito se timbraría con FormaPago 04.
+      await service.stampForInvoice(
+        invoice({
+          payment_intent: 'pi_123',
+        } as unknown as Partial<Stripe.Invoice>),
+      );
+
+      expect(retrieve).toHaveBeenCalledWith('pi_123', {
+        expand: ['payment_method'],
+      });
+      expect(stampSubscription.mock.calls[0][0].paymentForm).toBe('28');
+    });
+
+    it('timbra crédito cuando la tarjeta es de crédito', async () => {
+      const { service, stampSubscription } = buildService({
+        paymentIntentsRetrieve: jest.fn().mockResolvedValue({
+          payment_method: { card: { funding: 'credit' } },
+        }),
+      });
+
+      await service.stampForInvoice(
+        invoice({
+          payment_intent: 'pi_123',
+        } as unknown as Partial<Stripe.Invoice>),
+      );
+
+      expect(stampSubscription.mock.calls[0][0].paymentForm).toBe('04');
+    });
+
+    it('timbra igualmente si no se puede consultar el método de pago', async () => {
+      const { service, stampSubscription } = buildService({
+        paymentIntentsRetrieve: jest
+          .fn()
+          .mockRejectedValue(new Error('Stripe caído')),
+      });
+
+      // No saber el tipo de tarjeta no puede impedir la emisión del CFDI.
       await service.stampForInvoice(
         invoice({
           payment_intent: 'pi_123',

--- a/src/modules/billing/cfdi.service.spec.ts
+++ b/src/modules/billing/cfdi.service.spec.ts
@@ -1,0 +1,388 @@
+import type Stripe from 'stripe';
+import { CfdiService } from './cfdi.service.js';
+import { CfdiErrorCodes } from '../facturama/facturama.constants.js';
+import { FacturamaError } from '../facturama/interfaces/facturama.interface.js';
+
+/**
+ * El timbrado corre dentro de un webhook de Stripe, y eso impone dos reglas que
+ * no son negociables: no puede lanzar —Stripe reintentaría el evento— y no puede
+ * emitir dos veces el mismo comprobante, porque un CFDI duplicado no se borra,
+ * se cancela a mano ante el SAT.
+ */
+describe('CfdiService', () => {
+  function buildService(
+    overrides: {
+      user?: Record<string, unknown> | null;
+      profile?: Record<string, unknown> | null;
+      reserved?: boolean;
+      stampSubscription?: jest.Mock;
+      existingCfdi?: Record<string, unknown> | null;
+      saveFile?: jest.Mock;
+      downloadPdf?: jest.Mock;
+      downloadXml?: jest.Mock;
+    } = {},
+  ) {
+    const updates: Record<string, unknown>[] = [];
+    const stampSubscription =
+      overrides.stampSubscription ??
+      jest.fn().mockResolvedValue({
+        facturamaId: 'cfdi_123',
+        uuid: 'UUID-1',
+        stampedAt: new Date('2026-08-04T12:00:00.000Z'),
+      });
+
+    const reserveCfdi = jest
+      .fn()
+      .mockResolvedValue(
+        overrides.reserved === false ? null : { status: 'pending' },
+      );
+
+    const firestoreService = {
+      getUserByStripeCustomerId: jest
+        .fn()
+        .mockResolvedValue(
+          overrides.user === undefined
+            ? { id: 'uid-1', country: 'MX', plan: 'pro' }
+            : overrides.user,
+        ),
+      getTaxProfile: jest.fn().mockResolvedValue(
+        overrides.profile === undefined
+          ? {
+              type: 'mx',
+              isComplete: true,
+              rfc: 'ABC010101AB1',
+              legalName: 'EMPRESA DEMO',
+              cfdiUse: 'G03',
+              taxRegime: '601',
+              postalCode: '97000',
+            }
+          : overrides.profile,
+      ),
+      reserveCfdi,
+      getCfdiByInvoiceId: jest
+        .fn()
+        .mockResolvedValue(overrides.existingCfdi ?? null),
+      updateCfdi: jest
+        .fn()
+        .mockImplementation((_id: string, data: Record<string, unknown>) => {
+          updates.push(data);
+          return Promise.resolve();
+        }),
+    };
+
+    const facturamaService = {
+      stampSubscription,
+      downloadPdf:
+        overrides.downloadPdf ??
+        jest.fn().mockResolvedValue(Buffer.from('pdf')),
+      downloadXml:
+        overrides.downloadXml ??
+        jest.fn().mockResolvedValue(Buffer.from('xml')),
+    };
+
+    const storageService = {
+      saveFile: overrides.saveFile ?? jest.fn().mockResolvedValue(undefined),
+    };
+
+    const service = Object.create(CfdiService.prototype) as CfdiService;
+    Object.assign(service, {
+      logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+      firestoreService,
+      facturamaService,
+      storageService,
+    });
+
+    return {
+      service,
+      firestoreService,
+      facturamaService,
+      storageService,
+      stampSubscription,
+      reserveCfdi,
+      updates,
+    };
+  }
+
+  function invoice(overrides: Partial<Stripe.Invoice> = {}): Stripe.Invoice {
+    return {
+      id: 'in_123',
+      customer: 'cus_123',
+      amount_paid: 19900,
+      currency: 'mxn',
+      period_start: 1754006400,
+      period_end: 1756684800,
+      status_transitions: { paid_at: Math.floor(Date.now() / 1000) },
+      lines: { data: [] },
+      ...overrides,
+    } as unknown as Stripe.Invoice;
+  }
+
+  describe('a quién se le timbra', () => {
+    it('timbra a un usuario mexicano con perfil completo', async () => {
+      const { service, stampSubscription } = buildService();
+
+      await service.stampForInvoice(invoice());
+
+      expect(stampSubscription).toHaveBeenCalledWith(
+        expect.objectContaining({
+          total: 199,
+          currency: 'mxn',
+          receiver: expect.objectContaining({ Rfc: 'ABC010101AB1' }),
+        }),
+      );
+    });
+
+    it('timbra el primer cobro, que handleInvoicePaid descarta', async () => {
+      const { service, stampSubscription } = buildService();
+
+      // `billing_reason: 'subscription_create'` no llega a handleInvoicePaid
+      // porque el alta la resuelve checkout.session.completed. Fiscalmente sí
+      // hay que facturarlo: es el primer cobro del cliente.
+      await service.stampForInvoice(
+        invoice({
+          billing_reason: 'subscription_create',
+        } as Partial<Stripe.Invoice>),
+      );
+
+      expect(stampSubscription).toHaveBeenCalled();
+    });
+
+    it('no timbra a un usuario no mexicano', async () => {
+      const { service, stampSubscription } = buildService({
+        user: { id: 'uid-1', country: 'ES', plan: 'pro' },
+      });
+
+      await service.stampForInvoice(invoice());
+
+      expect(stampSubscription).not.toHaveBeenCalled();
+    });
+
+    it('no timbra sin perfil fiscal completo', async () => {
+      const { service, stampSubscription } = buildService({
+        profile: { type: 'mx', isComplete: false },
+      });
+
+      await service.stampForInvoice(invoice());
+
+      expect(stampSubscription).not.toHaveBeenCalled();
+    });
+
+    it('no timbra una factura de importe cero', async () => {
+      const { service, stampSubscription, reserveCfdi } = buildService();
+
+      // Cupón al 100 % o periodo de prueba: no ampara ningún ingreso.
+      await service.stampForInvoice(invoice({ amount_paid: 0 }));
+
+      expect(stampSubscription).not.toHaveBeenCalled();
+      expect(reserveCfdi).not.toHaveBeenCalled();
+    });
+
+    it('no timbra si el customer no corresponde a ningún usuario', async () => {
+      const { service, stampSubscription } = buildService({ user: null });
+
+      await service.stampForInvoice(invoice());
+
+      expect(stampSubscription).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('idempotencia', () => {
+    it('no timbra dos veces la misma factura', async () => {
+      const { service, stampSubscription } = buildService({ reserved: false });
+
+      // La reserva ya la tiene otra entrega del mismo webhook.
+      await service.stampForInvoice(invoice());
+
+      expect(stampSubscription).not.toHaveBeenCalled();
+    });
+
+    it('reserva usando el id de la factura de Stripe como clave', async () => {
+      const { service, reserveCfdi } = buildService();
+
+      await service.stampForInvoice(invoice());
+
+      expect(reserveCfdi).toHaveBeenCalledWith(
+        expect.objectContaining({ stripeInvoiceId: 'in_123', userId: 'uid-1' }),
+      );
+    });
+  });
+
+  describe('fallos', () => {
+    it('no propaga el error del PAC: el webhook debe responder 200', async () => {
+      const { service } = buildService({
+        stampSubscription: jest
+          .fn()
+          .mockRejectedValue(
+            new FacturamaError(CfdiErrorCodes.RFC_NOT_FOUND, 'RFC no inscrito'),
+          ),
+      });
+
+      await expect(service.stampForInvoice(invoice())).resolves.toBeUndefined();
+    });
+
+    it('guarda el código estable del rechazo', async () => {
+      const { service, updates } = buildService({
+        stampSubscription: jest
+          .fn()
+          .mockRejectedValue(
+            new FacturamaError(
+              CfdiErrorCodes.NAME_MISMATCH,
+              'Nombre no coincide',
+            ),
+          ),
+      });
+
+      await service.stampForInvoice(invoice());
+
+      expect(updates[0]).toMatchObject({
+        status: 'failed',
+        error: { code: CfdiErrorCodes.NAME_MISMATCH },
+        attempts: 1,
+      });
+    });
+
+    it('clasifica como unknown un error que no viene del PAC', async () => {
+      const { service, updates } = buildService({
+        stampSubscription: jest.fn().mockRejectedValue(new Error('boom')),
+      });
+
+      await service.stampForInvoice(invoice());
+
+      expect(updates[0]).toMatchObject({
+        status: 'failed',
+        error: { code: CfdiErrorCodes.UNKNOWN },
+      });
+    });
+
+    it('no timbra un cobro en divisa distinta de MXN', async () => {
+      const { service, stampSubscription, updates } = buildService();
+
+      await service.stampForInvoice(invoice({ currency: 'usd' }));
+
+      // Emitirlo como si fueran pesos declararía un importe que no es el
+      // cobrado; hacerlo en USD exigiría TipoCambio.
+      expect(stampSubscription).not.toHaveBeenCalled();
+      expect(updates[0]).toMatchObject({
+        status: 'failed',
+        error: { code: CfdiErrorCodes.INVOICE_NOT_STAMPABLE },
+      });
+    });
+
+    it('cuenta los intentos acumulados sobre un CFDI ya fallido', async () => {
+      const { service, updates } = buildService({
+        existingCfdi: { attempts: 2, status: 'failed' },
+        stampSubscription: jest
+          .fn()
+          .mockRejectedValue(
+            new FacturamaError(CfdiErrorCodes.PAC_UNAVAILABLE, 'caído'),
+          ),
+      });
+
+      await service.stampForInvoice(invoice());
+
+      expect(updates[0]).toMatchObject({ attempts: 3 });
+    });
+  });
+
+  describe('archivado del comprobante', () => {
+    it('guarda PDF y XML en Storage y registra sus rutas', async () => {
+      const saveFile = jest.fn().mockResolvedValue(undefined);
+      const { service, updates } = buildService({ saveFile });
+
+      await service.stampForInvoice(invoice());
+
+      expect(saveFile).toHaveBeenCalledWith(
+        'cfdis/uid-1/in_123.pdf',
+        expect.any(Buffer),
+        'application/pdf',
+      );
+      expect(saveFile).toHaveBeenCalledWith(
+        'cfdis/uid-1/in_123.xml',
+        expect.any(Buffer),
+        'application/xml',
+      );
+      expect(updates[0]).toMatchObject({
+        status: 'stamped',
+        uuid: 'UUID-1',
+        pdfPath: 'cfdis/uid-1/in_123.pdf',
+        xmlPath: 'cfdis/uid-1/in_123.xml',
+      });
+    });
+
+    it('deja el CFDI como stamped aunque falle el archivado', async () => {
+      const { service, updates } = buildService({
+        saveFile: jest.fn().mockRejectedValue(new Error('bucket caído')),
+      });
+
+      await service.stampForInvoice(invoice());
+
+      // El comprobante ya existe ante el SAT. Marcarlo failed llevaría a emitir
+      // un duplicado al reintentar; solo se pierden los enlaces de descarga.
+      expect(updates[0]).toMatchObject({ status: 'stamped', uuid: 'UUID-1' });
+      expect(updates[0].pdfPath).toBeUndefined();
+    });
+  });
+
+  describe('datos del comprobante', () => {
+    it('describe el plan y el periodo facturado', async () => {
+      const { service, stampSubscription } = buildService();
+
+      await service.stampForInvoice(invoice());
+
+      const { description } = stampSubscription.mock.calls[0][0];
+      expect(description).toContain('Plan PRO');
+      expect(description).toContain('periodo');
+    });
+
+    it('usa la forma de pago de débito cuando Stripe la informa', async () => {
+      const { service, stampSubscription } = buildService();
+
+      await service.stampForInvoice(
+        invoice({
+          payment_intent: {
+            payment_method: { card: { funding: 'debit' } },
+          },
+        } as unknown as Partial<Stripe.Invoice>),
+      );
+
+      expect(stampSubscription.mock.calls[0][0].paymentForm).toBe('28');
+    });
+
+    it('cae a tarjeta de crédito cuando no puede saberlo', async () => {
+      const { service, stampSubscription } = buildService();
+
+      // En el webhook `payment_intent` llega como id sin expandir.
+      await service.stampForInvoice(
+        invoice({
+          payment_intent: 'pi_123',
+        } as unknown as Partial<Stripe.Invoice>),
+      );
+
+      expect(stampSubscription.mock.calls[0][0].paymentForm).toBe('04');
+    });
+  });
+
+  describe('retry', () => {
+    it('propaga el error para que el usuario sepa si su corrección funcionó', async () => {
+      const { service } = buildService({
+        stampSubscription: jest
+          .fn()
+          .mockRejectedValue(
+            new FacturamaError(CfdiErrorCodes.RFC_NOT_FOUND, 'sigue mal'),
+          ),
+      });
+
+      await expect(
+        service.retry(invoice(), { id: 'uid-1', country: 'MX' } as never),
+      ).rejects.toThrow(FacturamaError);
+    });
+
+    it('rechaza el reintento si el perfil fiscal está incompleto', async () => {
+      const { service } = buildService({ profile: null });
+
+      await expect(
+        service.retry(invoice(), { id: 'uid-1', country: 'MX' } as never),
+      ).rejects.toMatchObject({ code: CfdiErrorCodes.INVOICE_NOT_STAMPABLE });
+    });
+  });
+});

--- a/src/modules/billing/cfdi.service.spec.ts
+++ b/src/modules/billing/cfdi.service.spec.ts
@@ -530,16 +530,46 @@ describe('CfdiService', () => {
       });
 
       await expect(
-        service.retry(invoice(), { id: 'uid-1', country: 'MX' } as never, 0),
+        service.retry(
+          invoice(),
+          { id: 'uid-1', country: 'MX' } as never,
+          {
+            type: 'mx',
+            isComplete: true,
+            rfc: 'ABC010101AB1',
+            legalName: 'EMPRESA DEMO',
+            cfdiUse: 'G03',
+            taxRegime: '601',
+            postalCode: '97000',
+          } as never,
+          0,
+        ),
       ).rejects.toThrow(FacturamaError);
     });
 
-    it('rechaza el reintento si el perfil fiscal está incompleto', async () => {
-      const { service } = buildService({ profile: null });
+    it('no relee el perfil: lo recibe ya validado de quien tomó el candado', async () => {
+      const { service, firestoreService } = buildService();
+      firestoreService.getTaxProfile.mockClear();
 
-      await expect(
-        service.retry(invoice(), { id: 'uid-1', country: 'MX' } as never, 0),
-      ).rejects.toMatchObject({ code: CfdiErrorCodes.INVOICE_NOT_STAMPABLE });
+      await service.retry(
+        invoice(),
+        { id: 'uid-1', country: 'MX' } as never,
+        {
+          type: 'mx',
+          isComplete: true,
+          rfc: 'ABC010101AB1',
+          legalName: 'EMPRESA DEMO',
+          cfdiUse: 'G03',
+          taxRegime: '601',
+          postalCode: '97000',
+        } as never,
+        0,
+      );
+
+      // Entre el candado y el PAC no puede quedar ninguna lectura que falle: el
+      // documento ya está en `pending` y un error ahí lo dejaría clavado,
+      // bloqueando todos los reintentos posteriores.
+      expect(firestoreService.getTaxProfile).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/billing/cfdi.service.ts
+++ b/src/modules/billing/cfdi.service.ts
@@ -1,0 +1,340 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type Stripe from 'stripe';
+import { FirestoreService } from '../cache/firestore.service.js';
+import { StorageService } from '../storage/storage.service.js';
+import { FacturamaService } from '../facturama/facturama.service.js';
+import {
+  CFDI_PAYMENT_FORM_CREDIT_CARD,
+  CFDI_PAYMENT_FORM_DEBIT_CARD,
+  CfdiErrorCodes,
+  type CfdiErrorCode,
+} from '../facturama/facturama.constants.js';
+import { FacturamaError } from '../facturama/interfaces/facturama.interface.js';
+import type { Cfdi } from '../../common/interfaces/cfdi.interface.js';
+import type { TaxProfile } from '../../common/interfaces/tax-profile.interface.js';
+import type { User } from '../../common/interfaces/user.interface.js';
+
+/**
+ * Emisión de CFDI 4.0 por los cobros de suscripción.
+ *
+ * Vive separado de `FacturamaService` a propósito: aquel es el cliente HTTP del
+ * PAC y este decide *si* un cobro lleva comprobante, con qué datos, y qué hacer
+ * cuando el timbrado falla.
+ */
+@Injectable()
+export class CfdiService {
+  private readonly logger = new Logger(CfdiService.name);
+
+  constructor(
+    private readonly firestoreService: FirestoreService,
+    private readonly facturamaService: FacturamaService,
+    private readonly storageService: StorageService,
+  ) {}
+
+  /**
+   * Timbra el CFDI de una factura pagada. **Nunca lanza.**
+   *
+   * Se invoca desde el webhook de Stripe, que debe responder 200 pase lo que
+   * pase: un rechazo del PAC no puede reintentar el evento ni tocar el estado de
+   * la suscripción. El fallo se persiste con su código y el usuario lo reintenta
+   * desde la app cuando corrige sus datos.
+   */
+  async stampForInvoice(invoice: Stripe.Invoice): Promise<void> {
+    try {
+      await this.stampForInvoiceOrThrow(invoice);
+    } catch (error) {
+      this.logger.error(
+        `Error no controlado timbrando la factura ${invoice?.id}: ${error?.message}`,
+        error?.stack,
+      );
+    }
+  }
+
+  private async stampForInvoiceOrThrow(invoice: Stripe.Invoice): Promise<void> {
+    const stripeInvoiceId = invoice.id;
+    const amountPaid = invoice.amount_paid ?? 0;
+
+    // Una factura de importe cero (cupón al 100 %, prueba gratuita) no ampara
+    // ningún ingreso y no se comprueba fiscalmente.
+    if (amountPaid <= 0) {
+      return;
+    }
+
+    const customerId = invoice.customer as string;
+    const user =
+      await this.firestoreService.getUserByStripeCustomerId(customerId);
+
+    if (!user) {
+      this.logger.warn(
+        `Factura ${stripeInvoiceId} sin usuario asociado al customer ${customerId}; no se timbra`,
+      );
+      return;
+    }
+
+    if (user.country?.toUpperCase() !== 'MX') {
+      // El resto del mundo se factura con el PDF de Stripe, que ya lleva los
+      // datos fiscales del perfil.
+      return;
+    }
+
+    const profile = await this.firestoreService.getTaxProfile(user.id);
+
+    if (!profile?.isComplete || profile.type !== 'mx') {
+      this.logger.log(
+        `Usuario ${user.id} sin perfil fiscal completo; la factura ${stripeInvoiceId} queda sin CFDI`,
+      );
+      return;
+    }
+
+    const amount = amountPaid / 100;
+    const currency = (invoice.currency || 'mxn').toLowerCase();
+
+    // La reserva es el candado de idempotencia: si otro intento ya la tiene, no
+    // se timbra por segunda vez.
+    const reserved = await this.firestoreService.reserveCfdi({
+      stripeInvoiceId,
+      userId: user.id,
+      amount,
+      currency,
+    });
+
+    if (!reserved) {
+      return;
+    }
+
+    await this.stamp(invoice, user, profile, { amount, currency });
+  }
+
+  /**
+   * Reintenta el timbrado de un CFDI que quedó en `failed`.
+   *
+   * A diferencia de `stampForInvoice`, aquí sí se propaga el error: hay un
+   * usuario esperando la respuesta y necesita saber si su corrección funcionó.
+   */
+  async retry(invoice: Stripe.Invoice, user: User): Promise<Cfdi> {
+    const profile = await this.firestoreService.getTaxProfile(user.id);
+
+    if (!profile?.isComplete || profile.type !== 'mx') {
+      throw new FacturamaError(
+        CfdiErrorCodes.INVOICE_NOT_STAMPABLE,
+        'El perfil fiscal está incompleto',
+      );
+    }
+
+    await this.stamp(
+      invoice,
+      user,
+      profile,
+      {
+        amount: (invoice.amount_paid ?? 0) / 100,
+        currency: (invoice.currency || 'mxn').toLowerCase(),
+      },
+      { rethrow: true },
+    );
+
+    return this.firestoreService.getCfdiByInvoiceId(invoice.id);
+  }
+
+  /**
+   * Timbra y persiste el resultado.
+   *
+   * El PDF y el XML se copian a Cloud Storage porque el comprobante debe
+   * conservarse cinco años y depender del PAC para siempre es una dependencia
+   * que no controlamos. Que esa copia falle no invalida el CFDI: ya está
+   * timbrado ante el SAT, así que se registra igualmente como `stamped` y solo
+   * se pierden los enlaces de descarga.
+   */
+  private async stamp(
+    invoice: Stripe.Invoice,
+    user: User,
+    profile: TaxProfile,
+    money: { amount: number; currency: string },
+    options: { rethrow?: boolean } = {},
+  ): Promise<void> {
+    const stripeInvoiceId = invoice.id;
+    const existing =
+      await this.firestoreService.getCfdiByInvoiceId(stripeInvoiceId);
+    const attempts = (existing?.attempts ?? 0) + 1;
+
+    // Los precios en MXN son finales y el CFDI los desglosa hacia atrás. Un
+    // cobro en otra divisa necesitaría TipoCambio, y emitirlo como si fuera
+    // pesos declararía un importe que no es el cobrado.
+    if (money.currency !== 'mxn') {
+      const message = `El cobro se hizo en ${money.currency.toUpperCase()} y el CFDI solo se emite en MXN`;
+      this.logger.error(
+        `Factura ${stripeInvoiceId} del usuario ${user.id}: ${message}`,
+      );
+      await this.persistFailure(
+        stripeInvoiceId,
+        attempts,
+        CfdiErrorCodes.INVOICE_NOT_STAMPABLE,
+        message,
+      );
+      if (options.rethrow) {
+        throw new FacturamaError(CfdiErrorCodes.INVOICE_NOT_STAMPABLE, message);
+      }
+      return;
+    }
+
+    try {
+      const result = await this.facturamaService.stampSubscription({
+        receiver: {
+          Rfc: profile.rfc,
+          Name: profile.legalName,
+          CfdiUse: profile.cfdiUse,
+          FiscalRegime: profile.taxRegime,
+          TaxZipCode: profile.postalCode,
+        },
+        total: money.amount,
+        currency: money.currency,
+        description: this.buildDescription(invoice, user),
+        paymentForm: this.resolvePaymentForm(invoice),
+        chargedAt: this.resolveChargedAt(invoice),
+      });
+
+      const paths = await this.archiveDocuments(
+        result.facturamaId,
+        user.id,
+        stripeInvoiceId,
+      );
+
+      await this.firestoreService.updateCfdi(stripeInvoiceId, {
+        status: 'stamped',
+        uuid: result.uuid,
+        facturamaId: result.facturamaId,
+        stampedAt: result.stampedAt,
+        attempts,
+        error: null,
+        userId: user.id,
+        amount: money.amount,
+        currency: money.currency,
+        ...paths,
+      });
+
+      this.logger.log(
+        `CFDI timbrado para la factura ${stripeInvoiceId} (usuario ${user.id}): ${result.uuid}`,
+      );
+    } catch (error) {
+      const code =
+        error instanceof FacturamaError ? error.code : CfdiErrorCodes.UNKNOWN;
+      const message =
+        error instanceof Error ? error.message : 'Error desconocido';
+
+      this.logger.error(
+        `Fallo al timbrar la factura ${stripeInvoiceId} (usuario ${user.id}) [${code}]: ${message}`,
+      );
+
+      await this.persistFailure(stripeInvoiceId, attempts, code, message);
+
+      if (options.rethrow) {
+        throw error;
+      }
+    }
+  }
+
+  private async persistFailure(
+    stripeInvoiceId: string,
+    attempts: number,
+    code: CfdiErrorCode,
+    message: string,
+  ): Promise<void> {
+    await this.firestoreService.updateCfdi(stripeInvoiceId, {
+      status: 'failed',
+      attempts,
+      error: { code, message },
+    });
+  }
+
+  /**
+   * Copia el PDF y el XML a Cloud Storage.
+   *
+   * Devuelve las rutas guardadas, o un objeto vacío si la copia falla: el
+   * comprobante ya existe ante el SAT y perder los enlaces es recuperable, marcar
+   * el CFDI como fallido cuando sí se timbró no lo es —llevaría a emitir un
+   * duplicado al reintentar.
+   */
+  private async archiveDocuments(
+    facturamaId: string,
+    userId: string,
+    stripeInvoiceId: string,
+  ): Promise<{ pdfPath?: string; xmlPath?: string }> {
+    try {
+      const [pdf, xml] = await Promise.all([
+        this.facturamaService.downloadPdf(facturamaId),
+        this.facturamaService.downloadXml(facturamaId),
+      ]);
+
+      const pdfPath = `cfdis/${userId}/${stripeInvoiceId}.pdf`;
+      const xmlPath = `cfdis/${userId}/${stripeInvoiceId}.xml`;
+
+      await Promise.all([
+        this.storageService.saveFile(pdfPath, pdf, 'application/pdf'),
+        this.storageService.saveFile(xmlPath, xml, 'application/xml'),
+      ]);
+
+      return { pdfPath, xmlPath };
+    } catch (error) {
+      this.logger.error(
+        `CFDI de ${stripeInvoiceId} timbrado, pero falló el archivado de PDF/XML: ${error.message}`,
+      );
+      return {};
+    }
+  }
+
+  /**
+   * Texto del concepto.
+   *
+   * Incluye el periodo facturado porque es lo que distingue una mensualidad de
+   * la siguiente en la contabilidad del cliente.
+   */
+  private buildDescription(invoice: Stripe.Invoice, user: User): string {
+    const plan = (user.plan || 'pro').toUpperCase();
+    const line = invoice.lines?.data?.[0];
+    const start = line?.period?.start ?? invoice.period_start;
+    const end = line?.period?.end ?? invoice.period_end;
+
+    if (!start || !end) {
+      return `Suscripción ZPLPDF Plan ${plan}`;
+    }
+
+    return `Suscripción ZPLPDF Plan ${plan} — periodo ${this.formatDate(start)} a ${this.formatDate(end)}`;
+  }
+
+  private formatDate(unixSeconds: number): string {
+    return new Date(unixSeconds * 1000).toLocaleDateString('es-MX', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      timeZone: 'America/Mexico_City',
+    });
+  }
+
+  /**
+   * Distingue tarjeta de crédito de débito en c_FormaPago.
+   *
+   * Stripe expande `payment_intent` solo bajo petición, así que en el webhook
+   * llega como id y no siempre se puede saber. Ante la duda, crédito: es la
+   * clave que el SAT acepta por defecto para un cobro con tarjeta.
+   */
+  private resolvePaymentForm(invoice: Stripe.Invoice): string {
+    const intent = (invoice as { payment_intent?: unknown }).payment_intent;
+
+    const funding =
+      typeof intent === 'object' && intent !== null
+        ? (
+            intent as {
+              payment_method?: { card?: { funding?: string } };
+            }
+          ).payment_method?.card?.funding
+        : undefined;
+
+    return funding === 'debit'
+      ? CFDI_PAYMENT_FORM_DEBIT_CARD
+      : CFDI_PAYMENT_FORM_CREDIT_CARD;
+  }
+
+  private resolveChargedAt(invoice: Stripe.Invoice): Date | undefined {
+    const paidAt = invoice.status_transitions?.paid_at;
+    return paidAt ? new Date(paidAt * 1000) : undefined;
+  }
+}

--- a/src/modules/billing/cfdi.service.ts
+++ b/src/modules/billing/cfdi.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
-import type Stripe from 'stripe';
+import { ConfigService } from '@nestjs/config';
+import Stripe from 'stripe';
 import { FirestoreService } from '../cache/firestore.service.js';
 import { StorageService } from '../storage/storage.service.js';
 import { FacturamaService } from '../facturama/facturama.service.js';
@@ -9,7 +10,10 @@ import {
   CfdiErrorCodes,
   type CfdiErrorCode,
 } from '../facturama/facturama.constants.js';
-import { FacturamaError } from '../facturama/interfaces/facturama.interface.js';
+import {
+  FacturamaError,
+  type StampResult,
+} from '../facturama/interfaces/facturama.interface.js';
 import type { Cfdi } from '../../common/interfaces/cfdi.interface.js';
 import type { TaxProfile } from '../../common/interfaces/tax-profile.interface.js';
 import type { User } from '../../common/interfaces/user.interface.js';
@@ -24,12 +28,20 @@ import type { User } from '../../common/interfaces/user.interface.js';
 @Injectable()
 export class CfdiService {
   private readonly logger = new Logger(CfdiService.name);
+  /** Solo se usa para resolver el tipo de tarjeta del cobro. */
+  private readonly stripe: Stripe | null = null;
 
   constructor(
     private readonly firestoreService: FirestoreService,
     private readonly facturamaService: FacturamaService,
     private readonly storageService: StorageService,
-  ) {}
+    private readonly configService: ConfigService,
+  ) {
+    const stripeSecretKey = this.configService.get<string>('STRIPE_SECRET_KEY');
+    if (stripeSecretKey) {
+      this.stripe = new Stripe(stripeSecretKey);
+    }
+  }
 
   /**
    * Timbra el CFDI de una factura pagada. **Nunca lanza.**
@@ -176,8 +188,12 @@ export class CfdiService {
       return;
     }
 
+    // El try cubre EXCLUSIVAMENTE la llamada al PAC. Todo lo que viene después
+    // ocurre con un comprobante ya emitido ante el SAT, y ahí `failed` es una
+    // mentira peligrosa: habilita un reintento que emitiría un duplicado.
+    let result: StampResult;
     try {
-      const result = await this.facturamaService.stampSubscription({
+      result = await this.facturamaService.stampSubscription({
         receiver: {
           Rfc: profile.rfc,
           Name: profile.legalName,
@@ -188,32 +204,9 @@ export class CfdiService {
         total: money.amount,
         currency: money.currency,
         description: this.buildDescription(invoice, user),
-        paymentForm: this.resolvePaymentForm(invoice),
+        paymentForm: await this.resolvePaymentForm(invoice),
         chargedAt: this.resolveChargedAt(invoice),
       });
-
-      const paths = await this.archiveDocuments(
-        result.facturamaId,
-        user.id,
-        stripeInvoiceId,
-      );
-
-      await this.firestoreService.updateCfdi(stripeInvoiceId, {
-        status: 'stamped',
-        uuid: result.uuid,
-        facturamaId: result.facturamaId,
-        stampedAt: result.stampedAt,
-        attempts,
-        error: null,
-        userId: user.id,
-        amount: money.amount,
-        currency: money.currency,
-        ...paths,
-      });
-
-      this.logger.log(
-        `CFDI timbrado para la factura ${stripeInvoiceId} (usuario ${user.id}): ${result.uuid}`,
-      );
     } catch (error) {
       const code =
         error instanceof FacturamaError ? error.code : CfdiErrorCodes.UNKNOWN;
@@ -228,6 +221,73 @@ export class CfdiService {
 
       if (options.rethrow) {
         throw error;
+      }
+      return;
+    }
+
+    // A partir de aquí el CFDI existe. Se registra antes de archivar nada, para
+    // que la ventana en la que el UUID solo vive en memoria sea la mínima.
+    await this.persistStamped(stripeInvoiceId, {
+      status: 'stamped',
+      uuid: result.uuid,
+      facturamaId: result.facturamaId,
+      stampedAt: result.stampedAt,
+      attempts,
+      error: null,
+      userId: user.id,
+      amount: money.amount,
+      currency: money.currency,
+    });
+
+    this.logger.log(
+      `CFDI timbrado para la factura ${stripeInvoiceId} (usuario ${user.id}): ${result.uuid}`,
+    );
+
+    const paths = await this.archiveDocuments(
+      result.facturamaId,
+      user.id,
+      stripeInvoiceId,
+    );
+
+    if (paths.pdfPath || paths.xmlPath) {
+      try {
+        await this.firestoreService.updateCfdi(stripeInvoiceId, paths);
+      } catch (error) {
+        // Solo se pierden los enlaces de descarga; el comprobante sigue en pie.
+        this.logger.error(
+          `CFDI ${result.uuid} archivado, pero no se pudieron guardar sus rutas: ${error.message}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Registra el CFDI como timbrado, reintentando la escritura.
+   *
+   * Es el único punto donde perder una escritura tiene consecuencias fiscales:
+   * el comprobante ya existe ante el SAT y el UUID solo vive en esta variable.
+   * Si aun con reintentos no se persiste, el documento se queda en `pending` —un
+   * estado que el reintento manual rechaza— y se deja constancia del UUID en el
+   * log para reconciliarlo a mano. Nunca `failed`: eso invitaría a duplicarlo.
+   */
+  private async persistStamped(
+    stripeInvoiceId: string,
+    data: Partial<Cfdi>,
+  ): Promise<void> {
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      try {
+        await this.firestoreService.updateCfdi(stripeInvoiceId, data);
+        return;
+      } catch (error) {
+        if (attempt === 3) {
+          this.logger.error(
+            `CRÍTICO: CFDI timbrado que no se pudo registrar. Factura ${stripeInvoiceId}, UUID ${data.uuid}, Facturama ${data.facturamaId}. Queda en 'pending' y necesita reconciliación manual. Último error: ${error.message}`,
+          );
+          return;
+        }
+        await new Promise((resolve) =>
+          setTimeout(resolve, 500 * Math.pow(2, attempt - 1)),
+        );
       }
     }
   }
@@ -310,27 +370,68 @@ export class CfdiService {
   }
 
   /**
-   * Distingue tarjeta de crédito de débito en c_FormaPago.
+   * Distingue tarjeta de crédito (04) de débito (28) en c_FormaPago.
    *
-   * Stripe expande `payment_intent` solo bajo petición, así que en el webhook
-   * llega como id y no siempre se puede saber. Ante la duda, crédito: es la
-   * clave que el SAT acepta por defecto para un cobro con tarjeta.
+   * En el webhook `payment_intent` llega como id sin expandir, así que mirar el
+   * objeto de la factura resolvía «crédito» siempre y todo cobro con débito se
+   * timbraba con una clave fiscal que no corresponde. Se recupera el intent
+   * expandiendo el método de pago: una llamada extra por CFDI es irrelevante al
+   * volumen de este servicio y es la única forma de saberlo.
+   *
+   * Si no se puede averiguar, crédito: es la clave habitual para un cobro con
+   * tarjeta y no hay una opción neutra en el catálogo.
    */
-  private resolvePaymentForm(invoice: Stripe.Invoice): string {
-    const intent = (invoice as { payment_intent?: unknown }).payment_intent;
+  private async resolvePaymentForm(invoice: Stripe.Invoice): Promise<string> {
+    const funding = await this.resolveCardFunding(invoice);
 
-    const funding =
-      typeof intent === 'object' && intent !== null
-        ? (
-            intent as {
-              payment_method?: { card?: { funding?: string } };
-            }
-          ).payment_method?.card?.funding
-        : undefined;
+    if (!funding) {
+      this.logger.warn(
+        `No se pudo determinar el tipo de tarjeta de la factura ${invoice.id}; se timbra como crédito (04)`,
+      );
+    }
 
     return funding === 'debit'
       ? CFDI_PAYMENT_FORM_DEBIT_CARD
       : CFDI_PAYMENT_FORM_CREDIT_CARD;
+  }
+
+  private async resolveCardFunding(
+    invoice: Stripe.Invoice,
+  ): Promise<string | null> {
+    const intent = (invoice as { payment_intent?: unknown }).payment_intent;
+
+    // Ya expandido (por ejemplo en un reintento que recuperó la factura).
+    if (typeof intent === 'object' && intent !== null) {
+      const expanded = (
+        intent as { payment_method?: { card?: { funding?: string } } }
+      ).payment_method?.card?.funding;
+      if (expanded) {
+        return expanded;
+      }
+    }
+
+    const intentId = typeof intent === 'string' ? intent : null;
+    if (!intentId || !this.stripe) {
+      return null;
+    }
+
+    try {
+      const retrieved = await this.stripe.paymentIntents.retrieve(intentId, {
+        expand: ['payment_method'],
+      });
+      const method = retrieved.payment_method;
+
+      return typeof method === 'object' && method !== null
+        ? (method.card?.funding ?? null)
+        : null;
+    } catch (error) {
+      // Un fallo aquí no puede impedir el timbrado: la factura se emite igual
+      // con la clave por defecto.
+      this.logger.warn(
+        `No se pudo recuperar el método de pago de ${invoice.id}: ${error.message}`,
+      );
+      return null;
+    }
   }
 
   private resolveChargedAt(invoice: Stripe.Invoice): Date | undefined {

--- a/src/modules/billing/cfdi.service.ts
+++ b/src/modules/billing/cfdi.service.ts
@@ -114,7 +114,11 @@ export class CfdiService {
       return;
     }
 
-    await this.stamp(invoice, user, profile, { amount, currency });
+    await this.stamp(invoice, user, profile, {
+      amount,
+      currency,
+      attempts: reserved.attempts,
+    });
   }
 
   /**
@@ -122,8 +126,16 @@ export class CfdiService {
    *
    * A diferencia de `stampForInvoice`, aquí sí se propaga el error: hay un
    * usuario esperando la respuesta y necesita saber si su corrección funcionó.
+   *
+   * Los intentos previos vienen de quien tomó el candado, no de una lectura
+   * nueva: el documento ya está en `pending` y releerlo sería otra operación que
+   * puede fallar y dejarlo bloqueado.
    */
-  async retry(invoice: Stripe.Invoice, user: User): Promise<Cfdi> {
+  async retry(
+    invoice: Stripe.Invoice,
+    user: User,
+    previousAttempts: number,
+  ): Promise<Cfdi> {
     const profile = await this.firestoreService.getTaxProfile(user.id);
 
     if (!profile?.isComplete || profile.type !== 'mx') {
@@ -140,6 +152,7 @@ export class CfdiService {
       {
         amount: (invoice.amount_paid ?? 0) / 100,
         currency: (invoice.currency || 'mxn').toLowerCase(),
+        attempts: previousAttempts,
       },
       { rethrow: true },
     );
@@ -160,13 +173,15 @@ export class CfdiService {
     invoice: Stripe.Invoice,
     user: User,
     profile: TaxProfile,
-    money: { amount: number; currency: string },
+    money: { amount: number; currency: string; attempts: number },
     options: { rethrow?: boolean } = {},
   ): Promise<void> {
     const stripeInvoiceId = invoice.id;
-    const existing =
-      await this.firestoreService.getCfdiByInvoiceId(stripeInvoiceId);
-    const attempts = (existing?.attempts ?? 0) + 1;
+    // Los intentos previos los trae quien tomó el documento. Releerlos aquí
+    // añadía una operación de Firestore fuera de todo manejo de error, con el
+    // CFDI ya en `pending`: un fallo transitorio lo dejaba clavado en ese estado
+    // sin haber llamado siquiera al PAC, bloqueando todo reintento posterior.
+    const attempts = money.attempts + 1;
 
     // Los precios en MXN son finales y el CFDI los desglosa hacia atrás. Un
     // cobro en otra divisa necesitaría TipoCambio, y emitirlo como si fuera
@@ -398,32 +413,31 @@ export class CfdiService {
   private async resolveCardFunding(
     invoice: Stripe.Invoice,
   ): Promise<string | null> {
-    const intent = (invoice as { payment_intent?: unknown }).payment_intent;
-
-    // Ya expandido (por ejemplo en un reintento que recuperó la factura).
-    if (typeof intent === 'object' && intent !== null) {
-      const expanded = (
-        intent as { payment_method?: { card?: { funding?: string } } }
-      ).payment_method?.card?.funding;
-      if (expanded) {
-        return expanded;
-      }
-    }
-
-    const intentId = typeof intent === 'string' ? intent : null;
-    if (!intentId || !this.stripe) {
+    if (!this.stripe) {
       return null;
     }
 
     try {
+      const intent = await this.resolvePaymentIntent(invoice);
+
+      if (!intent) {
+        return null;
+      }
+
+      // Ya expandido: el objeto trae el método de pago dentro.
+      if (typeof intent !== 'string') {
+        const funding = this.readFunding(intent);
+        if (funding) {
+          return funding;
+        }
+      }
+
+      const intentId = typeof intent === 'string' ? intent : intent.id;
       const retrieved = await this.stripe.paymentIntents.retrieve(intentId, {
         expand: ['payment_method'],
       });
-      const method = retrieved.payment_method;
 
-      return typeof method === 'object' && method !== null
-        ? (method.card?.funding ?? null)
-        : null;
+      return this.readFunding(retrieved);
     } catch (error) {
       // Un fallo aquí no puede impedir el timbrado: la factura se emite igual
       // con la clave por defecto.
@@ -432,6 +446,57 @@ export class CfdiService {
       );
       return null;
     }
+  }
+
+  /**
+   * Localiza el PaymentIntent de la factura.
+   *
+   * Desde la versión de API `2025-03-31.basil`, `Invoice` ya no expone
+   * `payment_intent` en el nivel superior: los cobros viven en `payments`, una
+   * lista de InvoicePayment donde el intent está en `payment.payment_intent`.
+   * Leer el campo viejo devolvía `undefined` siempre, y con él toda tarjeta de
+   * débito se habría timbrado como crédito.
+   */
+  private async resolvePaymentIntent(
+    invoice: Stripe.Invoice,
+  ): Promise<string | Stripe.PaymentIntent | null> {
+    const fromInvoice = this.pickIntentFromPayments(invoice.payments?.data);
+    if (fromInvoice) {
+      return fromInvoice;
+    }
+
+    // `payments` no viaja expandido en el evento del webhook.
+    const listed = await this.stripe.invoicePayments.list({
+      invoice: invoice.id,
+      limit: 10,
+    });
+
+    return this.pickIntentFromPayments(listed.data);
+  }
+
+  private pickIntentFromPayments(
+    payments: Stripe.InvoicePayment[] | undefined,
+  ): string | Stripe.PaymentIntent | null {
+    if (!payments?.length) {
+      return null;
+    }
+
+    // Una factura puede acumular intentos fallidos antes del que cobró; el que
+    // describe fiscalmente la operación es el que tuvo éxito.
+    const paid =
+      payments.find((payment) => payment.status === 'paid') ?? payments[0];
+
+    return paid?.payment?.type === 'payment_intent'
+      ? (paid.payment.payment_intent ?? null)
+      : null;
+  }
+
+  private readFunding(intent: Stripe.PaymentIntent): string | null {
+    const method = intent.payment_method;
+
+    return typeof method === 'object' && method !== null
+      ? (method.card?.funding ?? null)
+      : null;
   }
 
   private resolveChargedAt(invoice: Stripe.Invoice): Date | undefined {

--- a/src/modules/billing/cfdi.service.ts
+++ b/src/modules/billing/cfdi.service.ts
@@ -127,24 +127,18 @@ export class CfdiService {
    * A diferencia de `stampForInvoice`, aquí sí se propaga el error: hay un
    * usuario esperando la respuesta y necesita saber si su corrección funcionó.
    *
-   * Los intentos previos vienen de quien tomó el candado, no de una lectura
-   * nueva: el documento ya está en `pending` y releerlo sería otra operación que
-   * puede fallar y dejarlo bloqueado.
+   * Recibe el perfil y los intentos ya resueltos por quien tomó el candado, en
+   * vez de releerlos. Entre el candado y el PAC no puede quedar ninguna lectura
+   * que pueda fallar: en ese tramo el documento ya está en `pending`, así que
+   * cualquier error previo a llamar a Facturama lo dejaría clavado en ese estado
+   * y bloquearía todos los reintentos posteriores. Quien reserva, valida.
    */
   async retry(
     invoice: Stripe.Invoice,
     user: User,
+    profile: TaxProfile,
     previousAttempts: number,
   ): Promise<Cfdi> {
-    const profile = await this.firestoreService.getTaxProfile(user.id);
-
-    if (!profile?.isComplete || profile.type !== 'mx') {
-      throw new FacturamaError(
-        CfdiErrorCodes.INVOICE_NOT_STAMPABLE,
-        'El perfil fiscal está incompleto',
-      );
-    }
-
     await this.stamp(
       invoice,
       user,

--- a/src/modules/billing/dto/billing.dto.ts
+++ b/src/modules/billing/dto/billing.dto.ts
@@ -1,5 +1,62 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
+/**
+ * Estado del CFDI tal como lo pinta la UI.
+ *
+ * `not_applicable` es «se evaluó y este cobro no lleva comprobante» —una factura
+ * anterior a que el usuario cargara su perfil fiscal, por ejemplo—. El campo
+ * completo llega a `null` cuando el módulo no aplica: usuarios no mexicanos.
+ */
+export type CfdiApiStatus =
+  | 'stamped'
+  | 'pending'
+  | 'failed'
+  | 'canceled'
+  | 'not_applicable';
+
+export class CfdiErrorDto {
+  @ApiProperty({
+    description:
+      'Código estable que traduce el frontend: rfc_not_found, name_mismatch, postal_code_mismatch, regime_mismatch, cfdi_use_invalid, pac_unavailable, invoice_not_stampable, unknown',
+    example: 'rfc_not_found',
+  })
+  code: string;
+
+  @ApiProperty({
+    description:
+      'Texto libre para logs y diagnóstico. La UI solo cae aquí si el código no está mapeado.',
+  })
+  message: string;
+}
+
+export class CfdiDto {
+  @ApiProperty({
+    enum: ['stamped', 'pending', 'failed', 'canceled', 'not_applicable'],
+  })
+  status: CfdiApiStatus;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Folio fiscal del SAT' })
+  uuid: string | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'URL firmada, válida 15 minutos',
+  })
+  pdfUrl: string | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'URL firmada, válida 15 minutos',
+  })
+  xmlUrl: string | null;
+
+  @ApiPropertyOptional({ nullable: true, description: 'ISO 8601' })
+  stampedAt: string | null;
+
+  @ApiPropertyOptional({ type: CfdiErrorDto, nullable: true })
+  error: CfdiErrorDto | null;
+}
+
 // Invoice DTOs
 export class InvoiceDto {
   @ApiProperty()
@@ -37,6 +94,14 @@ export class InvoiceDto {
 
   @ApiPropertyOptional()
   description: string | null;
+
+  @ApiPropertyOptional({
+    type: CfdiDto,
+    nullable: true,
+    description:
+      'CFDI asociado al cobro. `null` cuando el módulo no aplica (usuario no mexicano).',
+  })
+  cfdi?: CfdiDto | null;
 }
 
 export class InvoicesResponseDto {
@@ -45,6 +110,14 @@ export class InvoicesResponseDto {
 
   @ApiProperty()
   hasMore: boolean;
+}
+
+export class CfdiRetryResponseDto {
+  @ApiProperty()
+  success: boolean;
+
+  @ApiProperty({ type: CfdiDto })
+  cfdi: CfdiDto;
 }
 
 // Payment Method DTOs

--- a/src/modules/billing/dto/tax-profile.dto.ts
+++ b/src/modules/billing/dto/tax-profile.dto.ts
@@ -1,0 +1,188 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsEmail,
+  IsIn,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  Length,
+  ValidateIf,
+  ValidateNested,
+} from 'class-validator';
+import type { TaxProfileType } from '../../../common/interfaces/tax-profile.interface.js';
+
+export class TaxProfileAddressDto {
+  @ApiProperty({ example: 'Calle Mayor 1' })
+  @IsString()
+  @IsNotEmpty()
+  line1: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  @IsOptional()
+  @IsString()
+  line2?: string | null;
+
+  @ApiProperty({ example: 'Madrid' })
+  @IsString()
+  @IsNotEmpty()
+  city: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  @IsOptional()
+  @IsString()
+  state?: string | null;
+
+  @ApiProperty({ example: '28001' })
+  @IsString()
+  @IsNotEmpty()
+  postalCode: string;
+
+  @ApiProperty({ example: 'ES', description: 'ISO 3166-1 alpha-2' })
+  @IsString()
+  @Length(2, 2)
+  country: string;
+}
+
+/**
+ * Body de `PUT /billing/tax-profile`.
+ *
+ * Un solo DTO con validación condicional en vez de dos: class-validator no
+ * resuelve uniones discriminadas, y partir el endpoint en dos rutas obligaría al
+ * frontend a saber qué formulario le toca antes de preguntarlo.
+ *
+ * Las reglas fiscales de fondo (coherencia RFC ↔ régimen ↔ uso de CFDI) no caben
+ * en decoradores y viven en `BillingService.validateTaxProfile`.
+ */
+export class UpdateTaxProfileDto {
+  @ApiProperty({ enum: ['mx', 'international'] })
+  @IsIn(['mx', 'international'])
+  type: TaxProfileType;
+
+  // ---- México ----
+
+  @ApiPropertyOptional({
+    example: 'XAXX010101000',
+    description: 'Solo type=mx',
+  })
+  @ValidateIf((o: UpdateTaxProfileDto) => o.type === 'mx')
+  @IsString()
+  @IsNotEmpty()
+  rfc?: string;
+
+  @ApiPropertyOptional({
+    example: '601',
+    description: 'c_RegimenFiscal. Solo type=mx',
+  })
+  @ValidateIf((o: UpdateTaxProfileDto) => o.type === 'mx')
+  @IsString()
+  @IsNotEmpty()
+  taxRegime?: string;
+
+  @ApiPropertyOptional({
+    example: 'G03',
+    description: 'c_UsoCFDI. Solo type=mx',
+  })
+  @ValidateIf((o: UpdateTaxProfileDto) => o.type === 'mx')
+  @IsString()
+  @IsNotEmpty()
+  cfdiUse?: string;
+
+  @ApiPropertyOptional({
+    example: '97000',
+    description: 'CP del domicilio fiscal. Solo type=mx',
+  })
+  @ValidateIf((o: UpdateTaxProfileDto) => o.type === 'mx')
+  @IsString()
+  @IsNotEmpty()
+  postalCode?: string;
+
+  // ---- Comunes ----
+
+  @ApiProperty({
+    example: 'EMPRESA DEMO',
+    description: 'Razón social sin régimen de capital',
+  })
+  @IsString()
+  @IsNotEmpty()
+  legalName: string;
+
+  @ApiProperty({ example: 'facturas@empresa.com' })
+  @IsEmail()
+  billingEmail: string;
+
+  // ---- Internacional ----
+
+  @ApiPropertyOptional({
+    example: 'eu_vat',
+    nullable: true,
+    description: 'Tipo de tax ID de Stripe. Solo type=international',
+  })
+  @IsOptional()
+  @IsString()
+  taxIdType?: string | null;
+
+  @ApiPropertyOptional({
+    example: 'ESB12345678',
+    nullable: true,
+    description: 'Solo type=international',
+  })
+  @IsOptional()
+  @IsString()
+  taxIdValue?: string | null;
+
+  @ApiPropertyOptional({
+    type: TaxProfileAddressDto,
+    description: 'Domicilio fiscal. Solo type=international',
+  })
+  @ValidateIf((o: UpdateTaxProfileDto) => o.type === 'international')
+  @IsObject()
+  @ValidateNested()
+  @Type(() => TaxProfileAddressDto)
+  address?: TaxProfileAddressDto;
+}
+
+export class TaxProfileResponseDto {
+  @ApiProperty({ enum: ['mx', 'international'] })
+  type: TaxProfileType;
+
+  @ApiProperty({ example: 'MX', description: 'ISO 3166-1 alpha-2' })
+  country: string;
+
+  @ApiProperty({
+    description:
+      'false cuando el usuario todavía no ha cargado su perfil. No es un 404: el frontend necesita `type` para saber qué formulario renderizar.',
+  })
+  isComplete: boolean;
+
+  @ApiPropertyOptional()
+  rfc?: string;
+
+  @ApiPropertyOptional()
+  legalName?: string;
+
+  @ApiPropertyOptional({ description: 'c_RegimenFiscal' })
+  taxRegime?: string;
+
+  @ApiPropertyOptional()
+  postalCode?: string;
+
+  @ApiPropertyOptional({ description: 'c_UsoCFDI' })
+  cfdiUse?: string;
+
+  @ApiPropertyOptional()
+  billingEmail?: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  taxIdType?: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  taxIdValue?: string | null;
+
+  @ApiPropertyOptional({ type: TaxProfileAddressDto, nullable: true })
+  address?: TaxProfileAddressDto | null;
+
+  @ApiPropertyOptional({ description: 'ISO 8601' })
+  updatedAt?: string;
+}

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -15,6 +15,7 @@ import type {
 } from '../../common/interfaces/feedback.interface.js';
 import type { Usage } from '../../common/interfaces/usage.interface.js';
 import type { TaxProfile } from '../../common/interfaces/tax-profile.interface.js';
+import type { Cfdi } from '../../common/interfaces/cfdi.interface.js';
 import type { ConversionHistory } from '../../common/interfaces/conversion-history.interface.js';
 import type { BatchJob } from '../zpl/interfaces/batch.interface.js';
 import type { HourlyLabelaryStats } from '../zpl/interfaces/labelary-analytics.interface.js';
@@ -6907,6 +6908,131 @@ export class FirestoreService {
       this.logger.log(`Perfil fiscal guardado: ${userId}`);
     } catch (error) {
       this.logger.error(`Error al guardar perfil fiscal: ${error.message}`);
+      throw error;
+    }
+  }
+
+  // ============== CFDIs ==============
+
+  private readonly cfdisCollection = 'cfdis';
+
+  /**
+   * Reserva el CFDI de una factura, o devuelve `null` si ya estaba reservado.
+   *
+   * El docId es el `stripeInvoiceId` y se usa `create`, que falla si el documento
+   * existe. Ahí está la idempotencia: dos entregas simultáneas del mismo webhook
+   * pueden pasar a la vez cualquier comprobación de aplicación, pero solo una
+   * gana el `create`. Un CFDI duplicado no se borra —se cancela a mano ante el
+   * SAT—, así que la garantía tiene que ser atómica.
+   */
+  async reserveCfdi(data: {
+    stripeInvoiceId: string;
+    userId: string;
+    amount: number;
+    currency: string;
+  }): Promise<Cfdi | null> {
+    const now = new Date();
+    const record: Cfdi = {
+      ...data,
+      status: 'pending',
+      attempts: 0,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    try {
+      await this.firestore
+        .collection(this.cfdisCollection)
+        .doc(data.stripeInvoiceId)
+        .create(record);
+
+      return record;
+    } catch (error) {
+      // ALREADY_EXISTS (código 6): otro intento ya lo reservó.
+      if (error?.code === 6) {
+        this.logger.log(
+          `CFDI de ${data.stripeInvoiceId} ya reservado; no se timbra de nuevo`,
+        );
+        return null;
+      }
+      this.logger.error(`Error al reservar CFDI: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async getCfdiByInvoiceId(stripeInvoiceId: string): Promise<Cfdi | null> {
+    try {
+      const doc = await this.firestore
+        .collection(this.cfdisCollection)
+        .doc(stripeInvoiceId)
+        .get();
+
+      if (!doc.exists) return null;
+
+      const data = doc.data();
+      return {
+        ...data,
+        stampedAt: data.stampedAt?.toDate?.() || data.stampedAt || null,
+        createdAt: data.createdAt?.toDate?.() || data.createdAt,
+        updatedAt: data.updatedAt?.toDate?.() || data.updatedAt,
+      } as Cfdi;
+    } catch (error) {
+      this.logger.error(`Error al obtener CFDI: ${error.message}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Resuelve varios CFDIs en una sola lectura para enriquecer el listado de
+   * facturas sin una consulta por fila.
+   */
+  async getCfdisByInvoiceIds(
+    stripeInvoiceIds: string[],
+  ): Promise<Map<string, Cfdi>> {
+    const result = new Map<string, Cfdi>();
+    const uniqueIds = [...new Set(stripeInvoiceIds.filter(Boolean))];
+
+    if (uniqueIds.length === 0) {
+      return result;
+    }
+
+    try {
+      const refs = uniqueIds.map((id) =>
+        this.firestore.collection(this.cfdisCollection).doc(id),
+      );
+      const docs = await this.firestore.getAll(...refs);
+
+      for (const doc of docs) {
+        if (!doc.exists) continue;
+        const data = doc.data();
+        result.set(doc.id, {
+          ...data,
+          stampedAt: data.stampedAt?.toDate?.() || data.stampedAt || null,
+          createdAt: data.createdAt?.toDate?.() || data.createdAt,
+          updatedAt: data.updatedAt?.toDate?.() || data.updatedAt,
+        } as Cfdi);
+      }
+
+      return result;
+    } catch (error) {
+      // El CFDI enriquece el listado de facturas; un fallo aquí no debe dejar al
+      // usuario sin ver sus facturas de Stripe.
+      this.logger.error(`Error al obtener CFDIs en lote: ${error.message}`);
+      return result;
+    }
+  }
+
+  async updateCfdi(
+    stripeInvoiceId: string,
+    data: Partial<Cfdi>,
+  ): Promise<void> {
+    try {
+      await this.firestore
+        .collection(this.cfdisCollection)
+        .doc(stripeInvoiceId)
+        .set({ ...data, updatedAt: new Date() }, { merge: true });
+    } catch (error) {
+      this.logger.error(`Error al actualizar CFDI: ${error.message}`);
       throw error;
     }
   }

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -6960,6 +6960,54 @@ export class FirestoreService {
     }
   }
 
+  /**
+   * Toma el CFDI para reintentar su timbrado, de forma atómica.
+   *
+   * Devuelve el estado que impide el reintento, o `null` si lo ha tomado. Leer
+   * el estado y timbrar después no sirve de candado: dos peticiones simultáneas
+   * —un doble clic basta— leerían `failed` a la vez y ambas llamarían al PAC,
+   * emitiendo dos comprobantes que solo se deshacen cancelándolos ante el SAT.
+   *
+   * La transición `failed → pending` ocurre dentro de la transacción, así que
+   * solo el ganador encuentra `failed` y el resto se topa con `pending`.
+   */
+  async claimCfdiForRetry(
+    stripeInvoiceId: string,
+    data: { userId: string; amount: number; currency: string },
+  ): Promise<{ blockedBy: Cfdi['status'] } | null> {
+    const ref = this.firestore
+      .collection(this.cfdisCollection)
+      .doc(stripeInvoiceId);
+
+    return this.firestore.runTransaction(async (transaction) => {
+      const snapshot = await transaction.get(ref);
+      const now = new Date();
+
+      if (!snapshot.exists) {
+        // Una factura anterior a que el usuario cargara su perfil fiscal no
+        // tiene documento, y debe poder facturarse.
+        transaction.create(ref, {
+          ...data,
+          stripeInvoiceId,
+          status: 'pending',
+          attempts: 0,
+          createdAt: now,
+          updatedAt: now,
+        });
+        return null;
+      }
+
+      const current = snapshot.data() as Cfdi;
+
+      if (current.status !== 'failed') {
+        return { blockedBy: current.status };
+      }
+
+      transaction.update(ref, { status: 'pending', updatedAt: now });
+      return null;
+    });
+  }
+
   async getCfdiByInvoiceId(stripeInvoiceId: string): Promise<Cfdi | null> {
     try {
       const doc = await this.firestore

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -14,6 +14,7 @@ import type {
   FeedbackSummary,
 } from '../../common/interfaces/feedback.interface.js';
 import type { Usage } from '../../common/interfaces/usage.interface.js';
+import type { TaxProfile } from '../../common/interfaces/tax-profile.interface.js';
 import type { ConversionHistory } from '../../common/interfaces/conversion-history.interface.js';
 import type { BatchJob } from '../zpl/interfaces/batch.interface.js';
 import type { HourlyLabelaryStats } from '../zpl/interfaces/labelary-analytics.interface.js';
@@ -6839,6 +6840,73 @@ export class FirestoreService {
       };
     } catch (error) {
       this.logger.error(`Error getting ZPL debug file: ${error.message}`);
+      throw error;
+    }
+  }
+
+  // ============== Tax Profiles (Perfil fiscal / CFDI) ==============
+
+  private readonly taxProfilesCollection = 'tax_profiles';
+
+  /**
+   * Devuelve el perfil fiscal del usuario, o `null` si nunca lo cargó.
+   *
+   * Vive en su propia colección con docId = userId: el doc de `users` se lee en
+   * casi cada request y no tiene por qué cargar con el RFC y el domicilio.
+   */
+  async getTaxProfile(userId: string): Promise<TaxProfile | null> {
+    try {
+      const doc = await this.firestore
+        .collection(this.taxProfilesCollection)
+        .doc(userId)
+        .get();
+
+      if (!doc.exists) {
+        return null;
+      }
+
+      const data = doc.data();
+      return {
+        ...data,
+        userId,
+        createdAt: data.createdAt?.toDate?.() || data.createdAt,
+        updatedAt: data.updatedAt?.toDate?.() || data.updatedAt,
+      } as TaxProfile;
+    } catch (error) {
+      this.logger.error(`Error al obtener perfil fiscal: ${error.message}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Crea o actualiza el perfil fiscal.
+   *
+   * Se usa `set` con merge en lugar de `update` porque el primer guardado crea el
+   * documento, y `createdAt` solo se fija si no existía.
+   */
+  async saveTaxProfile(
+    userId: string,
+    data: Partial<TaxProfile>,
+  ): Promise<void> {
+    try {
+      const ref = this.firestore
+        .collection(this.taxProfilesCollection)
+        .doc(userId);
+      const existing = await ref.get();
+
+      await ref.set(
+        {
+          ...data,
+          userId,
+          ...(existing.exists ? {} : { createdAt: new Date() }),
+          updatedAt: new Date(),
+        },
+        { merge: true },
+      );
+
+      this.logger.log(`Perfil fiscal guardado: ${userId}`);
+    } catch (error) {
+      this.logger.error(`Error al guardar perfil fiscal: ${error.message}`);
       throw error;
     }
   }

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -15,7 +15,10 @@ import type {
 } from '../../common/interfaces/feedback.interface.js';
 import type { Usage } from '../../common/interfaces/usage.interface.js';
 import type { TaxProfile } from '../../common/interfaces/tax-profile.interface.js';
-import type { Cfdi } from '../../common/interfaces/cfdi.interface.js';
+import type {
+  Cfdi,
+  CfdiClaim,
+} from '../../common/interfaces/cfdi.interface.js';
 import type { ConversionHistory } from '../../common/interfaces/conversion-history.interface.js';
 import type { BatchJob } from '../zpl/interfaces/batch.interface.js';
 import type { HourlyLabelaryStats } from '../zpl/interfaces/labelary-analytics.interface.js';
@@ -6974,12 +6977,14 @@ export class FirestoreService {
   async claimCfdiForRetry(
     stripeInvoiceId: string,
     data: { userId: string; amount: number; currency: string },
-  ): Promise<{ blockedBy: Cfdi['status'] } | null> {
+  ): Promise<CfdiClaim> {
     const ref = this.firestore
       .collection(this.cfdisCollection)
       .doc(stripeInvoiceId);
 
-    return this.firestore.runTransaction(async (transaction) => {
+    // El genérico va explícito para que el literal de `outcome` no se ensanche
+    // a `string` y la unión siga discriminando en quien la consume.
+    return this.firestore.runTransaction<CfdiClaim>(async (transaction) => {
       const snapshot = await transaction.get(ref);
       const now = new Date();
 
@@ -6994,17 +6999,20 @@ export class FirestoreService {
           createdAt: now,
           updatedAt: now,
         });
-        return null;
+        return { outcome: 'granted', attempts: 0 };
       }
 
       const current = snapshot.data() as Cfdi;
 
       if (current.status !== 'failed') {
-        return { blockedBy: current.status };
+        return { outcome: 'blocked', blockedBy: current.status };
       }
 
       transaction.update(ref, { status: 'pending', updatedAt: now });
-      return null;
+      // Los intentos acumulados salen de aquí, y no de una lectura posterior:
+      // el documento ya está en `pending` y un fallo al releerlo lo dejaría
+      // clavado en ese estado, bloqueando todos los reintentos futuros.
+      return { outcome: 'granted', attempts: current.attempts ?? 0 };
     });
   }
 

--- a/src/modules/facturama/facturama.constants.ts
+++ b/src/modules/facturama/facturama.constants.ts
@@ -1,0 +1,155 @@
+/**
+ * Constantes del CFDI que emite ZPLPDF.
+ *
+ * El emisor (RFC, régimen y CSD) NO vive aquí: lo define la cuenta de Facturama
+ * contra la que se autentica el servicio. La API web (`POST /3/cfdis`) toma el
+ * emisor del certificado cargado en esa cuenta, así que cambiar de emisor es
+ * cambiar de credenciales, no de código.
+ */
+
+/**
+ * c_ClaveProdServ 43231510 — «Software para hacer etiquetas».
+ *
+ * Describe literalmente el producto: convertir ZPL (el lenguaje de etiquetas de
+ * Zebra) a PDF. Es además la clave que ya se usa en la contabilidad del emisor,
+ * así que el criterio se mantiene consistente.
+ */
+export const CFDI_PRODUCT_CODE = '43231510';
+
+/** c_ClaveUnidad E48 — «Unidad de servicio». */
+export const CFDI_UNIT_CODE = 'E48';
+export const CFDI_UNIT_NAME = 'Unidad de servicio';
+
+/** c_Impuesto 002 — IVA. Facturama lo espera por nombre. */
+export const CFDI_TAX_NAME = 'IVA';
+export const CFDI_TAX_RATE = 0.16;
+
+/** c_ObjetoImp 02 — «Sí objeto de impuesto». */
+export const CFDI_TAX_OBJECT = '02';
+
+/** c_TipoDeComprobante I — Ingreso. */
+export const CFDI_TYPE_INCOME = 'I';
+
+/** c_Exportacion 01 — «No aplica». */
+export const CFDI_EXPORTATION_NOT_APPLICABLE = '01';
+
+/**
+ * c_MetodoPago PUE — «Pago en una sola exhibición».
+ *
+ * El cobro con tarjeta se liquida en el acto, así que nunca es PPD y no hace
+ * falta complemento de pago.
+ */
+export const CFDI_PAYMENT_METHOD_PUE = 'PUE';
+
+/** c_FormaPago 04 — «Tarjeta de crédito». */
+export const CFDI_PAYMENT_FORM_CREDIT_CARD = '04';
+
+/** c_FormaPago 28 — «Tarjeta de débito». */
+export const CFDI_PAYMENT_FORM_DEBIT_CARD = '28';
+
+/**
+ * Facturama rechaza un CFDI con fecha de expedición de más de 72 horas.
+ *
+ * Se usa para decidir si el comprobante lleva la fecha del cobro —lo deseable,
+ * porque mantiene CFDI y cobro en el mismo mes cuando el cobro cae a fin de
+ * mes— o la del momento del timbrado.
+ */
+export const CFDI_MAX_BACKDATE_MS = 72 * 60 * 60 * 1000;
+
+/**
+ * Códigos de error estables que consume el frontend.
+ *
+ * La app sirve en cuatro idiomas y el backend no conoce el del receptor, así que
+ * el código es la fuente de verdad y la traducción vive en el cliente
+ * (`src/lib/cfdi-errors.ts`). El `message` acompaña solo para logs y para que un
+ * código nuevo degrade a texto sin traducir en vez de a un genérico inútil.
+ */
+export const CfdiErrorCodes = {
+  RFC_NOT_FOUND: 'rfc_not_found',
+  NAME_MISMATCH: 'name_mismatch',
+  POSTAL_CODE_MISMATCH: 'postal_code_mismatch',
+  REGIME_MISMATCH: 'regime_mismatch',
+  CFDI_USE_INVALID: 'cfdi_use_invalid',
+  PAC_UNAVAILABLE: 'pac_unavailable',
+  INVOICE_NOT_STAMPABLE: 'invoice_not_stampable',
+  UNKNOWN: 'unknown',
+} as const;
+
+export type CfdiErrorCode =
+  (typeof CfdiErrorCodes)[keyof typeof CfdiErrorCodes];
+
+/**
+ * Traduce el rechazo del PAC a uno de los códigos estables.
+ *
+ * El emparejamiento va por texto y no solo por la clave `CFDI40xxx`: Facturama
+ * antepone su propia validación a la del SAT y no siempre incluye la clave, así
+ * que atarse a ella dejaría la mayoría de los rechazos en `unknown` —justo los
+ * que el usuario puede corregir solo.
+ */
+export function mapPacErrorToCode(rawMessage: string): CfdiErrorCode {
+  const message = (rawMessage || '').toLowerCase();
+
+  const matches = (...needles: string[]): boolean =>
+    needles.some((needle) => message.includes(needle));
+
+  // El orden importa: un mensaje sobre el nombre del receptor también menciona
+  // el RFC, así que las comprobaciones más específicas van primero.
+  if (
+    matches(
+      'cfdi40158',
+      'cfdi40157',
+      'nombre del receptor',
+      'razón social',
+      'razon social',
+    )
+  ) {
+    return CfdiErrorCodes.NAME_MISMATCH;
+  }
+
+  if (
+    matches(
+      'cfdi40161',
+      'domiciliofiscalreceptor',
+      'domicilio fiscal',
+      'código postal',
+      'codigo postal',
+    )
+  ) {
+    return CfdiErrorCodes.POSTAL_CODE_MISMATCH;
+  }
+
+  // Antes que el régimen: un rechazo por uso de CFDI incompatible menciona
+  // siempre el régimen —la incompatibilidad es justo entre ambos—, así que la
+  // regla del régimen se lo tragaría y el usuario corregiría el campo que no es.
+  if (matches('cfdi40163', 'usocfdi', 'uso del cfdi', 'uso de cfdi')) {
+    return CfdiErrorCodes.CFDI_USE_INVALID;
+  }
+
+  if (
+    matches(
+      'cfdi40162',
+      'regimenfiscalreceptor',
+      'régimen fiscal',
+      'regimen fiscal',
+    )
+  ) {
+    return CfdiErrorCodes.REGIME_MISMATCH;
+  }
+
+  if (
+    matches(
+      'cfdi40147',
+      'no se encuentra en la lista de rfc',
+      'no está en la lista de rfc',
+      'no esta en la lista de rfc',
+      'rfc no localizado',
+      'rfc inválido',
+      'rfc invalido',
+      'rfc del receptor',
+    )
+  ) {
+    return CfdiErrorCodes.RFC_NOT_FOUND;
+  }
+
+  return CfdiErrorCodes.UNKNOWN;
+}

--- a/src/modules/facturama/facturama.module.ts
+++ b/src/modules/facturama/facturama.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { FacturamaService } from './facturama.service.js';
+
+@Module({
+  providers: [FacturamaService],
+  exports: [FacturamaService],
+})
+export class FacturamaModule {}

--- a/src/modules/facturama/facturama.service.spec.ts
+++ b/src/modules/facturama/facturama.service.spec.ts
@@ -23,6 +23,7 @@ describe('FacturamaService', () => {
       logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
       http: { post, get },
       expeditionPlace: '97308',
+      timezone: 'America/Merida',
     });
 
     return { service, post, get };
@@ -119,12 +120,26 @@ describe('FacturamaService', () => {
   });
 
   describe('fecha de expedición', () => {
-    it('usa la fecha del cobro si está dentro de las 72 horas', async () => {
+    /** Hora local del emisor (Mérida, UTC-6) de un instante dado. */
+    function meridaLocal(date: Date): string {
+      const parts = new Intl.DateTimeFormat('en-CA', {
+        timeZone: 'America/Merida',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hourCycle: 'h23',
+      }).formatToParts(date);
+      const get = (t: string) => parts.find((p) => p.type === t).value;
+      return `${get('year')}-${get('month')}-${get('day')}T${get('hour')}:${get('minute')}:${get('second')}`;
+    }
+
+    async function stampWith(chargedAt?: Date) {
       const { service, post } = buildService({
         post: jest.fn().mockResolvedValue(stampedResponse()),
       });
-      const chargedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
-
       await service.stampSubscription({
         receiver,
         total: 199,
@@ -132,44 +147,51 @@ describe('FacturamaService', () => {
         description: 'Suscripción ZPLPDF',
         chargedAt,
       });
+      return sentPayload(post).Date;
+    }
+
+    it('expide en hora local del emisor, no en UTC', async () => {
+      const chargedAt = new Date('2026-08-04T18:30:00.000Z');
+      jest.useFakeTimers().setSystemTime(new Date('2026-08-04T19:00:00.000Z'));
+
+      try {
+        // Facturama lee `Date` como hora local del emisor. Mandarle el UTC
+        // adelantaba seis horas el comprobante y lo dejaba fechado en el futuro,
+        // que el PAC rechaza de plano.
+        expect(await stampWith(chargedAt)).toBe('2026-08-04T12:30:00');
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('usa la fecha del cobro si está dentro de las 72 horas', async () => {
+      const chargedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
 
       // Mantiene cobro y comprobante en el mismo mes cuando el cargo cae a fin
       // de mes y el webhook se procesa ya entrado el siguiente.
-      expect(sentPayload(post).Date).toBe(chargedAt.toISOString().slice(0, 19));
+      expect(await stampWith(chargedAt)).toBe(meridaLocal(chargedAt));
     });
 
-    it('omite la fecha si el cobro tiene más de 72 horas', async () => {
-      const { service, post } = buildService({
-        post: jest.fn().mockResolvedValue(stampedResponse()),
-      });
+    it('expide con la hora actual si el cobro tiene más de 72 horas', async () => {
+      const viejo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
 
-      await service.stampSubscription({
-        receiver,
-        total: 199,
-        currency: 'MXN',
-        description: 'Suscripción ZPLPDF',
-        chargedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000),
-      });
+      const enviado = await stampWith(viejo);
 
-      // Facturama rechaza cualquier fecha más vieja; sin el campo, sella con la
-      // hora del timbrado y el CFDI sale igualmente.
-      expect(sentPayload(post).Date).toBeUndefined();
+      // Facturama rechaza cualquier fecha más vieja. En un reintento la única
+      // fecha válida es la de ahora, y hay que decirlo explícitamente en vez de
+      // omitir el campo.
+      expect(enviado).not.toBe(meridaLocal(viejo));
+      expect(enviado).toBe(meridaLocal(new Date()));
     });
 
-    it('omite una fecha futura', async () => {
-      const { service, post } = buildService({
-        post: jest.fn().mockResolvedValue(stampedResponse()),
-      });
+    it('expide con la hora actual si el cobro viene en el futuro', async () => {
+      const futuro = new Date(Date.now() + 60 * 60 * 1000);
 
-      await service.stampSubscription({
-        receiver,
-        total: 199,
-        currency: 'MXN',
-        description: 'Suscripción ZPLPDF',
-        chargedAt: new Date(Date.now() + 60 * 60 * 1000),
-      });
+      expect(await stampWith(futuro)).toBe(meridaLocal(new Date()));
+    });
 
-      expect(sentPayload(post).Date).toBeUndefined();
+    it('manda siempre la fecha, aunque no se conozca la del cobro', async () => {
+      expect(await stampWith(undefined)).toBe(meridaLocal(new Date()));
     });
   });
 

--- a/src/modules/facturama/facturama.service.spec.ts
+++ b/src/modules/facturama/facturama.service.spec.ts
@@ -1,0 +1,402 @@
+import axios from 'axios';
+import { FacturamaService } from './facturama.service.js';
+import { CfdiErrorCodes, mapPacErrorToCode } from './facturama.constants.js';
+import {
+  FacturamaError,
+  type FacturamaCfdiRequest,
+} from './interfaces/facturama.interface.js';
+
+/**
+ * El CFDI se emite sin nadie delante: lo dispara un webhook de Stripe. Un
+ * desglose de IVA que no cuadre, o un rechazo del PAC mal clasificado, no se
+ * detectan hasta que el cliente reclama su factura y el plazo del SAT ya corrió.
+ */
+describe('FacturamaService', () => {
+  function buildService(overrides: { post?: jest.Mock; get?: jest.Mock } = {}) {
+    const post = overrides.post ?? jest.fn();
+    const get = overrides.get ?? jest.fn();
+
+    const service = Object.create(
+      FacturamaService.prototype,
+    ) as FacturamaService;
+    Object.assign(service, {
+      logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+      http: { post, get },
+      expeditionPlace: '97308',
+    });
+
+    return { service, post, get };
+  }
+
+  const receiver = {
+    Rfc: 'ABC010101AB1',
+    Name: 'EMPRESA DEMO',
+    CfdiUse: 'G03',
+    FiscalRegime: '601',
+    TaxZipCode: '97000',
+  };
+
+  function stampedResponse() {
+    return {
+      data: {
+        Id: 'cfdi_123',
+        Complement: {
+          TaxStamp: {
+            Uuid: '27568D31-7E57-442F-BA77-798CBF30BD7D',
+            Date: '2026-08-04T12:00:00',
+          },
+        },
+      },
+    };
+  }
+
+  /** Devuelve el payload que se le mandó a Facturama. */
+  function sentPayload(post: jest.Mock): FacturamaCfdiRequest {
+    return post.mock.calls[0][1] as FacturamaCfdiRequest;
+  }
+
+  describe('desglose de IVA', () => {
+    it('desglosa hacia atrás un precio con IVA incluido', async () => {
+      const { service, post } = buildService({
+        post: jest.fn().mockResolvedValue(stampedResponse()),
+      });
+
+      // $199 MXN es el total que paga el cliente, no el subtotal.
+      await service.stampSubscription({
+        receiver,
+        total: 199,
+        currency: 'MXN',
+        description: 'Suscripción ZPLPDF Plan PRO',
+      });
+
+      const item = sentPayload(post).Items[0];
+      expect(item.Subtotal).toBe('171.551724');
+      expect(item.Taxes[0].Total).toBe('27.448276');
+      expect(item.Total).toBe('199.000000');
+    });
+
+    it('cuadra subtotal + IVA con el total cobrado', async () => {
+      const { service, post } = buildService({
+        post: jest.fn().mockResolvedValue(stampedResponse()),
+      });
+
+      // Importes con decimales incómodos: son los que produce una proración.
+      for (const total of [199, 184.61, 1000, 0.99, 3499.37]) {
+        post.mockClear();
+        await service.stampSubscription({
+          receiver,
+          total,
+          currency: 'MXN',
+          description: 'Suscripción ZPLPDF',
+        });
+
+        const item = sentPayload(post).Items[0];
+        const suma =
+          parseFloat(item.Subtotal) + parseFloat(item.Taxes[0].Total);
+
+        // El PAC rechaza el comprobante si la suma no coincide con el total.
+        expect(suma.toFixed(6)).toBe(parseFloat(item.Total).toFixed(6));
+      }
+    });
+
+    it('usa la base del impuesto igual al subtotal', async () => {
+      const { service, post } = buildService({
+        post: jest.fn().mockResolvedValue(stampedResponse()),
+      });
+
+      await service.stampSubscription({
+        receiver,
+        total: 199,
+        currency: 'MXN',
+        description: 'Suscripción ZPLPDF',
+      });
+
+      const item = sentPayload(post).Items[0];
+      expect(item.Taxes[0].Base).toBe(item.Subtotal);
+      expect(item.Taxes[0].Rate).toBe('0.160000');
+      expect(item.Taxes[0].IsRetention).toBe(false);
+    });
+  });
+
+  describe('fecha de expedición', () => {
+    it('usa la fecha del cobro si está dentro de las 72 horas', async () => {
+      const { service, post } = buildService({
+        post: jest.fn().mockResolvedValue(stampedResponse()),
+      });
+      const chargedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+
+      await service.stampSubscription({
+        receiver,
+        total: 199,
+        currency: 'MXN',
+        description: 'Suscripción ZPLPDF',
+        chargedAt,
+      });
+
+      // Mantiene cobro y comprobante en el mismo mes cuando el cargo cae a fin
+      // de mes y el webhook se procesa ya entrado el siguiente.
+      expect(sentPayload(post).Date).toBe(chargedAt.toISOString().slice(0, 19));
+    });
+
+    it('omite la fecha si el cobro tiene más de 72 horas', async () => {
+      const { service, post } = buildService({
+        post: jest.fn().mockResolvedValue(stampedResponse()),
+      });
+
+      await service.stampSubscription({
+        receiver,
+        total: 199,
+        currency: 'MXN',
+        description: 'Suscripción ZPLPDF',
+        chargedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000),
+      });
+
+      // Facturama rechaza cualquier fecha más vieja; sin el campo, sella con la
+      // hora del timbrado y el CFDI sale igualmente.
+      expect(sentPayload(post).Date).toBeUndefined();
+    });
+
+    it('omite una fecha futura', async () => {
+      const { service, post } = buildService({
+        post: jest.fn().mockResolvedValue(stampedResponse()),
+      });
+
+      await service.stampSubscription({
+        receiver,
+        total: 199,
+        currency: 'MXN',
+        description: 'Suscripción ZPLPDF',
+        chargedAt: new Date(Date.now() + 60 * 60 * 1000),
+      });
+
+      expect(sentPayload(post).Date).toBeUndefined();
+    });
+  });
+
+  describe('respuesta del PAC', () => {
+    it('devuelve el UUID y el id de Facturama', async () => {
+      const { service } = buildService({
+        post: jest.fn().mockResolvedValue(stampedResponse()),
+      });
+
+      const result = await service.stampSubscription({
+        receiver,
+        total: 199,
+        currency: 'MXN',
+        description: 'Suscripción ZPLPDF',
+      });
+
+      expect(result.facturamaId).toBe('cfdi_123');
+      expect(result.uuid).toBe('27568D31-7E57-442F-BA77-798CBF30BD7D');
+    });
+
+    it('falla si el PAC responde 200 pero sin folio fiscal', async () => {
+      const { service } = buildService({
+        post: jest.fn().mockResolvedValue({ data: { Id: 'cfdi_123' } }),
+      });
+
+      // Sin UUID no hay comprobante fiscal, por muy 200 que sea la respuesta:
+      // darlo por bueno dejaría al cliente con un CFDI inexistente marcado como
+      // timbrado.
+      await expect(
+        service.stampSubscription({
+          receiver,
+          total: 199,
+          currency: 'MXN',
+          description: 'Suscripción ZPLPDF',
+        }),
+      ).rejects.toThrow(FacturamaError);
+    });
+  });
+
+  describe('clasificación de errores', () => {
+    function axiosError(status: number | undefined, data: unknown) {
+      const error = new Error('Request failed') as Error & {
+        isAxiosError: boolean;
+        response?: { status: number; data: unknown };
+      };
+      error.isAxiosError = true;
+      if (status !== undefined) {
+        error.response = { status, data };
+      }
+      return error;
+    }
+
+    beforeAll(() => {
+      jest
+        .spyOn(axios, 'isAxiosError')
+        .mockImplementation(
+          (payload: unknown) =>
+            (payload as { isAxiosError?: boolean })?.isAxiosError === true,
+        );
+    });
+
+    afterAll(() => jest.restoreAllMocks());
+
+    async function stampExpectingCode(post: jest.Mock) {
+      const { service } = buildService({ post });
+      try {
+        await service.stampSubscription({
+          receiver,
+          total: 199,
+          currency: 'MXN',
+          description: 'Suscripción ZPLPDF',
+        });
+        throw new Error('Se esperaba un FacturamaError');
+      } catch (error) {
+        expect(error).toBeInstanceOf(FacturamaError);
+        return error as FacturamaError;
+      }
+    }
+
+    it('clasifica un 500 del PAC como pac_unavailable', async () => {
+      const error = await stampExpectingCode(
+        jest.fn().mockRejectedValue(axiosError(500, {})),
+      );
+      // Reintentable tal cual: no es culpa del perfil del usuario.
+      expect(error.code).toBe(CfdiErrorCodes.PAC_UNAVAILABLE);
+    });
+
+    it('clasifica un timeout sin respuesta como pac_unavailable', async () => {
+      const error = await stampExpectingCode(
+        jest.fn().mockRejectedValue(axiosError(undefined, undefined)),
+      );
+      expect(error.code).toBe(CfdiErrorCodes.PAC_UNAVAILABLE);
+    });
+
+    it('clasifica un 401 como pac_unavailable, no como error del usuario', async () => {
+      const error = await stampExpectingCode(
+        jest.fn().mockRejectedValue(axiosError(401, {})),
+      );
+      // Es un fallo de configuración del emisor; reintentar el mismo CFDI no lo
+      // arregla, pero tampoco debe culpar al RFC del cliente.
+      expect(error.code).toBe(CfdiErrorCodes.PAC_UNAVAILABLE);
+    });
+
+    it('extrae el detalle de ModelState de ASP.NET', async () => {
+      const error = await stampExpectingCode(
+        jest.fn().mockRejectedValue(
+          axiosError(400, {
+            Message: 'The request is invalid.',
+            ModelState: {
+              'Cfdi.Receiver.Rfc': [
+                'El RFC del receptor no se encuentra en la lista de RFC inscritos del SAT',
+              ],
+            },
+          }),
+        ),
+      );
+
+      // El `Message` de primer nivel es genérico; el detalle útil está en las
+      // hojas de ModelState.
+      expect(error.code).toBe(CfdiErrorCodes.RFC_NOT_FOUND);
+      expect(error.message).toContain('no se encuentra en la lista de RFC');
+    });
+  });
+
+  describe('mapPacErrorToCode', () => {
+    const casos: Array<[string, string]> = [
+      [
+        'El campo Nombre del receptor no coincide con el registrado ante el SAT',
+        CfdiErrorCodes.NAME_MISMATCH,
+      ],
+      [
+        'CFDI40161 - El DomicilioFiscalReceptor no corresponde con el código postal',
+        CfdiErrorCodes.POSTAL_CODE_MISMATCH,
+      ],
+      [
+        'El RegimenFiscalReceptor no corresponde al RFC del receptor',
+        CfdiErrorCodes.REGIME_MISMATCH,
+      ],
+      [
+        'El UsoCFDI no es compatible con el régimen fiscal del receptor',
+        CfdiErrorCodes.CFDI_USE_INVALID,
+      ],
+      [
+        'El RFC del receptor no se encuentra en la lista de RFC inscritos',
+        CfdiErrorCodes.RFC_NOT_FOUND,
+      ],
+      ['Un rechazo que nadie previó', CfdiErrorCodes.UNKNOWN],
+    ];
+
+    it.each(casos)('mapea «%s»', (mensaje, esperado) => {
+      expect(mapPacErrorToCode(mensaje)).toBe(esperado);
+    });
+
+    it('prioriza el nombre sobre el RFC cuando el mensaje menciona ambos', () => {
+      // Los rechazos por razón social siempre citan también el RFC; si ganara la
+      // regla del RFC, el usuario corregiría el campo equivocado.
+      expect(
+        mapPacErrorToCode(
+          'El Nombre del receptor no coincide con el registrado para el RFC ABC010101AB1',
+        ),
+      ).toBe(CfdiErrorCodes.NAME_MISMATCH);
+    });
+
+    it('prioriza el uso de CFDI sobre el régimen cuando menciona ambos', () => {
+      // Mismo problema: la incompatibilidad es entre uso y régimen, así que el
+      // rechazo nombra los dos. El campo que el usuario debe cambiar es el uso.
+      expect(
+        mapPacErrorToCode(
+          'El UsoCFDI G03 no es compatible con el régimen fiscal 605 del receptor',
+        ),
+      ).toBe(CfdiErrorCodes.CFDI_USE_INVALID);
+    });
+
+    it('mantiene regime_mismatch cuando el rechazo es solo del régimen', () => {
+      expect(
+        mapPacErrorToCode(
+          'El campo RegimenFiscalReceptor no contiene una clave válida para el RFC',
+        ),
+      ).toBe(CfdiErrorCodes.REGIME_MISMATCH);
+    });
+  });
+
+  describe('descargas', () => {
+    it('decodifica el PDF que llega en base64', async () => {
+      const contenido = Buffer.from('%PDF-1.4 contenido');
+      const { service, get } = buildService({
+        get: jest.fn().mockResolvedValue({
+          data: { Content: contenido.toString('base64') },
+        }),
+      });
+
+      const pdf = await service.downloadPdf('cfdi_123');
+
+      expect(get).toHaveBeenCalledWith('/Cfdi/pdf/issued/cfdi_123');
+      expect(pdf.toString()).toBe('%PDF-1.4 contenido');
+    });
+
+    it('falla si el XML llega vacío', async () => {
+      const { service } = buildService({
+        get: jest.fn().mockResolvedValue({ data: {} }),
+      });
+
+      await expect(service.downloadXml('cfdi_123')).rejects.toThrow(
+        FacturamaError,
+      );
+    });
+  });
+
+  describe('sin credenciales', () => {
+    it('no timbra y reporta el PAC como no disponible', async () => {
+      const service = Object.create(
+        FacturamaService.prototype,
+      ) as FacturamaService;
+      Object.assign(service, {
+        logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+        http: null,
+      });
+
+      expect(service.isConfigured).toBe(false);
+      await expect(
+        service.stampSubscription({
+          receiver,
+          total: 199,
+          currency: 'MXN',
+          description: 'Suscripción ZPLPDF',
+        }),
+      ).rejects.toThrow(FacturamaError);
+    });
+  });
+});

--- a/src/modules/facturama/facturama.service.ts
+++ b/src/modules/facturama/facturama.service.ts
@@ -1,0 +1,334 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios, { AxiosInstance } from 'axios';
+import {
+  CFDI_EXPORTATION_NOT_APPLICABLE,
+  CFDI_MAX_BACKDATE_MS,
+  CFDI_PAYMENT_FORM_CREDIT_CARD,
+  CFDI_PAYMENT_METHOD_PUE,
+  CFDI_PRODUCT_CODE,
+  CFDI_TAX_NAME,
+  CFDI_TAX_OBJECT,
+  CFDI_TAX_RATE,
+  CFDI_TYPE_INCOME,
+  CFDI_UNIT_CODE,
+  CFDI_UNIT_NAME,
+  CfdiErrorCodes,
+  mapPacErrorToCode,
+} from './facturama.constants.js';
+import {
+  FacturamaError,
+  type FacturamaCfdiRequest,
+  type FacturamaCfdiResponse,
+  type FacturamaItem,
+  type StampResult,
+  type StampSubscriptionParams,
+} from './interfaces/facturama.interface.js';
+
+/**
+ * Cliente de Facturama para el timbrado de CFDI 4.0.
+ *
+ * Es una integración propia y no una llamada al backend de la intranet, que ya
+ * factura contra la misma cuenta: aquel endpoint exige que cada concepto exista
+ * como SKU en su catálogo de inventario, y colgar el timbrado de un segundo
+ * servicio metería una dependencia de disponibilidad en la ruta de un webhook
+ * con plazo fiscal. Lo único que se comparte es la cuenta —mismo RFC emisor,
+ * mismo CSD, mismos timbres.
+ */
+@Injectable()
+export class FacturamaService {
+  private readonly logger = new Logger(FacturamaService.name);
+  private readonly http: AxiosInstance | null = null;
+  private readonly expeditionPlace: string;
+
+  constructor(private readonly configService: ConfigService) {
+    const username = this.configService.get<string>('FACTURAMA_USERNAME');
+    const password = this.configService.get<string>('FACTURAMA_PASSWORD');
+    const baseURL = this.configService.get<string>(
+      'FACTURAMA_URL_BASE',
+      'https://api.facturama.mx',
+    );
+    this.expeditionPlace = this.configService.get<string>(
+      'FACTURAMA_EXPEDITION_PLACE',
+      '97308',
+    );
+
+    if (!username || !password) {
+      // Sin credenciales el módulo queda inerte en vez de tumbar el arranque:
+      // el resto de la app (conversión, pagos) no depende del PAC.
+      this.logger.warn(
+        'Facturama no configurado (FACTURAMA_USERNAME / FACTURAMA_PASSWORD). El timbrado de CFDI queda deshabilitado.',
+      );
+      return;
+    }
+
+    this.http = axios.create({
+      baseURL,
+      timeout: 30000,
+      headers: {
+        Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`,
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
+  get isConfigured(): boolean {
+    return this.http !== null;
+  }
+
+  /**
+   * Timbra un CFDI de ingreso por una suscripción cobrada.
+   *
+   * El importe llega con el IVA ya incluido —los precios publicados son finales—
+   * así que el desglose se hace hacia atrás: el subtotal es el total entre 1.16 y
+   * el IVA es la diferencia. Calcular el impuesto como `subtotal * 0.16` en vez
+   * de por diferencia deja descuadres de una millonésima que el PAC rechaza.
+   */
+  async stampSubscription(
+    params: StampSubscriptionParams,
+  ): Promise<StampResult> {
+    this.assertConfigured();
+
+    const item = this.buildItem(params.total, params.description);
+
+    const payload: FacturamaCfdiRequest = {
+      Currency: params.currency.toUpperCase(),
+      CfdiType: CFDI_TYPE_INCOME,
+      ExpeditionPlace: this.expeditionPlace,
+      Exportation: CFDI_EXPORTATION_NOT_APPLICABLE,
+      PaymentForm: params.paymentForm ?? CFDI_PAYMENT_FORM_CREDIT_CARD,
+      PaymentMethod: CFDI_PAYMENT_METHOD_PUE,
+      Receiver: params.receiver,
+      Items: [item],
+      ...this.resolveExpeditionDate(params.chargedAt),
+    };
+
+    this.logger.log(
+      `Timbrando CFDI para ${params.receiver.Rfc} por ${params.total} ${params.currency}`,
+    );
+
+    const response = await this.request<FacturamaCfdiResponse>(
+      'post',
+      '/3/cfdis',
+      payload,
+    );
+
+    const uuid = response.Complement?.TaxStamp?.Uuid;
+
+    if (!response.Id || !uuid) {
+      // Sin UUID no hay comprobante fiscal, por muy 200 que devuelva el PAC.
+      throw new FacturamaError(
+        CfdiErrorCodes.UNKNOWN,
+        'Facturama respondió sin folio fiscal (UUID)',
+        response,
+      );
+    }
+
+    this.logger.log(`CFDI timbrado: ${response.Id} — UUID ${uuid}`);
+
+    return {
+      facturamaId: response.Id,
+      uuid,
+      stampedAt: response.Complement?.TaxStamp?.Date
+        ? new Date(response.Complement.TaxStamp.Date)
+        : new Date(),
+    };
+  }
+
+  /** Descarga el PDF del CFDI emitido. Facturama lo devuelve en base64. */
+  async downloadPdf(facturamaId: string): Promise<Buffer> {
+    return this.downloadFile(`/Cfdi/pdf/issued/${facturamaId}`, 'PDF');
+  }
+
+  /** Descarga el XML timbrado, que es el comprobante fiscal con validez legal. */
+  async downloadXml(facturamaId: string): Promise<Buffer> {
+    return this.downloadFile(`/Cfdi/xml/issued/${facturamaId}`, 'XML');
+  }
+
+  private async downloadFile(path: string, kind: string): Promise<Buffer> {
+    this.assertConfigured();
+
+    const response = await this.request<{ Content?: string }>('get', path);
+
+    if (!response?.Content) {
+      throw new FacturamaError(
+        CfdiErrorCodes.UNKNOWN,
+        `Facturama devolvió un ${kind} vacío`,
+        response,
+      );
+    }
+
+    return Buffer.from(response.Content, 'base64');
+  }
+
+  /**
+   * Construye el único concepto del CFDI.
+   *
+   * Seis decimales en los importes unitarios porque es lo que admite el anexo 20
+   * y lo que evita que la suma de conceptos no cuadre con el total.
+   */
+  private buildItem(total: number, description: string): FacturamaItem {
+    const subtotal = total / (1 + CFDI_TAX_RATE);
+    const tax = total - subtotal;
+
+    const subtotalStr = subtotal.toFixed(6);
+    const taxStr = tax.toFixed(6);
+
+    return {
+      ProductCode: CFDI_PRODUCT_CODE,
+      Description: description,
+      UnitCode: CFDI_UNIT_CODE,
+      Unit: CFDI_UNIT_NAME,
+      UnitPrice: subtotalStr,
+      Quantity: '1',
+      Subtotal: subtotalStr,
+      TaxObject: CFDI_TAX_OBJECT,
+      Taxes: [
+        {
+          Total: taxStr,
+          Name: CFDI_TAX_NAME,
+          Base: subtotalStr,
+          Rate: CFDI_TAX_RATE.toFixed(6),
+          IsRetention: false,
+        },
+      ],
+      Total: total.toFixed(6),
+    };
+  }
+
+  /**
+   * Decide la fecha de expedición.
+   *
+   * Se prefiere la del cobro para que comprobante y cobro caigan en el mismo mes
+   * —importa cuando el cargo es de los últimos días—, pero Facturama rechaza
+   * cualquier fecha de más de 72 h, así que fuera de esa ventana se omite el
+   * campo y el PAC sella con la hora del timbrado.
+   */
+  private resolveExpeditionDate(chargedAt?: Date): { Date?: string } {
+    if (!chargedAt) {
+      return {};
+    }
+
+    const age = Date.now() - chargedAt.getTime();
+    if (age < 0 || age > CFDI_MAX_BACKDATE_MS) {
+      return {};
+    }
+
+    // Facturama espera hora local sin zona; el sufijo Z se lo rechaza.
+    return { Date: chargedAt.toISOString().slice(0, 19) };
+  }
+
+  private async request<T>(
+    method: 'get' | 'post',
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    try {
+      const { data } =
+        method === 'get'
+          ? await this.http.get<T>(path)
+          : await this.http.post<T>(path, body);
+      return data;
+    } catch (error) {
+      throw this.toFacturamaError(error, path);
+    }
+  }
+
+  /**
+   * Normaliza cualquier fallo a un `FacturamaError` con código estable.
+   *
+   * Se separa el PAC caído (reintentable, no es culpa del usuario) del rechazo
+   * fiscal (el usuario tiene que corregir su perfil): en el primer caso el CFDI
+   * se puede reintentar tal cual, en el segundo reintentar sin tocar nada vuelve
+   * a fallar igual.
+   */
+  private toFacturamaError(error: unknown, path: string): FacturamaError {
+    if (error instanceof FacturamaError) {
+      return error;
+    }
+
+    if (!axios.isAxiosError(error)) {
+      return new FacturamaError(
+        CfdiErrorCodes.UNKNOWN,
+        (error as Error)?.message ?? 'Error desconocido de Facturama',
+        error,
+      );
+    }
+
+    const status = error.response?.status;
+    const data = error.response?.data;
+
+    // Sin respuesta, timeout o 5xx: el PAC no está disponible.
+    if (!status || status >= 500) {
+      this.logger.error(
+        `Facturama no disponible en ${path}: ${error.message} (status ${status ?? 'sin respuesta'})`,
+      );
+      return new FacturamaError(
+        CfdiErrorCodes.PAC_UNAVAILABLE,
+        `Facturama no disponible: ${error.message}`,
+        data,
+      );
+    }
+
+    if (status === 401 || status === 403) {
+      // Credenciales o permisos: es un fallo de configuración nuestro, no del
+      // usuario, y no se arregla reintentando el mismo CFDI.
+      this.logger.error(
+        `Facturama rechazó las credenciales en ${path} (status ${status})`,
+      );
+      return new FacturamaError(
+        CfdiErrorCodes.PAC_UNAVAILABLE,
+        'Facturama rechazó las credenciales del emisor',
+        data,
+      );
+    }
+
+    const detail = this.extractErrorMessage(data) || error.message;
+    const code = mapPacErrorToCode(detail);
+
+    this.logger.error(
+      `Facturama rechazó ${path} (status ${status}) [${code}]: ${detail}`,
+    );
+
+    return new FacturamaError(code, detail, data);
+  }
+
+  /**
+   * Extrae el mensaje útil de la respuesta de error.
+   *
+   * Facturama corre sobre ASP.NET Web API, que reporta las validaciones en
+   * `ModelState` como un mapa de campo → lista de errores. El `Message` de
+   * primer nivel suele ser genérico («The request is invalid»), así que el
+   * detalle aprovechable está en las hojas.
+   */
+  private extractErrorMessage(data: unknown): string {
+    if (!data) return '';
+    if (typeof data === 'string') return data;
+
+    const body = data as {
+      Message?: string;
+      message?: string;
+      ModelState?: Record<string, string[]>;
+      Error?: string;
+    };
+
+    const modelStateErrors = body.ModelState
+      ? Object.values(body.ModelState).flat().filter(Boolean)
+      : [];
+
+    if (modelStateErrors.length > 0) {
+      return modelStateErrors.join(' | ');
+    }
+
+    return body.Message || body.message || body.Error || JSON.stringify(data);
+  }
+
+  private assertConfigured(): void {
+    if (!this.http) {
+      throw new FacturamaError(
+        CfdiErrorCodes.PAC_UNAVAILABLE,
+        'Facturama no está configurado en este entorno',
+      );
+    }
+  }
+}

--- a/src/modules/facturama/facturama.service.ts
+++ b/src/modules/facturama/facturama.service.ts
@@ -40,6 +40,8 @@ export class FacturamaService {
   private readonly logger = new Logger(FacturamaService.name);
   private readonly http: AxiosInstance | null = null;
   private readonly expeditionPlace: string;
+  /** Zona del lugar de expedición. El emisor tiene su domicilio fiscal en Mérida. */
+  private readonly timezone: string;
 
   constructor(private readonly configService: ConfigService) {
     const username = this.configService.get<string>('FACTURAMA_USERNAME');
@@ -51,6 +53,10 @@ export class FacturamaService {
     this.expeditionPlace = this.configService.get<string>(
       'FACTURAMA_EXPEDITION_PLACE',
       '97308',
+    );
+    this.timezone = this.configService.get<string>(
+      'FACTURAMA_TIMEZONE',
+      'America/Merida',
     );
 
     if (!username || !password) {
@@ -197,25 +203,53 @@ export class FacturamaService {
   }
 
   /**
-   * Decide la fecha de expedición.
+   * Decide la fecha de expedición, siempre en la hora local del emisor.
    *
    * Se prefiere la del cobro para que comprobante y cobro caigan en el mismo mes
-   * —importa cuando el cargo es de los últimos días—, pero Facturama rechaza
-   * cualquier fecha de más de 72 h, así que fuera de esa ventana se omite el
-   * campo y el PAC sella con la hora del timbrado.
+   * —importa cuando el cargo es de los últimos días del mes—, pero Facturama
+   * rechaza cualquier fecha de más de 72 h, así que fuera de esa ventana se
+   * expide con la hora actual.
+   *
+   * El campo se manda siempre. Omitirlo delegaba la fecha al PAC, que es
+   * aceptable en el timbrado inmediato pero no en un reintento: ahí la única
+   * fecha válida es la de ahora, y hay que decirlo explícitamente.
    */
-  private resolveExpeditionDate(chargedAt?: Date): { Date?: string } {
-    if (!chargedAt) {
-      return {};
-    }
+  private resolveExpeditionDate(chargedAt?: Date): { Date: string } {
+    const now = Date.now();
+    const age = chargedAt ? now - chargedAt.getTime() : Infinity;
+    const withinWindow = age >= 0 && age <= CFDI_MAX_BACKDATE_MS;
 
-    const age = Date.now() - chargedAt.getTime();
-    if (age < 0 || age > CFDI_MAX_BACKDATE_MS) {
-      return {};
-    }
+    return {
+      Date: this.formatIssuerLocalTime(withinWindow ? chargedAt : new Date()),
+    };
+  }
 
-    // Facturama espera hora local sin zona; el sufijo Z se lo rechaza.
-    return { Date: chargedAt.toISOString().slice(0, 19) };
+  /**
+   * Formatea una fecha en la hora local del lugar de expedición, sin zona.
+   *
+   * Facturama interpreta `Date` como hora local del emisor. Mandarle el UTC de
+   * `toISOString()` adelantaba seis horas el comprobante —el domicilio fiscal
+   * está en Mérida, UTC-6—, y un cobro de la tarde salía fechado en el futuro,
+   * que el PAC rechaza de plano.
+   */
+  private formatIssuerLocalTime(date: Date): string {
+    const parts = new Intl.DateTimeFormat('en-CA', {
+      timeZone: this.timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      // h23 y no hour12:false: este último devuelve «24» a medianoche en algunos
+      // runtimes, y «24:00:00» no es una hora válida en el XML.
+      hourCycle: 'h23',
+    }).formatToParts(date);
+
+    const get = (type: string) =>
+      parts.find((part) => part.type === type)?.value ?? '00';
+
+    return `${get('year')}-${get('month')}-${get('day')}T${get('hour')}:${get('minute')}:${get('second')}`;
   }
 
   private async request<T>(

--- a/src/modules/facturama/interfaces/facturama.interface.ts
+++ b/src/modules/facturama/interfaces/facturama.interface.ts
@@ -1,0 +1,101 @@
+import type { CfdiErrorCode } from '../facturama.constants.js';
+
+/** Receptor del CFDI, tal como lo espera la API de Facturama. */
+export interface FacturamaReceiver {
+  Rfc: string;
+  /** Razón social sin régimen de capital, en mayúsculas. */
+  Name: string;
+  /** c_UsoCFDI */
+  CfdiUse: string;
+  /** c_RegimenFiscal */
+  FiscalRegime: string;
+  /** CP del domicilio fiscal del receptor. */
+  TaxZipCode: string;
+}
+
+export interface FacturamaItemTax {
+  Total: string;
+  Name: string;
+  Base: string;
+  Rate: string;
+  IsRetention: boolean;
+}
+
+export interface FacturamaItem {
+  ProductCode: string;
+  Description: string;
+  UnitCode: string;
+  Unit: string;
+  UnitPrice: string;
+  Quantity: string;
+  Subtotal: string;
+  TaxObject: string;
+  Taxes?: FacturamaItemTax[];
+  Total: string;
+}
+
+export interface FacturamaCfdiRequest {
+  Currency: string;
+  CfdiType: string;
+  ExpeditionPlace: string;
+  Exportation: string;
+  PaymentForm: string;
+  PaymentMethod: string;
+  /** ISO 8601 sin zona. Se omite para que Facturama use la hora del timbrado. */
+  Date?: string;
+  Receiver: FacturamaReceiver;
+  Items: FacturamaItem[];
+}
+
+export interface FacturamaCfdiResponse {
+  Id: string;
+  Folio?: string;
+  Serie?: string;
+  Date?: string;
+  Total?: number;
+  Complement?: {
+    TaxStamp?: {
+      Uuid?: string;
+      Date?: string;
+      RfcProvCertif?: string;
+    };
+  };
+}
+
+/** Lo que necesita el servicio para construir un CFDI de suscripción. */
+export interface StampSubscriptionParams {
+  receiver: FacturamaReceiver;
+  /** Total efectivamente cobrado, con IVA incluido, en unidades (no centavos). */
+  total: number;
+  currency: string;
+  /** Texto del concepto, p. ej. «Suscripción ZPLPDF Plan PRO — 01/08/2026 a 31/08/2026». */
+  description: string;
+  /** c_FormaPago. Por defecto tarjeta de crédito. */
+  paymentForm?: string;
+  /** Fecha del cobro. Se usa si cae dentro de las 72 h que admite Facturama. */
+  chargedAt?: Date;
+}
+
+/** Resultado de un timbrado, ya normalizado para persistir. */
+export interface StampResult {
+  facturamaId: string;
+  uuid: string;
+  stampedAt: Date;
+}
+
+/**
+ * Error de Facturama ya traducido a un código estable.
+ *
+ * Se modela como clase para poder distinguirlo con `instanceof` de un fallo
+ * cualquiera al capturarlo en el webhook.
+ */
+export class FacturamaError extends Error {
+  constructor(
+    readonly code: CfdiErrorCode,
+    message: string,
+    readonly raw?: unknown,
+  ) {
+    super(message);
+    this.name = 'FacturamaError';
+  }
+}

--- a/src/modules/payments/payments.module.ts
+++ b/src/modules/payments/payments.module.ts
@@ -5,9 +5,15 @@ import { CacheModule } from '../cache/cache.module.js';
 import { AnalyticsModule } from '../analytics/analytics.module.js';
 import { ExchangeRateService } from '../admin/services/exchange-rate.service.js';
 import { EmailModule } from '../email/email.module.js';
+import { BillingModule } from '../billing/billing.module.js';
 
 @Module({
-  imports: [CacheModule, AnalyticsModule, forwardRef(() => EmailModule)],
+  imports: [
+    CacheModule,
+    AnalyticsModule,
+    forwardRef(() => EmailModule),
+    BillingModule,
+  ],
   controllers: [PaymentsController],
   providers: [PaymentsService, ExchangeRateService],
   exports: [PaymentsService],

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -359,7 +359,23 @@ export class PaymentsService {
     // en el momento de finalizarla —lo hace durante el propio checkout— y ya no
     // vuelve a tocarlos: propagarlos al recibir `checkout.session.completed`
     // llegaría tarde y el primer PDF saldría sin ellos.
-    await this.billingService.syncTaxProfileToStripe(userId);
+    //
+    // En modo estricto, para que el fallo detenga el checkout. Es preferible que
+    // el usuario reintente el pago a emitirle una factura fiscalmente incompleta
+    // que después no hay forma de corregir. Solo afecta a quien tiene perfil
+    // fiscal cargado: sin él la sincronización no hace nada y no puede fallar.
+    try {
+      await this.billingService.syncTaxProfileToStripe(userId, {
+        throwOnError: true,
+      });
+    } catch (error) {
+      this.logger.error(
+        `No se pudo propagar el perfil fiscal de ${userId} antes del checkout: ${error.message}`,
+      );
+      throw new ServiceUnavailableException(
+        'No se pudieron sincronizar tus datos de facturación. Inténtalo de nuevo en unos momentos.',
+      );
+    }
 
     // Create checkout session
     const session = await this.stripe.checkout.sessions.create({

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -16,6 +16,7 @@ import {
 import { GA4Service } from '../analytics/ga4.service.js';
 import { ExchangeRateService } from '../admin/services/exchange-rate.service.js';
 import { EmailService } from '../email/email.service.js';
+import { BillingService } from '../billing/billing.service.js';
 import type {
   StripeTransaction,
   SubscriptionEvent,
@@ -75,6 +76,7 @@ export class PaymentsService {
     private readonly exchangeRateService: ExchangeRateService,
     @Inject(forwardRef(() => EmailService))
     private readonly emailService: EmailService,
+    private readonly billingService: BillingService,
   ) {
     const stripeSecretKey = this.configService.get<string>('STRIPE_SECRET_KEY');
     const nodeEnv = this.configService.get<string>('NODE_ENV');
@@ -967,6 +969,11 @@ export class PaymentsService {
     );
 
     this.logger.log(`User ${userId} upgraded to ${plan} plan`);
+
+    // Un usuario puede haber cargado su perfil fiscal antes de tener customer en
+    // Stripe. Sin este segundo intento, su primera factura saldría sin la razón
+    // social ni el tax ID. Es idempotente y no lanza.
+    await this.billingService.syncTaxProfileToStripe(userId);
 
     // Determine transaction type based on previous plan
     const previousPlan = user?.plan || 'free';

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -354,6 +354,13 @@ export class PaymentsService {
       });
     }
 
+    // Los datos fiscales tienen que estar en el customer ANTES de abrir el
+    // checkout. Stripe copia el nombre, el domicilio y los tax IDs a la factura
+    // en el momento de finalizarla —lo hace durante el propio checkout— y ya no
+    // vuelve a tocarlos: propagarlos al recibir `checkout.session.completed`
+    // llegaría tarde y el primer PDF saldría sin ellos.
+    await this.billingService.syncTaxProfileToStripe(userId);
+
     // Create checkout session
     const session = await this.stripe.checkout.sessions.create({
       customer: customerId,
@@ -970,9 +977,10 @@ export class PaymentsService {
 
     this.logger.log(`User ${userId} upgraded to ${plan} plan`);
 
-    // Un usuario puede haber cargado su perfil fiscal antes de tener customer en
-    // Stripe. Sin este segundo intento, su primera factura saldría sin la razón
-    // social ni el tax ID. Es idempotente y no lanza.
+    // Segunda pasada, para las facturas siguientes. La primera ya se propagó
+    // antes de abrir el checkout —Stripe congela los datos fiscales al finalizar
+    // la factura—, pero aquí puede haberse detectado el país desde la dirección
+    // de facturación, y con él cambia el tipo de perfil que corresponde.
     await this.billingService.syncTaxProfileToStripe(userId);
 
     // Determine transaction type based on previous plan

--- a/src/modules/storage/storage.service.ts
+++ b/src/modules/storage/storage.service.ts
@@ -74,6 +74,24 @@ export class StorageService {
   }
 
   /**
+   * Guarda un archivo en una ruta arbitraria del bucket.
+   *
+   * Sin URL firmada de vuelta: los CFDI se conservan cinco años y su descarga se
+   * autoriza por usuario en cada petición, así que la URL se genera al leer y no
+   * al guardar.
+   */
+  async saveFile(
+    filePath: string,
+    content: Buffer,
+    contentType: string,
+  ): Promise<void> {
+    await this.storage
+      .bucket(this.bucketName)
+      .file(filePath)
+      .save(content, { metadata: { contentType } });
+  }
+
+  /**
    * Genera una URL firmada para cualquier archivo en el bucket
    * @param filePath Path del archivo en el bucket (ej: label-xxx.pdf)
    * @param downloadFilename Nombre del archivo para descarga (opcional)

--- a/src/modules/webhooks/webhooks.module.ts
+++ b/src/modules/webhooks/webhooks.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { WebhooksController } from './webhooks.controller.js';
 import { WebhooksService } from './webhooks.service.js';
 import { PaymentsModule } from '../payments/payments.module.js';
+import { BillingModule } from '../billing/billing.module.js';
 
 @Module({
-  imports: [PaymentsModule],
+  imports: [PaymentsModule, BillingModule],
   controllers: [WebhooksController],
   providers: [WebhooksService],
 })

--- a/src/modules/webhooks/webhooks.service.ts
+++ b/src/modules/webhooks/webhooks.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, BadRequestException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import Stripe from 'stripe';
 import { PaymentsService } from '../payments/payments.service.js';
+import { CfdiService } from '../billing/cfdi.service.js';
 
 @Injectable()
 export class WebhooksService {
@@ -12,6 +13,7 @@ export class WebhooksService {
   constructor(
     private readonly configService: ConfigService,
     private readonly paymentsService: PaymentsService,
+    private readonly cfdiService: CfdiService,
   ) {
     const stripeSecretKey = this.configService.get<string>('STRIPE_SECRET_KEY');
     this.webhookSecret = this.configService.get<string>(
@@ -73,11 +75,20 @@ export class WebhooksService {
         );
         break;
 
-      case 'invoice.payment_succeeded':
-        await this.paymentsService.handleInvoicePaid(
-          event.data.object as Stripe.Invoice,
-        );
+      case 'invoice.payment_succeeded': {
+        const invoice = event.data.object as Stripe.Invoice;
+
+        // El CFDI va aparte de `handleInvoicePaid` y antes que él a propósito.
+        // Aquel descarta `billing_reason: 'subscription_create'` porque el alta
+        // la resuelve `checkout.session.completed`, así que colgar de él el
+        // timbrado dejaría sin comprobante el primer cobro de cada cliente
+        // —justo el que más reclaman—. Fiscalmente se factura todo cobro, sea
+        // alta, renovación o cambio de plan.
+        await this.cfdiService.stampForInvoice(invoice);
+
+        await this.paymentsService.handleInvoicePaid(invoice);
         break;
+      }
 
       default:
         this.logger.log(`Unhandled event type: ${event.type}`);


### PR DESCRIPTION
Closes #68.

Dos flujos según el país del usuario: los mexicanos reciben un CFDI 4.0 timbrado automáticamente tras cada cobro, y el resto del mundo el PDF que Stripe ya genera, ahora con sus datos fiscales impresos.

## Por qué una integración propia y no la API de la intranet

`intranet-guatever-backend` ya factura contra la misma cuenta de Facturama, pero reutilizar su API no salía a cuenta:

- Su endpoint (`createCfdiInvoice`) exige que cada concepto exista como SKU en el catálogo de inventario (`productModel.findOne({ sku })`). Facturar una suscripción SaaS habría obligado a dar de alta productos ficticios en el inventario.
- Habría metido un segundo servicio en la ruta de un webhook con plazo fiscal: `Stripe → Cloud Run → intranet → Facturama`.
- Le falta descarga de PDF/XML y validación, así que había que escribir código igual, solo que allá.

Lo que sí se comparte es la **cuenta**: mismo RFC emisor (`GME200922Q73`), mismo CSD, mismos timbres. `POST /3/cfdis` toma el emisor del certificado cargado ahí, no del payload.

El cliente propio son ~250 líneas de axios; la «integración» reutilizable de la intranet eran 40.

## Endpoints

| Endpoint | Qué hace |
|---|---|
| `GET /api/billing/tax-profile` | Perfil fiscal. Nunca 404: un perfil vacío es un estado válido y el frontend necesita el `type` para renderizar |
| `PUT /api/billing/tax-profile` | Guarda y propaga a Stripe (`customers.update` + tax ID) |
| `GET /api/billing/invoices` | Cada factura gana un bloque `cfdi` |
| `POST /api/billing/invoices/:id/cfdi/retry` | Reintento del usuario cuando corrige sus datos |

## Decisiones que el frontend necesita conocer

1. **`errors` llega en `data.errors`, no en el nivel superior.** El `HttpExceptionFilter` global reescribe todas las respuestas de error del proyecto a `{success, error, message, data, requestId}`. Cambiarlo afectaría a toda la API. Igual con el 422: el código va en `data.cfdiError.code`.
2. **Los valores de `errors` son códigos estables** (`rfc_invalid_format`, `tax_regime_not_valid_for_person_type`), no frases. Mismo criterio que se acordó para `cfdi.error.code`: cuatro idiomas y el backend no conoce el del receptor.
3. **No se inventó ningún código fuera de la lista de 8.** El caso «usuario MX que paga en USD» sale como `invoice_not_stampable`.
4. **`pdfUrl` y `xmlUrl` son URLs firmadas que caducan a los 15 minutos**, no permanentes: el CFDI lleva el RFC y el domicilio del cliente.

## Detalles que no eran obvios

**El primer cobro no pasa por `handleInvoicePaid`.** Ese método descarta `billing_reason: 'subscription_create'` porque el alta la resuelve `checkout.session.completed`. Colgar de él el timbrado habría dejado sin comprobante la primera factura de cada cliente. El CFDI se engancha aparte y antes.

**Stripe congela los datos fiscales al finalizar la factura**, y eso ocurre durante el propio checkout. Por eso el perfil se propaga *antes* de `checkout.sessions.create` y en modo estricto: si la sincronización falla, el checkout no se abre. Es preferible que el usuario reintente el pago a emitirle un comprobante incompleto que después no hay forma de corregir.

**`Invoice` ya no expone `payment_intent`.** Con stripe@20 y la API `2025-11-17.clover`, los cobros viven en `payments.data[].payment.payment_intent`. De ahí se saca el tipo de tarjeta para elegir entre FormaPago `04` y `28`.

**Idempotencia por docId.** La colección `cfdis` usa el id de la factura de Stripe como identificador de documento, escrito con `create`, que falla si ya existe. Dos entregas del mismo webhook pueden pasar a la vez cualquier comprobación de aplicación, y un CFDI duplicado no se borra: se cancela a mano ante el SAT. El reintento manual usa una transición transaccional `failed → pending` por el mismo motivo.

**Nada de esto tumba el webhook.** Un rechazo del PAC deja el CFDI en `failed` con su código y Stripe recibe 200. Si el timbrado sale bien pero falla la persistencia, el documento queda en `pending` —estado que el reintento rechaza— con el UUID en el log: nunca `failed`, porque eso invitaría a duplicarlo.

**IVA hacia atrás.** Los precios en MXN son finales, así que subtotal = total / 1.16 e IVA por diferencia. Calcularlo como `subtotal * 0.16` deja descuadres de una millonésima que el PAC rechaza.

**Clave SAT 43231510** («Software para hacer etiquetas»), verificada contra el catálogo real y coherente con lo que ya usa la contabilidad del emisor.

## Verificación

- 185 tests (61 nuevos), build y lint limpios.
- Arranque completo comprobado: DI resuelta y las 6 rutas de billing registradas.
- Contra la cuenta real de Facturama, en llamadas de solo lectura: credenciales válidas, emisor `GME200922Q73`, CSD vigente hasta 2030-06-19, y `97308` confirmado como lugar de expedición.

**No se ha timbrado ningún CFDI real.** Todo el flujo del PAC está verificado contra mocks. La primera emisión será un comprobante real ante el SAT.

## Antes de desplegar

1. Dar de alta en Cloud Run `FACTURAMA_USERNAME`, `FACTURAMA_PASSWORD`, `FACTURAMA_URL_BASE` y `FACTURAMA_EXPEDITION_PLACE` con `--update-env-vars` (**no** `--set-env-vars`, que borraría las 28 existentes).
2. Variables primero, deploy después: al revés, el primer webhook encontraría el módulo inerte y esa factura se quedaría sin CFDI.

## Fuera de alcance

Cancelación de CFDI por reembolso, facturación de periodos anteriores a la carga del perfil, y complemento de pago (el cobro con tarjeta es PUE).

## Detectado de paso, no incluido

`payments.service.ts:1365` lee `(invoice as { subscription?: string | null }).subscription`, campo que también desapareció del nivel superior de `Invoice` en la API Basil. Si se confirma, `handleInvoicePaid` no estaría resolviendo el plan ni las fechas de periodo en las renovaciones. Es anterior a este PR y merece issue aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)