### PR TITLE
fix(payments): serializar los upgrades a destinos distintos sobre una suscripción

### DIFF
--- a/src/modules/cache/firestore.service.spec.ts
+++ b/src/modules/cache/firestore.service.spec.ts
@@ -143,7 +143,7 @@ describe('FirestoreService — updateUserSubscriptionState', () => {
  */
 describe('FirestoreService — acquireUpgradeIdempotency', () => {
   const TTL_MS = 24 * 60 * 60 * 1000;
-  const IN_FLIGHT_MS = 90 * 1000;
+  const LEASE_MS = 5 * 60 * 1000;
 
   function buildService(stored?: Record<string, unknown>) {
     const docData: Record<string, unknown> = stored
@@ -181,22 +181,71 @@ describe('FirestoreService — acquireUpgradeIdempotency', () => {
 
   it('reutiliza la clave del mismo destino dentro del TTL', async () => {
     // El caso original: el reintento del mismo upgrade no debe cobrar dos veces.
-    const { service, update } = buildService({
+    // El instante se captura UNA vez: dos llamadas a `hace()` difieren en algún
+    // milisegundo y la comparación quedaría a merced del reloj.
+    const haceUnaHora = hace(60 * 60 * 1000);
+    const { service, docData } = buildService({
       key: 'upgrade_previo',
       targetPlan: 'promax',
       subscriptionId: 'sub_123',
-      createdAt: hace(60 * 60 * 1000),
+      createdAt: haceUnaHora,
+      lastAttemptAt: haceUnaHora,
     });
 
     const result = await service.acquireUpgradeIdempotency(
       'uid-1',
       candidato('promax'),
       TTL_MS,
-      IN_FLIGHT_MS,
+      LEASE_MS,
     );
 
     expect(result).toEqual({ status: 'ok', key: 'upgrade_previo' });
-    expect(update).not.toHaveBeenCalled();
+    // La edad de la clave no se toca —de ella depende el TTL—, pero el lease sí
+    // se renueva: es una ejecución nueva.
+    expect((docData.upgradeIdempotency as any).createdAt).toBe(haceUnaHora);
+    expect(
+      new Date((docData.upgradeIdempotency as any).lastAttemptAt).getTime(),
+    ).toBeGreaterThan(new Date(haceUnaHora).getTime());
+  });
+
+  /**
+   * El escenario que el lease existe para cubrir: un reintento reutiliza la
+   * clave, pero con la antigüedad congelada en `createdAt` su ejecución quedaba
+   * desprotegida en cuanto la clave envejecía más que la ventana, y otro destino
+   * entraba con clave propia mientras el reintento seguía vivo.
+   */
+  it('renueva el lease al reutilizar, de modo que el reintento sigue excluyendo a otros destinos', async () => {
+    const haceMediaHora = hace(30 * 60 * 1000);
+    const { service, docData } = buildService({
+      key: 'upgrade_previo',
+      targetPlan: 'promax',
+      subscriptionId: 'sub_123',
+      // Clave nacida hace media hora: el lease original expiró hace mucho.
+      createdAt: haceMediaHora,
+      lastAttemptAt: haceMediaHora,
+    });
+
+    // El cliente reintenta el MISMO upgrade: reutiliza la clave.
+    const reintento = await service.acquireUpgradeIdempotency(
+      'uid-1',
+      candidato('promax'),
+      TTL_MS,
+      LEASE_MS,
+    );
+    expect(reintento).toEqual({ status: 'ok', key: 'upgrade_previo' });
+
+    // Y ahora entra otro destino, con el reintento todavía en curso.
+    const otroDestino = await service.acquireUpgradeIdempotency(
+      'uid-1',
+      candidato('pro'),
+      TTL_MS,
+      LEASE_MS,
+    );
+
+    // Sin renovar el lease, este habría entrado con clave propia y las dos
+    // mutaciones habrían salido hacia Stripe.
+    expect(otroDestino).toEqual({ status: 'conflict', targetPlan: 'promax' });
+    expect((docData.upgradeIdempotency as any).key).toBe('upgrade_previo');
   });
 
   it('rechaza otro destino sobre la misma suscripción mientras pueda estar en vuelo', async () => {
@@ -211,7 +260,7 @@ describe('FirestoreService — acquireUpgradeIdempotency', () => {
       'uid-1',
       candidato('promax'),
       TTL_MS,
-      IN_FLIGHT_MS,
+      LEASE_MS,
     );
 
     expect(result).toEqual({ status: 'conflict', targetPlan: 'pro' });
@@ -234,7 +283,7 @@ describe('FirestoreService — acquireUpgradeIdempotency', () => {
       'uid-1',
       candidato('promax'),
       TTL_MS,
-      IN_FLIGHT_MS,
+      LEASE_MS,
     );
 
     expect(result).toEqual({ status: 'ok', key: 'upgrade_nuevo_promax' });
@@ -255,7 +304,7 @@ describe('FirestoreService — acquireUpgradeIdempotency', () => {
       'uid-1',
       candidato('promax'),
       TTL_MS,
-      IN_FLIGHT_MS,
+      LEASE_MS,
     );
 
     expect(result).toEqual({ status: 'ok', key: 'upgrade_nuevo_promax' });
@@ -273,7 +322,7 @@ describe('FirestoreService — acquireUpgradeIdempotency', () => {
       'uid-1',
       candidato('promax'),
       TTL_MS,
-      IN_FLIGHT_MS,
+      LEASE_MS,
     );
 
     expect(result).toEqual({ status: 'ok', key: 'upgrade_nuevo_promax' });
@@ -291,7 +340,7 @@ describe('FirestoreService — acquireUpgradeIdempotency', () => {
       'uid-1',
       candidato('promax'),
       TTL_MS,
-      IN_FLIGHT_MS,
+      LEASE_MS,
     );
 
     expect(result).toEqual({ status: 'ok', key: 'upgrade_nuevo_promax' });
@@ -311,7 +360,7 @@ describe('FirestoreService — acquireUpgradeIdempotency', () => {
       'uid-1',
       candidato('promax'),
       TTL_MS,
-      IN_FLIGHT_MS,
+      LEASE_MS,
     );
 
     expect(result).toEqual({ status: 'conflict', targetPlan: 'pro' });
@@ -330,7 +379,7 @@ describe('FirestoreService — acquireUpgradeIdempotency', () => {
       'uid-1',
       candidato('promax'),
       TTL_MS,
-      IN_FLIGHT_MS,
+      LEASE_MS,
     );
 
     expect(result).toEqual({ status: 'ok', key: 'upgrade_nuevo_promax' });

--- a/src/modules/cache/firestore.service.spec.ts
+++ b/src/modules/cache/firestore.service.spec.ts
@@ -135,3 +135,204 @@ describe('FirestoreService — updateUserSubscriptionState', () => {
     expect(aplicada).toBe(true);
   });
 });
+
+/**
+ * La clave protege del doble cargo del MISMO upgrade, pero dos upgrades a
+ * destinos DISTINTOS no pueden compartirla: si el segundo sobrescribe al
+ * primero, Stripe procesa ambas mutaciones (issue #73).
+ */
+describe('FirestoreService — acquireUpgradeIdempotency', () => {
+  const TTL_MS = 24 * 60 * 60 * 1000;
+  const IN_FLIGHT_MS = 90 * 1000;
+
+  function buildService(stored?: Record<string, unknown>) {
+    const docData: Record<string, unknown> = stored
+      ? { upgradeIdempotency: stored }
+      : {};
+    const update = jest
+      .fn()
+      .mockImplementation((_ref: unknown, data: Record<string, unknown>) => {
+        Object.assign(docData, data);
+      });
+
+    const ref = { id: 'uid-1' };
+    const service: any = Object.create(FirestoreService.prototype);
+    service.usersCollection = 'users';
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    service.firestore = {
+      collection: () => ({ doc: () => ref }),
+      runTransaction: (fn: (t: unknown) => Promise<unknown>) =>
+        fn({
+          get: async () => ({ data: () => docData }),
+          update,
+        }),
+    };
+
+    return { service, update, docData };
+  }
+
+  function candidato(targetPlan: string, subscriptionId = 'sub_123') {
+    return { key: `upgrade_nuevo_${targetPlan}`, targetPlan, subscriptionId };
+  }
+
+  function hace(ms: number) {
+    return new Date(Date.now() - ms).toISOString();
+  }
+
+  it('reutiliza la clave del mismo destino dentro del TTL', async () => {
+    // El caso original: el reintento del mismo upgrade no debe cobrar dos veces.
+    const { service, update } = buildService({
+      key: 'upgrade_previo',
+      targetPlan: 'promax',
+      subscriptionId: 'sub_123',
+      createdAt: hace(60 * 60 * 1000),
+    });
+
+    const result = await service.acquireUpgradeIdempotency(
+      'uid-1',
+      candidato('promax'),
+      TTL_MS,
+      IN_FLIGHT_MS,
+    );
+
+    expect(result).toEqual({ status: 'ok', key: 'upgrade_previo' });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('rechaza otro destino sobre la misma suscripción mientras pueda estar en vuelo', async () => {
+    const { service, update, docData } = buildService({
+      key: 'upgrade_previo',
+      targetPlan: 'pro',
+      subscriptionId: 'sub_123',
+      createdAt: hace(5 * 1000),
+    });
+
+    const result = await service.acquireUpgradeIdempotency(
+      'uid-1',
+      candidato('promax'),
+      TTL_MS,
+      IN_FLIGHT_MS,
+    );
+
+    expect(result).toEqual({ status: 'conflict', targetPlan: 'pro' });
+    // Sobrescribir aquí dejaría salir las dos mutaciones hacia Stripe.
+    expect(update).not.toHaveBeenCalled();
+    expect((docData.upgradeIdempotency as any).key).toBe('upgrade_previo');
+  });
+
+  it('permite otro destino pasada la ventana en vuelo, aunque siga dentro del TTL', async () => {
+    // Excluir por el TTL de 24 h dejaría al cliente sin poder cambiar de plan
+    // durante un día entero por un intento que quedó a medias.
+    const { service, update } = buildService({
+      key: 'upgrade_previo',
+      targetPlan: 'pro',
+      subscriptionId: 'sub_123',
+      createdAt: hace(10 * 60 * 1000),
+    });
+
+    const result = await service.acquireUpgradeIdempotency(
+      'uid-1',
+      candidato('promax'),
+      TTL_MS,
+      IN_FLIGHT_MS,
+    );
+
+    expect(result).toEqual({ status: 'ok', key: 'upgrade_nuevo_promax' });
+    expect(update).toHaveBeenCalled();
+  });
+
+  it('no bloquea por un intento sobre otra suscripción', async () => {
+    // Otro contrato no dice nada del actual: normalmente una suscripción
+    // anterior ya cancelada.
+    const { service } = buildService({
+      key: 'upgrade_previo',
+      targetPlan: 'pro',
+      subscriptionId: 'sub_viejo',
+      createdAt: hace(1000),
+    });
+
+    const result = await service.acquireUpgradeIdempotency(
+      'uid-1',
+      candidato('promax'),
+      TTL_MS,
+      IN_FLIGHT_MS,
+    );
+
+    expect(result).toEqual({ status: 'ok', key: 'upgrade_nuevo_promax' });
+  });
+
+  it('persiste una clave nueva cuando la del mismo destino ya caducó', async () => {
+    const { service, docData } = buildService({
+      key: 'upgrade_previo',
+      targetPlan: 'promax',
+      subscriptionId: 'sub_123',
+      createdAt: hace(TTL_MS + 1000),
+    });
+
+    const result = await service.acquireUpgradeIdempotency(
+      'uid-1',
+      candidato('promax'),
+      TTL_MS,
+      IN_FLIGHT_MS,
+    );
+
+    expect(result).toEqual({ status: 'ok', key: 'upgrade_nuevo_promax' });
+    expect((docData.upgradeIdempotency as any).key).toBe(
+      'upgrade_nuevo_promax',
+    );
+    // Se persiste como ISO string: un Date se leería mal al volver de Firestore.
+    expect(typeof (docData.upgradeIdempotency as any).createdAt).toBe('string');
+  });
+
+  it('persiste la clave cuando no hay ningún intento previo', async () => {
+    const { service, update } = buildService();
+
+    const result = await service.acquireUpgradeIdempotency(
+      'uid-1',
+      candidato('promax'),
+      TTL_MS,
+      IN_FLIGHT_MS,
+    );
+
+    expect(result).toEqual({ status: 'ok', key: 'upgrade_nuevo_promax' });
+    expect(update).toHaveBeenCalled();
+  });
+
+  it('evalúa la exclusión sobre un createdAt en formato Timestamp', async () => {
+    // Leerlo mal degradaría la guarda en silencio y volvería el bug.
+    const { service } = buildService({
+      key: 'upgrade_previo',
+      targetPlan: 'pro',
+      subscriptionId: 'sub_123',
+      createdAt: { toDate: () => new Date(Date.now() - 5 * 1000) },
+    });
+
+    const result = await service.acquireUpgradeIdempotency(
+      'uid-1',
+      candidato('promax'),
+      TTL_MS,
+      IN_FLIGHT_MS,
+    );
+
+    expect(result).toEqual({ status: 'conflict', targetPlan: 'pro' });
+  });
+
+  it('no bloquea si el createdAt almacenado es ilegible', async () => {
+    // Un valor corrupto no debe dejar al usuario sin poder cambiar de plan.
+    const { service } = buildService({
+      key: 'upgrade_previo',
+      targetPlan: 'pro',
+      subscriptionId: 'sub_123',
+      createdAt: 'no-es-fecha',
+    });
+
+    const result = await service.acquireUpgradeIdempotency(
+      'uid-1',
+      candidato('promax'),
+      TTL_MS,
+      IN_FLIGHT_MS,
+    );
+
+    expect(result).toEqual({ status: 'ok', key: 'upgrade_nuevo_promax' });
+  });
+});

--- a/src/modules/cache/firestore.service.spec.ts
+++ b/src/modules/cache/firestore.service.spec.ts
@@ -143,7 +143,7 @@ describe('FirestoreService — updateUserSubscriptionState', () => {
  */
 describe('FirestoreService — acquireUpgradeIdempotency', () => {
   const TTL_MS = 24 * 60 * 60 * 1000;
-  const LEASE_MS = 5 * 60 * 1000;
+  const LEASE_MS = 7 * 60 * 1000;
 
   function buildService(stored?: Record<string, unknown>) {
     const docData: Record<string, unknown> = stored

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -605,42 +605,51 @@ export class FirestoreService {
    * mutaciones a Stripe — justo el doble cargo que la idempotencia debe evitar.
    * La transacción garantiza que solo una gane y que la otra reutilice su clave.
    *
-   * Hay dos ventanas distintas, y confundirlas rompe uno u otro caso:
+   * Hay dos ventanas distintas, medidas sobre marcas distintas, y confundirlas
+   * rompe uno u otro caso:
    *
-   * - `ttlMs` (24 h) gobierna la REUTILIZACIÓN de la clave para el MISMO
-   *   destino. Es lo que hace que el reintento de un upgrade que falló llegue a
-   *   Stripe con la misma clave y no cobre dos veces.
-   * - `inFlightMs` (segundos) gobierna la EXCLUSIÓN entre destinos DISTINTOS
-   *   sobre la misma suscripción. Dos cambios distintos no pueden compartir
-   *   clave, así que la única forma de que no salgan los dos hacia Stripe es
-   *   rechazar el segundo mientras el primero pueda seguir en vuelo.
+   * - `ttlMs` (24 h) sobre `createdAt` gobierna la REUTILIZACIÓN de la clave
+   *   para el MISMO destino. Es lo que hace que el reintento de un upgrade que
+   *   falló llegue a Stripe con la misma clave y no cobre dos veces.
+   * - `leaseMs` (minutos) sobre `lastAttemptAt` gobierna la EXCLUSIÓN entre
+   *   destinos DISTINTOS sobre la misma suscripción. Dos cambios distintos no
+   *   pueden compartir clave, así que la única forma de que no salgan los dos
+   *   hacia Stripe es rechazar el segundo mientras el primero siga vivo.
    *
-   * La exclusión NO usa el TTL a propósito (issue #73): un intento que quedó a
-   * medias —el caso del error indeterminado, donde la clave se conserva
-   * deliberadamente— bloquearía durante 24 h un cambio de plan legítimo. Pasada
-   * la ventana en vuelo, un destino distinto sobrescribe la clave con
-   * normalidad.
+   * `lastAttemptAt` no puede ser `createdAt`: un reintento REUTILIZA la clave
+   * pero abre una ejecución NUEVA, y con la marca de nacimiento congelada esa
+   * ejecución quedaría desprotegida en cuanto la clave envejeciera más que el
+   * lease. Por eso la reutilización también escribe: renueva el lease.
+   *
+   * La exclusión tampoco usa el TTL (issue #73): un intento que quedó a medias
+   * —el caso del error indeterminado, donde la clave se conserva
+   * deliberadamente— bloquearía durante 24 h un cambio de plan legítimo.
    */
   async acquireUpgradeIdempotency(
     userId: string,
     candidate: { key: string; targetPlan: string; subscriptionId: string },
     ttlMs: number,
-    inFlightMs: number,
+    leaseMs: number,
   ): Promise<
     { status: 'ok'; key: string } | { status: 'conflict'; targetPlan: string }
   > {
     const ref = this.firestore.collection(this.usersCollection).doc(userId);
 
+    // Defensivo con el formato: lo escribimos como ISO string, pero un
+    // documento anterior pudo quedar con Timestamp o Date.
+    const enMs = (value: unknown): number =>
+      value
+        ? new Date((value as any)?.toDate?.() ?? (value as any)).getTime()
+        : NaN;
+
     return this.firestore.runTransaction(async (transaction) => {
       const snapshot = await transaction.get(ref);
       const stored = snapshot.data()?.upgradeIdempotency;
+      const ahora = new Date().toISOString();
 
-      // Defensivo con el formato: lo escribimos como ISO string, pero un
-      // documento anterior pudo quedar con Timestamp o Date.
-      const createdAtMs = stored?.createdAt
-        ? new Date(stored.createdAt?.toDate?.() ?? stored.createdAt).getTime()
-        : NaN;
-      const edadMs = Date.now() - createdAtMs;
+      const createdAtMs = enMs(stored?.createdAt);
+      // Documentos escritos antes de existir el lease solo tienen `createdAt`.
+      const lastAttemptMs = enMs(stored?.lastAttemptAt ?? stored?.createdAt);
 
       // Un intento sobre OTRA suscripción no dice nada del contrato actual.
       const mismoContrato =
@@ -649,11 +658,21 @@ export class FirestoreService {
         stored.subscriptionId === candidate.subscriptionId;
 
       if (mismoContrato && stored.targetPlan === candidate.targetPlan) {
-        if (edadMs < ttlMs) {
+        if (Date.now() - createdAtMs < ttlMs) {
+          // Misma clave, ejecución nueva: hay que renovar el lease o esta
+          // quedaría sin exclusión frente a otros destinos.
+          transaction.update(ref, {
+            upgradeIdempotency: { ...stored, lastAttemptAt: ahora },
+            updatedAt: new Date(),
+          });
           return { status: 'ok' as const, key: stored.key as string };
         }
-      } else if (mismoContrato && edadMs < inFlightMs) {
-        // Otro destino sobre la misma suscripción, aún posiblemente en vuelo.
+      } else if (
+        mismoContrato &&
+        Number.isFinite(lastAttemptMs) &&
+        Date.now() - lastAttemptMs < leaseMs
+      ) {
+        // Otro destino sobre la misma suscripción, con un intento aún vivo.
         // Sobrescribir la clave dejaría salir las dos mutaciones hacia Stripe y
         // la suscripción acabaría en la que llegara última, con una proración
         // que el usuario no pidió y Firestore apuntando a otro plan.
@@ -666,7 +685,8 @@ export class FirestoreService {
       transaction.update(ref, {
         upgradeIdempotency: {
           ...candidate,
-          createdAt: new Date().toISOString(),
+          createdAt: ahora,
+          lastAttemptAt: ahora,
         },
         updatedAt: new Date(),
       });

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -605,14 +605,30 @@ export class FirestoreService {
    * mutaciones a Stripe — justo el doble cargo que la idempotencia debe evitar.
    * La transacción garantiza que solo una gane y que la otra reutilice su clave.
    *
-   * Devuelve la clave vigente si la hay (mismo plan, misma suscripción y dentro
-   * del TTL); si no, persiste `candidate` y la devuelve.
+   * Hay dos ventanas distintas, y confundirlas rompe uno u otro caso:
+   *
+   * - `ttlMs` (24 h) gobierna la REUTILIZACIÓN de la clave para el MISMO
+   *   destino. Es lo que hace que el reintento de un upgrade que falló llegue a
+   *   Stripe con la misma clave y no cobre dos veces.
+   * - `inFlightMs` (segundos) gobierna la EXCLUSIÓN entre destinos DISTINTOS
+   *   sobre la misma suscripción. Dos cambios distintos no pueden compartir
+   *   clave, así que la única forma de que no salgan los dos hacia Stripe es
+   *   rechazar el segundo mientras el primero pueda seguir en vuelo.
+   *
+   * La exclusión NO usa el TTL a propósito (issue #73): un intento que quedó a
+   * medias —el caso del error indeterminado, donde la clave se conserva
+   * deliberadamente— bloquearía durante 24 h un cambio de plan legítimo. Pasada
+   * la ventana en vuelo, un destino distinto sobrescribe la clave con
+   * normalidad.
    */
   async acquireUpgradeIdempotency(
     userId: string,
     candidate: { key: string; targetPlan: string; subscriptionId: string },
     ttlMs: number,
-  ): Promise<string> {
+    inFlightMs: number,
+  ): Promise<
+    { status: 'ok'; key: string } | { status: 'conflict'; targetPlan: string }
+  > {
     const ref = this.firestore.collection(this.usersCollection).doc(userId);
 
     return this.firestore.runTransaction(async (transaction) => {
@@ -624,16 +640,27 @@ export class FirestoreService {
       const createdAtMs = stored?.createdAt
         ? new Date(stored.createdAt?.toDate?.() ?? stored.createdAt).getTime()
         : NaN;
+      const edadMs = Date.now() - createdAtMs;
 
-      const vigente =
+      // Un intento sobre OTRA suscripción no dice nada del contrato actual.
+      const mismoContrato =
         !!stored?.key &&
-        stored.targetPlan === candidate.targetPlan &&
-        stored.subscriptionId === candidate.subscriptionId &&
         Number.isFinite(createdAtMs) &&
-        Date.now() - createdAtMs < ttlMs;
+        stored.subscriptionId === candidate.subscriptionId;
 
-      if (vigente) {
-        return stored.key as string;
+      if (mismoContrato && stored.targetPlan === candidate.targetPlan) {
+        if (edadMs < ttlMs) {
+          return { status: 'ok' as const, key: stored.key as string };
+        }
+      } else if (mismoContrato && edadMs < inFlightMs) {
+        // Otro destino sobre la misma suscripción, aún posiblemente en vuelo.
+        // Sobrescribir la clave dejaría salir las dos mutaciones hacia Stripe y
+        // la suscripción acabaría en la que llegara última, con una proración
+        // que el usuario no pidió y Firestore apuntando a otro plan.
+        return {
+          status: 'conflict' as const,
+          targetPlan: stored.targetPlan as string,
+        };
       }
 
       transaction.update(ref, {
@@ -643,7 +670,7 @@ export class FirestoreService {
         },
         updatedAt: new Date(),
       });
-      return candidate.key;
+      return { status: 'ok' as const, key: candidate.key };
     });
   }
 

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -277,9 +277,11 @@ describe('PaymentsService — upgradeSubscription', () => {
         subscriptionId: 'sub_123',
       }),
       // TTL de reutilización (24 h) y lease de exclusión entre destinos
-      // distintos (minutos): son dos cosas y no pueden ser el mismo número.
+      // distintos (minutos): son dos cosas y no pueden ser el mismo número. El
+      // lease cubre el peor caso de `subscriptions.update`: 3 × 80 s de timeout
+      // más 2 × 60 s de Retry-After = 360 s.
       24 * 60 * 60 * 1000,
-      5 * 60 * 1000,
+      7 * 60 * 1000,
     );
     // La clave no se decide a partir del usuario leído antes de la transacción.
     expect(getUserById).toHaveBeenCalledTimes(1);

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -3,6 +3,7 @@ jest.mock('stripe', () => jest.fn());
 
 import {
   BadRequestException,
+  ConflictException,
   ServiceUnavailableException,
 } from '@nestjs/common';
 import { PaymentsService } from './payments.service.js';
@@ -61,9 +62,11 @@ describe('PaymentsService — upgradeSubscription', () => {
     }));
 
     /**
-     * Reproduce la semántica transaccional real: reutiliza la clave vigente y,
-     * si no la hay, persiste la candidata. El TTL se evalúa sobre el valor
-     * almacenado tal cual, para que un `createdAt` mal serializado se note.
+     * Reproduce la semántica transaccional real: reutiliza la clave vigente del
+     * mismo destino, rechaza un destino distinto mientras el anterior pueda
+     * seguir en vuelo, y en el resto de casos persiste la candidata. Las dos
+     * ventanas se evalúan sobre el valor almacenado tal cual, para que un
+     * `createdAt` mal serializado se note.
      */
     const acquireUpgradeIdempotency = jest.fn().mockImplementation(
       async (
@@ -74,6 +77,7 @@ describe('PaymentsService — upgradeSubscription', () => {
           subscriptionId: string;
         },
         ttlMs: number,
+        inFlightMs: number,
       ) => {
         const stored = userDoc.upgradeIdempotency as
           | Record<string, any>
@@ -82,21 +86,25 @@ describe('PaymentsService — upgradeSubscription', () => {
         const createdAtMs = stored?.createdAt
           ? new Date(stored.createdAt?.toDate?.() ?? stored.createdAt).getTime()
           : NaN;
-        const vigente =
+        const edadMs = Date.now() - createdAtMs;
+        const mismoContrato =
           !!stored?.key &&
-          stored.targetPlan === candidate.targetPlan &&
-          stored.subscriptionId === candidate.subscriptionId &&
           Number.isFinite(createdAtMs) &&
-          Date.now() - createdAtMs < ttlMs;
+          stored.subscriptionId === candidate.subscriptionId;
 
-        if (vigente) {
-          return stored.key;
+        if (mismoContrato && stored.targetPlan === candidate.targetPlan) {
+          if (edadMs < ttlMs) {
+            return { status: 'ok', key: stored.key };
+          }
+        } else if (mismoContrato && edadMs < inFlightMs) {
+          return { status: 'conflict', targetPlan: stored.targetPlan };
         }
+
         userDoc.upgradeIdempotency = {
           ...candidate,
           createdAt: new Date().toISOString(),
         };
-        return candidate.key;
+        return { status: 'ok', key: candidate.key };
       },
     );
 
@@ -261,7 +269,10 @@ describe('PaymentsService — upgradeSubscription', () => {
         targetPlan: 'promax',
         subscriptionId: 'sub_123',
       }),
-      expect.any(Number),
+      // TTL de reutilización (24 h) y ventana de exclusión entre destinos
+      // distintos (segundos): son dos cosas y no pueden ser el mismo número.
+      24 * 60 * 60 * 1000,
+      90 * 1000,
     );
     // La clave no se decide a partir del usuario leído antes de la transacción.
     expect(getUserById).toHaveBeenCalledTimes(1);
@@ -279,6 +290,59 @@ describe('PaymentsService — upgradeSubscription', () => {
 
     // Misma clave ⇒ Stripe deduplica y solo se cobra una vez.
     expect(claveUsada(update, 0)).toBe(claveUsada(update, 1));
+  });
+
+  /**
+   * Dos destinos distintos no pueden compartir clave de idempotencia, así que
+   * Stripe procesaría ambas mutaciones: la suscripción acabaría en la que
+   * llegara última —con una proración que el usuario no pidió— y Firestore en la
+   * que terminara última, que no tiene por qué ser la misma (issue #73).
+   */
+  it('rechaza un segundo upgrade a otro destino mientras el primero sigue en curso', async () => {
+    const { service, update, userDoc } = buildService({
+      subscription: activeSubscription,
+    });
+    // Desde lite ambos destinos son upgrades válidos: el caso de las dos
+    // pestañas con botones distintos.
+    userDoc.plan = 'lite';
+    service.proPriceIdMxn = 'price_pro_mxn';
+
+    const resultados = await Promise.allSettled([
+      service.upgradeSubscription('uid-1', 'pro'),
+      service.upgradeSubscription('uid-1', 'promax'),
+    ]);
+
+    const rechazados = resultados.filter((r) => r.status === 'rejected');
+    expect(rechazados).toHaveLength(1);
+    expect((rechazados[0] as PromiseRejectedResult).reason).toBeInstanceOf(
+      ConflictException,
+    );
+    // Lo que importa no es el 409, sino que solo una mutación llegue a Stripe.
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+
+  it('permite cambiar de destino cuando el intento anterior ya no puede estar en vuelo', async () => {
+    const { service, update, userDoc } = buildService({
+      subscription: activeSubscription,
+    });
+    userDoc.plan = 'lite';
+    service.proPriceIdMxn = 'price_pro_mxn';
+    // Intento anterior a otro plan, de hace dos minutos: pasada la ventana en
+    // vuelo. Sigue dentro del TTL de 24 h, y ahí está la trampa — usar el TTL
+    // para excluir dejaría al cliente sin poder cambiar de plan durante un día.
+    userDoc.upgradeIdempotency = {
+      key: 'upgrade_uid-1_viejo',
+      targetPlan: 'pro',
+      subscriptionId: 'sub_123',
+      createdAt: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+    };
+
+    await expect(
+      service.upgradeSubscription('uid-1', 'promax'),
+    ).resolves.toMatchObject({ success: true });
+    expect(update).toHaveBeenCalledTimes(1);
+    // Clave nueva: la del intento caducado no protege de nada aquí.
+    expect(claveUsada(update, 0)).not.toBe('upgrade_uid-1_viejo');
   });
 
   it('libera la clave comparando, sin pisar la de un intento posterior', async () => {

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -63,10 +63,10 @@ describe('PaymentsService — upgradeSubscription', () => {
 
     /**
      * Reproduce la semántica transaccional real: reutiliza la clave vigente del
-     * mismo destino, rechaza un destino distinto mientras el anterior pueda
-     * seguir en vuelo, y en el resto de casos persiste la candidata. Las dos
-     * ventanas se evalúan sobre el valor almacenado tal cual, para que un
-     * `createdAt` mal serializado se note.
+     * mismo destino RENOVANDO su lease, rechaza un destino distinto mientras el
+     * anterior siga vivo, y en el resto de casos persiste la candidata. Las dos
+     * ventanas se evalúan sobre marcas distintas y sobre el valor almacenado tal
+     * cual, para que un `createdAt` mal serializado se note.
      */
     const acquireUpgradeIdempotency = jest.fn().mockImplementation(
       async (
@@ -77,32 +77,39 @@ describe('PaymentsService — upgradeSubscription', () => {
           subscriptionId: string;
         },
         ttlMs: number,
-        inFlightMs: number,
+        leaseMs: number,
       ) => {
         const stored = userDoc.upgradeIdempotency as
           | Record<string, any>
           | null
           | undefined;
-        const createdAtMs = stored?.createdAt
-          ? new Date(stored.createdAt?.toDate?.() ?? stored.createdAt).getTime()
-          : NaN;
-        const edadMs = Date.now() - createdAtMs;
+        const enMs = (value: any) =>
+          value ? new Date(value?.toDate?.() ?? value).getTime() : NaN;
+        const createdAtMs = enMs(stored?.createdAt);
+        const lastAttemptMs = enMs(stored?.lastAttemptAt ?? stored?.createdAt);
+        const ahora = new Date().toISOString();
         const mismoContrato =
           !!stored?.key &&
           Number.isFinite(createdAtMs) &&
           stored.subscriptionId === candidate.subscriptionId;
 
         if (mismoContrato && stored.targetPlan === candidate.targetPlan) {
-          if (edadMs < ttlMs) {
+          if (Date.now() - createdAtMs < ttlMs) {
+            userDoc.upgradeIdempotency = { ...stored, lastAttemptAt: ahora };
             return { status: 'ok', key: stored.key };
           }
-        } else if (mismoContrato && edadMs < inFlightMs) {
+        } else if (
+          mismoContrato &&
+          Number.isFinite(lastAttemptMs) &&
+          Date.now() - lastAttemptMs < leaseMs
+        ) {
           return { status: 'conflict', targetPlan: stored.targetPlan };
         }
 
         userDoc.upgradeIdempotency = {
           ...candidate,
-          createdAt: new Date().toISOString(),
+          createdAt: ahora,
+          lastAttemptAt: ahora,
         };
         return { status: 'ok', key: candidate.key };
       },
@@ -269,10 +276,10 @@ describe('PaymentsService — upgradeSubscription', () => {
         targetPlan: 'promax',
         subscriptionId: 'sub_123',
       }),
-      // TTL de reutilización (24 h) y ventana de exclusión entre destinos
-      // distintos (segundos): son dos cosas y no pueden ser el mismo número.
+      // TTL de reutilización (24 h) y lease de exclusión entre destinos
+      // distintos (minutos): son dos cosas y no pueden ser el mismo número.
       24 * 60 * 60 * 1000,
-      90 * 1000,
+      5 * 60 * 1000,
     );
     // La clave no se decide a partir del usuario leído antes de la transacción.
     expect(getUserById).toHaveBeenCalledTimes(1);
@@ -321,20 +328,22 @@ describe('PaymentsService — upgradeSubscription', () => {
     expect(update).toHaveBeenCalledTimes(1);
   });
 
-  it('permite cambiar de destino cuando el intento anterior ya no puede estar en vuelo', async () => {
+  it('permite cambiar de destino cuando el intento anterior ya no puede estar vivo', async () => {
     const { service, update, userDoc } = buildService({
       subscription: activeSubscription,
     });
     userDoc.plan = 'lite';
     service.proPriceIdMxn = 'price_pro_mxn';
-    // Intento anterior a otro plan, de hace dos minutos: pasada la ventana en
-    // vuelo. Sigue dentro del TTL de 24 h, y ahí está la trampa — usar el TTL
+    // Intento anterior a otro plan, de hace media hora: el lease expiró hace
+    // mucho. Sigue dentro del TTL de 24 h, y ahí está la trampa — usar el TTL
     // para excluir dejaría al cliente sin poder cambiar de plan durante un día.
+    const haceMediaHora = new Date(Date.now() - 30 * 60 * 1000).toISOString();
     userDoc.upgradeIdempotency = {
       key: 'upgrade_uid-1_viejo',
       targetPlan: 'pro',
       subscriptionId: 'sub_123',
-      createdAt: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+      createdAt: haceMediaHora,
+      lastAttemptAt: haceMediaHora,
     };
 
     await expect(

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   Logger,
   BadRequestException,
+  ConflictException,
   ServiceUnavailableException,
   Inject,
   forwardRef,
@@ -551,6 +552,17 @@ export class PaymentsService {
   private static readonly IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
 
   /**
+   * Cuánto se considera que un upgrade puede seguir en vuelo, y por tanto
+   * durante cuánto se rechaza otro hacia un destino distinto (issue #73).
+   *
+   * Dimensionado sobre el timeout por defecto del SDK de Stripe (80 s) con algo
+   * de margen. No se usa el TTL de 24 h: el 3DS no lo necesita —ese camino
+   * libera la clave al devolver el enlace de pago— y un intento que quedó a
+   * medias no debe secuestrar el plan del usuario durante un día entero.
+   */
+  private static readonly UPGRADE_IN_FLIGHT_MS = 90 * 1000;
+
+  /**
    * Clave de idempotencia del intento de upgrade, estable entre reintentos.
    *
    * No se deriva del reloj: una cubeta temporal (`Date.now() / 60000`) parte dos
@@ -567,7 +579,7 @@ export class PaymentsService {
   ): Promise<string> {
     // La adquisición es transaccional: dos upgrades simultáneos no pueden
     // acabar con claves distintas y, por tanto, con dos mutaciones en Stripe.
-    return this.firestoreService.acquireUpgradeIdempotency(
+    const result = await this.firestoreService.acquireUpgradeIdempotency(
       userId,
       {
         key: `upgrade_${userId}_${randomUUID()}`,
@@ -575,7 +587,26 @@ export class PaymentsService {
         subscriptionId,
       },
       PaymentsService.IDEMPOTENCY_TTL_MS,
+      PaymentsService.UPGRADE_IN_FLIGHT_MS,
     );
+
+    // Dos destinos distintos no pueden compartir clave, así que serializarlos es
+    // lo único que impide que Stripe procese ambos. Se rechaza el segundo en vez
+    // de encolarlo: el primero puede acabar en pago pendiente o rechazo, y
+    // entonces el cliente ya no querrá el mismo cambio.
+    if (result.status === 'conflict') {
+      this.logger.warn(
+        `Upgrade a ${targetPlan} rechazado para ${userId}: hay otro a ` +
+          `${result.targetPlan} todavía en curso sobre ${subscriptionId}.`,
+      );
+      throw new ConflictException(
+        `A plan change to ${result.targetPlan.toUpperCase()} is already in progress. ` +
+          `Please wait for it to finish and check your subscription before requesting ` +
+          `a different plan.`,
+      );
+    }
+
+    return result.key;
   }
 
   /**

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -552,15 +552,22 @@ export class PaymentsService {
   private static readonly IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
 
   /**
-   * Cuánto se considera que un upgrade puede seguir en vuelo, y por tanto
-   * durante cuánto se rechaza otro hacia un destino distinto (issue #73).
+   * Lease del upgrade en curso: durante cuánto se rechaza otro hacia un destino
+   * distinto sin haber recibido señal de que el primero terminó (issue #73).
    *
-   * Dimensionado sobre el timeout por defecto del SDK de Stripe (80 s) con algo
-   * de margen. No se usa el TTL de 24 h: el 3DS no lo necesita —ese camino
-   * libera la clave al devolver el enlace de pago— y un intento que quedó a
-   * medias no debe secuestrar el plan del usuario durante un día entero.
+   * Dimensionado sobre el peor caso REAL de la única llamada que queda dentro
+   * del candado, `subscriptions.update`: el SDK se instancia con sus valores por
+   * defecto, o sea 80 s de timeout y 2 reintentos de red, luego hasta 240 s más
+   * backoff. Cinco minutos lo cubren con margen.
+   *
+   * El lease casi nunca llega a agotarse: todos los desenlaces definitivos
+   * liberan la clave —incluido el 3DS, que la suelta al devolver el enlace de
+   * pago—, así que solo cuenta cuando la petición sigue viva de verdad, murió
+   * sin liberar, o terminó en el error indeterminado, donde la clave se conserva
+   * a propósito. Tampoco puede ser el TTL de 24 h: eso dejaría al cliente sin
+   * poder cambiar de plan durante un día por un intento que quedó a medias.
    */
-  private static readonly UPGRADE_IN_FLIGHT_MS = 90 * 1000;
+  private static readonly UPGRADE_LEASE_MS = 5 * 60 * 1000;
 
   /**
    * Clave de idempotencia del intento de upgrade, estable entre reintentos.
@@ -587,7 +594,7 @@ export class PaymentsService {
         subscriptionId,
       },
       PaymentsService.IDEMPOTENCY_TTL_MS,
-      PaymentsService.UPGRADE_IN_FLIGHT_MS,
+      PaymentsService.UPGRADE_LEASE_MS,
     );
 
     // Dos destinos distintos no pueden compartir clave, así que serializarlos es
@@ -824,12 +831,6 @@ export class PaymentsService {
       );
     }
 
-    const idempotencyKey = await this.getUpgradeIdempotencyKey(
-      userId,
-      targetPlan,
-      user.stripeSubscriptionId,
-    );
-
     // `always_invoice` emite y cobra la factura de la proración dentro del
     // propio update, y Stripe congela en ella los datos fiscales del customer al
     // finalizarla. Igual que en el checkout, hay que propagarlos antes y en modo
@@ -848,6 +849,19 @@ export class PaymentsService {
         'No se pudieron sincronizar tus datos de facturación. Inténtalo de nuevo en unos momentos.',
       );
     }
+
+    // La clave se toma DESPUÉS de la sincronización fiscal y justo antes de la
+    // única llamada que mueve dinero. Tomarla al principio metía dentro del
+    // candado las tres llamadas del perfil fiscal, y el peor caso pasaba a ser
+    // cuatro veces el de una sola —el SDK reintenta hasta 3 veces con 80 s de
+    // timeout—, imposible de cubrir con un lease razonable. El sync no cobra
+    // nada y es idempotente, así que dejarlo fuera no arriesga un doble cargo;
+    // además, así un fallo suyo ya no retiene una clave que nadie liberará.
+    const idempotencyKey = await this.getUpgradeIdempotencyKey(
+      userId,
+      targetPlan,
+      user.stripeSubscriptionId,
+    );
 
     // Update subscription with proration
     let updatedSubscription: Stripe.Subscription;

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -556,9 +556,17 @@ export class PaymentsService {
    * distinto sin haber recibido señal de que el primero terminó (issue #73).
    *
    * Dimensionado sobre el peor caso REAL de la única llamada que queda dentro
-   * del candado, `subscriptions.update`: el SDK se instancia con sus valores por
-   * defecto, o sea 80 s de timeout y 2 reintentos de red, luego hasta 240 s más
-   * backoff. Cinco minutos lo cubren con margen.
+   * del candado, `subscriptions.update`, con el SDK en sus valores por defecto:
+   *
+   *   3 intentos × 80 s de timeout        = 240 s
+   * + 2 esperas × 60 s (`MAX_RETRY_AFTER_WAIT`, que el SDK respeta cuando
+   *   Stripe manda `Retry-After`)         = 120 s
+   *                                       -------
+   *                                         360 s
+   *
+   * Siete minutos (420 s) dejan un minuto de margen. El backoff de red normal
+   * tiene tope de 5 s, así que solo se acerca a esa cota una llamada que además
+   * choque con limitación de tasa.
    *
    * El lease casi nunca llega a agotarse: todos los desenlaces definitivos
    * liberan la clave —incluido el 3DS, que la suelta al devolver el enlace de
@@ -567,7 +575,7 @@ export class PaymentsService {
    * a propósito. Tampoco puede ser el TTL de 24 h: eso dejaría al cliente sin
    * poder cambiar de plan durante un día por un intento que quedó a medias.
    */
-  private static readonly UPGRADE_LEASE_MS = 5 * 60 * 1000;
+  private static readonly UPGRADE_LEASE_MS = 7 * 60 * 1000;
 
   /**
    * Clave de idempotencia del intento de upgrade, estable entre reintentos.


### PR DESCRIPTION
Cierra #73.

## Problema

`acquireUpgradeIdempotency` solo reutilizaba la clave cuando coincidía el `targetPlan`. Con destinos distintos el segundo intento **sobrescribía** la clave del primero, así que ambos `subscriptions.update` salían hacia Stripe con claves diferentes y Stripe procesaba los dos.

Un usuario en `lite` que dispara `lite → pro` y `lite → promax` casi a la vez (dos pestañas, botones distintos) acababa con la suscripción en la mutación que llegara última —con una proración que no pidió— y Firestore en la que terminara última, que no tiene por qué ser la misma.

## Solución

Dos cambios distintos no pueden compartir clave de idempotencia, así que la única forma de que no salgan ambos es **rechazar el segundo**. La transacción devuelve conflicto en lugar de sobrescribir, y `PaymentsService` lo traduce a **409** antes de tocar Stripe, así que un rechazo no deja efectos a medias.

## Tres relojes, no uno

El núcleo del cambio es separar cosas que se estaban midiendo con la misma marca:

| Marca | Ventana | Mide |
|---|---|---|
| `createdAt` | TTL 24 h | Edad de la **clave** — hasta cuándo se puede reutilizar para el mismo destino (evita el doble cargo del reintento, #66 / PR #67) |
| `lastAttemptAt` | Lease 7 min | Última **ejecución** iniciada — hasta cuándo excluye a otros destinos |

Usar `createdAt` para excluir fallaba en dos direcciones a la vez:

- **Con el TTL:** un intento a medias —el caso del error indeterminado, donde la clave se conserva a propósito— habría bloqueado un cambio de plan legítimo durante 24 h.
- **Con la edad congelada:** un reintento reutiliza la clave pero abre una ejecución nueva; con la marca de nacimiento sin renovar, esa ejecución quedaba desprotegida en cuanto la clave envejecía más que el lease, y otro destino entraba con clave propia mientras seguía viva. Por eso la reutilización ahora **escribe**: renueva el lease.

## Dimensionado del lease

El candado se toma **después** de la sincronización fiscal y justo antes de `subscriptions.update`, la única llamada que mueve dinero. Tomarlo al principio metía dentro las tres llamadas del perfil fiscal (`customers.update`, `listTaxIds`, `createTaxId`) y el peor caso rondaba los 16 minutos, imposible de cubrir sin secuestrar el plan del usuario.

Con una sola llamada dentro, el peor caso estricto con el SDK en sus valores por defecto es:

```
  3 intentos × 80 s de timeout                    = 240 s
+ 2 esperas × 60 s (MAX_RETRY_AFTER_WAIT)         = 120 s
                                                  -------
                                                    360 s
```

Siete minutos (420 s) dejan un minuto de margen. El lease casi nunca llega a agotarse: todos los desenlaces definitivos liberan la clave, incluido el 3DS, que la suelta al devolver el enlace de pago.

Mover el candado no abre riesgo nuevo: el sync no cobra, es idempotente y **ya se ejecutaba por duplicado** en los upgrades concurrentes al mismo destino. De regalo, un fallo suyo deja de retener una clave que nadie iba a liberar — antes lanzaba `ServiceUnavailableException` sin pasar por `clearUpgradeIdempotencyKey`.

## Tipo discriminado

El resultado pasa de `string` a `{status:'ok',key} | {status:'conflict',targetPlan}`. No es cosmético: obliga a resolver el conflicto antes de poder leer la clave. Al intentar mutar el código para verificar las pruebas, el compilador rechazó saltarse el manejo del conflicto.

## Tests

**233 en verde** (13 suites), `tsc` sin issues, lint limpio.

`firestore.service.spec.ts` cubre la transacción real: reutiliza el mismo destino dentro del TTL **renovando el lease**, rechaza otro destino mientras el anterior siga vivo, permite otro destino pasado el lease aunque siga dentro del TTL, ignora intentos sobre otra suscripción, renueva la clave caducada, y evalúa la exclusión con `createdAt` en formato `Timestamp` sin bloquear si es ilegible.

`payments.service.spec.ts` cubre el flujo: dos upgrades concurrentes a destinos distintos dejan **una sola** mutación en Stripe y un 409, y un destino distinto pasado el lease procede con clave nueva.

**Verificado por mutación** que las pruebas detectan las regresiones:

- Sin la guarda transaccional → fallan los dos casos de conflicto.
- Sin la traducción a 409 → `Expected length: 1, Received length: 0`: no se rechaza ningún upgrade y ambas mutaciones llegan a Stripe.
- Sin renovar el lease → el reintento deja entrar al otro destino.

## Nota para el frontend

El endpoint de upgrade puede devolver **409** ahora. Conviene comprobar que se muestra el mensaje del backend en lugar de un error genérico; recordar que el `HttpExceptionFilter` global reescribe las respuestas, como se vio en zplpdf_front#211. No he abierto issue en el front todavía.

## Fuera de alcance

El sello de frescura del webhook (`readAt`) no ordena por el estado observado en Stripe: queda en #77, porque el código es del PR #75 y su corrección es un cambio de diseño propio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)