### PR TITLE
fix(payments): leer el periodo de facturación de donde Stripe lo dejó en Basil

### DIFF
--- a/src/common/utils/stripe-billing-period.util.spec.ts
+++ b/src/common/utils/stripe-billing-period.util.spec.ts
@@ -1,0 +1,116 @@
+import type Stripe from 'stripe';
+import {
+  extractBillingPeriod,
+  getSubscriptionIdFromInvoice,
+} from './stripe-billing-period.util.js';
+
+/**
+ * Estos dos accesos llevaban meses devolviendo `undefined` en producción sin que
+ * nada lo delatara: los campos que leían desaparecieron del nivel superior en la
+ * versión de API `2025-03-31.basil`, y los `as unknown as {...}` que envolvían el
+ * acceso impidieron al compilador avisar al subir a `stripe@20`.
+ *
+ * El síntoma no era un error, era una ausencia: `subscriptionPeriodStart/End`
+ * dejaron de escribirse y la cuota mensual de todo usuario de pago pasó a
+ * calcularse desde su día de registro en vez de su día de facturación.
+ */
+describe('stripe-billing-period.util', () => {
+  describe('extractBillingPeriod', () => {
+    const START = 1754006400;
+    const END = 1756684800;
+
+    it('lee el periodo de items.data[0], donde vive desde Basil', () => {
+      const subscription = {
+        id: 'sub_1',
+        items: {
+          data: [{ current_period_start: START, current_period_end: END }],
+        },
+      } as unknown as Stripe.Subscription;
+
+      const period = extractBillingPeriod(subscription);
+
+      expect(period.start).toEqual(new Date(START * 1000));
+      expect(period.end).toEqual(new Date(END * 1000));
+    });
+
+    it('ignora el campo del nivel superior, que ya no existe', () => {
+      // Forma anterior a Basil: si alguien la reintroduce, no debe colarse.
+      const subscription = {
+        id: 'sub_1',
+        current_period_start: START,
+        current_period_end: END,
+        items: { data: [] },
+      } as unknown as Stripe.Subscription;
+
+      expect(extractBillingPeriod(subscription)).toEqual({});
+    });
+
+    it('devuelve vacío si la suscripción no tiene líneas', () => {
+      const subscription = {
+        id: 'sub_1',
+        items: { data: [] },
+      } as unknown as Stripe.Subscription;
+
+      expect(extractBillingPeriod(subscription)).toEqual({});
+    });
+
+    it('devuelve vacío si falta una de las dos fechas', () => {
+      const subscription = {
+        id: 'sub_1',
+        items: { data: [{ current_period_start: START }] },
+      } as unknown as Stripe.Subscription;
+
+      // Un periodo a medias no sirve: `calculateCurrentPeriod` exige las dos.
+      expect(extractBillingPeriod(subscription)).toEqual({});
+    });
+
+    it('no revienta con una suscripción malformada', () => {
+      expect(extractBillingPeriod({} as Stripe.Subscription)).toEqual({});
+      expect(extractBillingPeriod(undefined as never)).toEqual({});
+    });
+  });
+
+  describe('getSubscriptionIdFromInvoice', () => {
+    it('lee el id de parent.subscription_details', () => {
+      const invoice = {
+        id: 'in_1',
+        parent: { subscription_details: { subscription: 'sub_123' } },
+      } as unknown as Stripe.Invoice;
+
+      expect(getSubscriptionIdFromInvoice(invoice)).toBe('sub_123');
+    });
+
+    it('acepta la suscripción expandida como objeto', () => {
+      const invoice = {
+        id: 'in_1',
+        parent: { subscription_details: { subscription: { id: 'sub_123' } } },
+      } as unknown as Stripe.Invoice;
+
+      expect(getSubscriptionIdFromInvoice(invoice)).toBe('sub_123');
+    });
+
+    it('ignora invoice.subscription, que ya no existe', () => {
+      // Esta era exactamente la lectura rota: devolvía `undefined` en todas las
+      // facturas, así que el bloque que actualizaba plan y periodo se saltaba
+      // entero y en silencio.
+      const invoice = {
+        id: 'in_1',
+        subscription: 'sub_123',
+      } as unknown as Stripe.Invoice;
+
+      expect(getSubscriptionIdFromInvoice(invoice)).toBeNull();
+    });
+
+    it('devuelve null en una factura que no viene de una suscripción', () => {
+      const invoice = {
+        id: 'in_1',
+        parent: { subscription_details: null },
+      } as unknown as Stripe.Invoice;
+
+      expect(getSubscriptionIdFromInvoice(invoice)).toBeNull();
+      expect(
+        getSubscriptionIdFromInvoice({ id: 'in_1' } as Stripe.Invoice),
+      ).toBeNull();
+    });
+  });
+});

--- a/src/common/utils/stripe-billing-period.util.ts
+++ b/src/common/utils/stripe-billing-period.util.ts
@@ -1,0 +1,58 @@
+import type Stripe from 'stripe';
+
+export interface BillingPeriod {
+  start?: Date;
+  end?: Date;
+}
+
+/**
+ * Fechas del periodo de facturación vigente de una suscripción de Stripe.
+ *
+ * Desde la versión de API `2025-03-31.basil` el periodo dejó de vivir en la
+ * suscripción y pasó a cada línea: `items.data[].current_period_*`. El código
+ * anterior leía `subscription.current_period_start` a través de un
+ * `as unknown as { current_period_start: number }`, y ese cast es lo que impidió
+ * al compilador avisar cuando el proyecto subió a `stripe@20`: el valor pasó a
+ * ser `undefined`, los `if` que guardaban el periodo se saltaron sin ruido y
+ * `subscriptionPeriodStart/End` dejaron de escribirse para todos los usuarios de
+ * pago.
+ *
+ * Vive aquí y no en un servicio porque lo necesitan tanto los webhooks de pagos
+ * como el job de backfill del cron, y la lección del incidente es justamente que
+ * este acceso no debe estar duplicado.
+ *
+ * Devuelve un objeto vacío si no puede resolverlo; corresponde a quien llama
+ * decidir si eso merece un aviso.
+ */
+export function extractBillingPeriod(
+  subscription: Stripe.Subscription,
+): BillingPeriod {
+  const item = subscription?.items?.data?.[0];
+
+  if (!item?.current_period_start || !item?.current_period_end) {
+    return {};
+  }
+
+  return {
+    start: new Date(item.current_period_start * 1000),
+    end: new Date(item.current_period_end * 1000),
+  };
+}
+
+/**
+ * Id de la suscripción que originó una factura.
+ *
+ * Misma historia que el periodo: `invoice.subscription` desapareció del nivel
+ * superior en Basil y ahora cuelga de `parent.subscription_details`.
+ */
+export function getSubscriptionIdFromInvoice(
+  invoice: Stripe.Invoice,
+): string | null {
+  const subscription = invoice?.parent?.subscription_details?.subscription;
+
+  if (!subscription) {
+    return null;
+  }
+
+  return typeof subscription === 'string' ? subscription : subscription.id;
+}

--- a/src/modules/cron/cron.service.ts
+++ b/src/modules/cron/cron.service.ts
@@ -7,6 +7,7 @@ import { ExchangeRateService } from '../admin/services/exchange-rate.service.js'
 import { ExpenseService } from '../admin/services/expense.service.js';
 import { GoalsService } from '../admin/services/goals.service.js';
 import { GA4Service } from '../analytics/ga4.service.js';
+import { extractBillingPeriod } from '../../common/utils/stripe-billing-period.util.js';
 
 export interface ResetUsageResult {
   resetCount: number;
@@ -394,14 +395,9 @@ export class CronService {
           );
 
           // Extract period from subscription items
-          const periodStart = (
-            subscription as unknown as { current_period_start: number }
-          ).current_period_start;
-          const periodEnd = (
-            subscription as unknown as { current_period_end: number }
-          ).current_period_end;
+          const period = extractBillingPeriod(subscription);
 
-          if (!periodStart || !periodEnd) {
+          if (!period.start || !period.end) {
             this.logger.warn(
               `User ${user.email}: No period data in subscription`,
             );
@@ -411,16 +407,12 @@ export class CronService {
 
           // Update user in Firestore
           await this.firestoreService.updateUser(user.id, {
-            subscriptionPeriodStart: new Date(periodStart * 1000),
-            subscriptionPeriodEnd: new Date(periodEnd * 1000),
+            subscriptionPeriodStart: period.start,
+            subscriptionPeriodEnd: period.end,
           });
 
-          const startDate = new Date(periodStart * 1000)
-            .toISOString()
-            .split('T')[0];
-          const endDate = new Date(periodEnd * 1000)
-            .toISOString()
-            .split('T')[0];
+          const startDate = period.start.toISOString().split('T')[0];
+          const endDate = period.end.toISOString().split('T')[0];
           this.logger.log(`✅ ${user.email}: ${startDate} → ${endDate}`);
           updated++;
         } catch (error) {

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -17,6 +17,11 @@ import { GA4Service } from '../analytics/ga4.service.js';
 import { ExchangeRateService } from '../admin/services/exchange-rate.service.js';
 import { EmailService } from '../email/email.service.js';
 import { BillingService } from '../billing/billing.service.js';
+import {
+  extractBillingPeriod,
+  getSubscriptionIdFromInvoice,
+  type BillingPeriod,
+} from '../../common/utils/stripe-billing-period.util.js';
 import type {
   StripeTransaction,
   SubscriptionEvent,
@@ -40,6 +45,26 @@ export class PaymentsService {
   private litePriceId: string;
   private litePriceIdMxn: string;
   private readonly MAX_RETRIES = 3;
+
+  /**
+   * Resuelve el periodo de la suscripción y deja constancia si no puede.
+   *
+   * El aviso importa: la versión anterior fallaba en silencio y por eso el
+   * periodo llevaba meses sin escribirse sin que nada lo delatara.
+   */
+  private resolveBillingPeriod(
+    subscription: Stripe.Subscription,
+  ): BillingPeriod {
+    const period = extractBillingPeriod(subscription);
+
+    if (!period.start || !period.end) {
+      this.logger.warn(
+        `Subscription ${subscription.id} sin fechas de periodo en items.data[0]; no se actualiza el ciclo de facturación`,
+      );
+    }
+
+    return period;
+  }
 
   /**
    * Ejecuta una operación con reintentos
@@ -920,15 +945,9 @@ export class PaymentsService {
       if (priceId) {
         plan = this.getPlanFromPriceId(priceId);
       }
-      // Extract billing period dates (type cast for Stripe API compatibility)
-      const periodStart = (
-        subscription as unknown as { current_period_start: number }
-      ).current_period_start;
-      const periodEnd = (
-        subscription as unknown as { current_period_end: number }
-      ).current_period_end;
-      if (periodStart) subscriptionPeriodStart = new Date(periodStart * 1000);
-      if (periodEnd) subscriptionPeriodEnd = new Date(periodEnd * 1000);
+      const period = this.resolveBillingPeriod(subscription);
+      subscriptionPeriodStart = period.start;
+      subscriptionPeriodEnd = period.end;
     } catch (error) {
       this.logger.warn(`Failed to get subscription details: ${error.message}`);
     }
@@ -1105,13 +1124,7 @@ export class PaymentsService {
     }
 
     // Check subscription status with retry
-    // Type cast for Stripe API compatibility
-    const periodStart = (
-      subscription as unknown as { current_period_start: number }
-    ).current_period_start;
-    const periodEnd = (
-      subscription as unknown as { current_period_end: number }
-    ).current_period_end;
+    const period = this.resolveBillingPeriod(subscription);
 
     if (subscription.status === 'active') {
       // IMPORTANT: Only include period fields if they have values - Firestore rejects undefined
@@ -1119,11 +1132,11 @@ export class PaymentsService {
         plan,
         stripeSubscriptionId: subscription.id,
       };
-      if (periodStart) {
-        activeUpdateData.subscriptionPeriodStart = new Date(periodStart * 1000);
+      if (period.start) {
+        activeUpdateData.subscriptionPeriodStart = period.start;
       }
-      if (periodEnd) {
-        activeUpdateData.subscriptionPeriodEnd = new Date(periodEnd * 1000);
+      if (period.end) {
+        activeUpdateData.subscriptionPeriodEnd = period.end;
       }
       await this.withRetry(
         () => this.firestoreService.updateUser(user.id, activeUpdateData),
@@ -1378,9 +1391,16 @@ export class PaymentsService {
         : 'pro';
     let subscriptionPeriodStart: Date | undefined;
     let subscriptionPeriodEnd: Date | undefined;
-    const subscriptionId = (invoice as { subscription?: string | null })
-      .subscription as string;
-    if (subscriptionId) {
+    const subscriptionId = getSubscriptionIdFromInvoice(invoice);
+
+    if (!subscriptionId) {
+      // Antes se resolvía como `undefined` en todas las facturas y este bloque
+      // no llegaba a ejecutarse nunca, en silencio. Si vuelve a pasar, que se
+      // vea.
+      this.logger.warn(
+        `Invoice ${invoice.id} sin suscripción en parent.subscription_details; no se actualiza plan ni periodo`,
+      );
+    } else {
       try {
         const subscription =
           await this.stripe.subscriptions.retrieve(subscriptionId);
@@ -1391,15 +1411,9 @@ export class PaymentsService {
             plan = resolvedPlan;
           }
         }
-        // Extract new billing period dates (type cast for Stripe API compatibility)
-        const periodStart = (
-          subscription as unknown as { current_period_start: number }
-        ).current_period_start;
-        const periodEnd = (
-          subscription as unknown as { current_period_end: number }
-        ).current_period_end;
-        if (periodStart) subscriptionPeriodStart = new Date(periodStart * 1000);
-        if (periodEnd) subscriptionPeriodEnd = new Date(periodEnd * 1000);
+        const period = this.resolveBillingPeriod(subscription);
+        subscriptionPeriodStart = period.start;
+        subscriptionPeriodEnd = period.end;
       } catch (error) {
         this.logger.warn(
           `Failed to get subscription details for invoice: ${error.message}`,


### PR DESCRIPTION
Closes #70.

## El fallo

`subscriptionPeriodStart` y `subscriptionPeriodEnd` no se escribían para **ningún** usuario de pago. Los sitios que debían hacerlo leían campos que la API `2025-03-31.basil` movió de sitio, y el proyecto corre con `2025-11-17.clover`:

| Campo leído | Dónde vive ahora |
|---|---|
| `invoice.subscription` | `invoice.parent.subscription_details.subscription` |
| `subscription.current_period_start` | `subscription.items.data[].current_period_start` |
| `subscription.current_period_end` | `subscription.items.data[].current_period_end` |

Como las escrituras iban condicionadas a que el valor existiera (`if (periodStart) ...`), el fallo era una **ausencia**, no un error: ni excepción, ni log, ni rastro.

## Evidencia

`Updated billing period` no aparece **ni una vez en 30 días** de logs de Cloud Run, pese a que sí hubo webhooks de suscripción en ese intervalo:

```
gcloud logging read '... textPayload:"Updated billing period"' --freshness=30d   → (vacío)
gcloud logging read '... textPayload:"Subscription updated for user"'            → 3 resultados el 2026-08-04
```

## Impacto

`calculateCurrentPeriod` (`period-calculator.util.ts:56`) usa el periodo de suscripción si está, y si no cae a `calculateFreePeriod`. Como nunca estaba, **la cuota mensual de todo usuario de pago se renovaba el día de su registro en vez del día de su facturación**. Quien se registró el día 3 y se suscribió el 20 recuperaba cuota dos semanas antes de pagar el periodo siguiente.

No hubo pérdida de servicio —la cuota se seguía renovando cada mes—, solo desalineación con el ciclo de cobro.

## Un cuarto sitio que el issue no recogía

`cron.service.ts:397`, el job de backfill `migrateSubscriptionPeriods`, tenía el mismo cast. Su comentario decía literalmente «Extract period from subscription items» mientras leía del nivel superior.

Importa doble: es precisamente la herramienta que sirve para **rellenar el periodo de los usuarios ya afectados**, y estaba inutilizada por la misma causa que iba a remediar.

## Enfoque

Dos decisiones deliberadas más allá de cambiar las rutas de acceso:

**El acceso va a una utilidad compartida** (`common/utils/stripe-billing-period.util.ts`) en vez de arreglarse cuatro veces. La lección del incidente es justamente que estaba duplicado en cuatro sitios y por eso pudo romperse en los cuatro a la vez sin que nadie lo notara.

**Se quitan los casts.** Los cuatro accesos iban envueltos en `as unknown as { current_period_start: number }`, y eso es lo que impidió al compilador señalarlos al subir a `stripe@20`. Sin el cast, esto habría sido un error de build el día del upgrade en lugar de meses de silencio. Verificado que no queda ninguno:

```
grep -rE "as unknown as \{ current_period|as \{ subscription\?: string" src/  → (ninguno)
```

**Los fallos ahora se ven.** Donde antes había un `if` silencioso, ahora hay un `logger.warn` que nombra la suscripción o la factura que no se pudo resolver.

## Verificación

- 194 tests (9 nuevos sobre la utilidad), build y lint limpios.
- Los tests incluyen dos casos de regresión que fallarían si alguien reintrodujera la forma antigua: una suscripción con `current_period_start` en el nivel superior y una factura con `invoice.subscription` deben resolverse como vacío.

## Después de desplegar

Los usuarios de pago actuales siguen sin periodo guardado. `migrateSubscriptionPeriods` ya funciona y salta a quien ya lo tiene, así que ejecutarlo una vez rellena a los afectados sin tocar al resto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)