### PR TITLE
fix(webhooks): serializar el ciclo relectura→escritura de la suscripción

### DIFF
--- a/src/common/constants/error-codes.ts
+++ b/src/common/constants/error-codes.ts
@@ -34,6 +34,13 @@ export const ErrorCodes = {
 
   // Errores de servidor (500/503/504)
   SERVER_ERROR: 'SERVER_ERROR',
+  /**
+   * El cambio de plan SÍ se cobró en Stripe, pero la escritura del plan no se
+   * confirmó en el mismo ciclo. Va aparte de SERVICE_UNAVAILABLE porque el
+   * status 503 lo comparten casos donde NO hubo cargo, y presentar cualquiera
+   * de ellos como cobrado sería falso.
+   */
+  UPGRADE_APPLIED_SYNC_PENDING: 'UPGRADE_APPLIED_SYNC_PENDING',
   SERVICE_UNAVAILABLE: 'SERVICE_UNAVAILABLE',
   PROCESSING_TIMEOUT: 'PROCESSING_TIMEOUT',
 
@@ -85,6 +92,7 @@ export const ErrorHttpStatus: Record<ErrorCode, number> = {
 
   // 503 Service Unavailable
   [ErrorCodes.SERVICE_UNAVAILABLE]: 503,
+  [ErrorCodes.UPGRADE_APPLIED_SYNC_PENDING]: 503,
 
   // 504 Gateway Timeout
   [ErrorCodes.PROCESSING_TIMEOUT]: 504,
@@ -119,6 +127,8 @@ export const ErrorMessagesEs: Record<ErrorCode, string> = {
   [ErrorCodes.JOB_NOT_COMPLETE]: 'La conversión no está completa',
   [ErrorCodes.SERVER_ERROR]: 'Error interno del servidor',
   [ErrorCodes.SERVICE_UNAVAILABLE]: 'Servicio temporalmente no disponible',
+  [ErrorCodes.UPGRADE_APPLIED_SYNC_PENDING]:
+    'Tu pago se procesó; el plan estará disponible en unos momentos',
   [ErrorCodes.PROCESSING_TIMEOUT]: 'La conversión tomó demasiado tiempo',
   [ErrorCodes.UNAUTHORIZED]: 'Autenticación requerida',
   [ErrorCodes.INVALID_TOKEN]: 'Token de acceso inválido o expirado',
@@ -148,6 +158,8 @@ export const ErrorMessagesEn: Record<ErrorCode, string> = {
   [ErrorCodes.JOB_NOT_COMPLETE]: 'Conversion is not complete',
   [ErrorCodes.SERVER_ERROR]: 'Internal server error',
   [ErrorCodes.SERVICE_UNAVAILABLE]: 'Service temporarily unavailable',
+  [ErrorCodes.UPGRADE_APPLIED_SYNC_PENDING]:
+    'Your payment went through; your plan will be available shortly',
   [ErrorCodes.PROCESSING_TIMEOUT]: 'Conversion took too long',
   [ErrorCodes.UNAUTHORIZED]: 'Authentication required',
   [ErrorCodes.INVALID_TOKEN]: 'Invalid or expired access token',

--- a/src/modules/cache/firestore.service.spec.ts
+++ b/src/modules/cache/firestore.service.spec.ts
@@ -616,3 +616,84 @@ describe('FirestoreService — updateUserSubscriptionState con fencing token', (
     expect(docData.plan).toBe('promax');
   });
 });
+
+/**
+ * El ciclo del upgrade puede encadenar tres llamadas a Stripe cuando el update
+ * acaba en error indeterminado. Renovar antes de la tercera evita dimensionar el
+ * lease por las tres de golpe, que dejaría al usuario bloqueado casi veinte
+ * minutos si el proceso muriera (issue #77).
+ */
+describe('FirestoreService — renewSubscriptionSyncLock', () => {
+  function buildService(stored?: Record<string, unknown>) {
+    const docData: Record<string, unknown> = stored
+      ? { subscriptionSyncLock: stored }
+      : {};
+    const update = jest
+      .fn()
+      .mockImplementation((_ref: unknown, data: Record<string, unknown>) => {
+        Object.assign(docData, data);
+      });
+
+    const ref = { id: 'uid-1' };
+    const service: any = Object.create(FirestoreService.prototype);
+    service.usersCollection = 'users';
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    service.firestore = {
+      collection: () => ({ doc: () => ref }),
+      runTransaction: (fn: (t: unknown) => Promise<unknown>) =>
+        fn({
+          get: async () => ({ data: () => docData }),
+          update,
+        }),
+    };
+
+    return { service, update, docData };
+  }
+
+  it('renueva la marca si el token sigue siendo el del titular', async () => {
+    const viejo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    const { service, docData } = buildService({
+      token: 'tok-mio',
+      takenAt: viejo,
+    });
+
+    const renovado = await service.renewSubscriptionSyncLock(
+      'uid-1',
+      'tok-mio',
+    );
+
+    expect(renovado).toBe(true);
+    expect((docData.subscriptionSyncLock as any).token).toBe('tok-mio');
+    expect(
+      new Date((docData.subscriptionSyncLock as any).takenAt).getTime(),
+    ).toBeGreaterThan(new Date(viejo).getTime());
+  });
+
+  it('no renueva —ni pisa— el lease de quien ya nos relevó', async () => {
+    const { service, update, docData } = buildService({
+      token: 'tok-del-relevo',
+      takenAt: new Date().toISOString(),
+    });
+
+    const renovado = await service.renewSubscriptionSyncLock(
+      'uid-1',
+      'tok-mio',
+    );
+
+    expect(renovado).toBe(false);
+    expect(update).not.toHaveBeenCalled();
+    expect((docData.subscriptionSyncLock as any).token).toBe('tok-del-relevo');
+  });
+
+  it('no renueva si el lock ya no existe', async () => {
+    const { service, update } = buildService();
+
+    const renovado = await service.renewSubscriptionSyncLock(
+      'uid-1',
+      'tok-mio',
+    );
+
+    expect(renovado).toBe(false);
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/cache/firestore.service.spec.ts
+++ b/src/modules/cache/firestore.service.spec.ts
@@ -385,3 +385,124 @@ describe('FirestoreService — acquireUpgradeIdempotency', () => {
     expect(result).toEqual({ status: 'ok', key: 'upgrade_nuevo_promax' });
   });
 });
+
+/**
+ * El sello de `updateUserSubscriptionState` ordena por cuándo llegó la respuesta
+ * de Stripe, no por cuándo Stripe observó el estado: entre ambos instantes cabe
+ * una red lenta, así que una relectura del plan viejo podía sellar más fresca
+ * que otra del plan nuevo y revertirlo. Sin ciclos solapados el problema no se
+ * plantea (issue #77).
+ */
+describe('FirestoreService — subscriptionSyncLock', () => {
+  const LEASE_MS = 7 * 60 * 1000;
+
+  function buildService(stored?: Record<string, unknown> | null) {
+    const docData: Record<string, unknown> = stored
+      ? { subscriptionSyncLock: stored }
+      : {};
+    const update = jest
+      .fn()
+      .mockImplementation((_ref: unknown, data: Record<string, unknown>) => {
+        Object.assign(docData, data);
+      });
+
+    const ref = { id: 'uid-1' };
+    const service: any = Object.create(FirestoreService.prototype);
+    service.usersCollection = 'users';
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    service.firestore = {
+      collection: () => ({ doc: () => ref }),
+      runTransaction: (fn: (t: unknown) => Promise<unknown>) =>
+        fn({
+          get: async () => ({ data: () => docData }),
+          update,
+        }),
+    };
+
+    return { service, update, docData };
+  }
+
+  function hace(ms: number) {
+    return new Date(Date.now() - ms).toISOString();
+  }
+
+  it('concede el lock cuando nadie lo tiene', async () => {
+    const { service, docData } = buildService();
+
+    const token = await service.acquireSubscriptionSyncLock('uid-1', LEASE_MS);
+
+    expect(typeof token).toBe('string');
+    expect((docData.subscriptionSyncLock as any).token).toBe(token);
+  });
+
+  it('lo niega mientras otro ciclo lo tenga vivo', async () => {
+    const { service, update } = buildService({
+      token: 'tok-previo',
+      takenAt: hace(5 * 1000),
+    });
+
+    const token = await service.acquireSubscriptionSyncLock('uid-1', LEASE_MS);
+
+    expect(token).toBeNull();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('lo concede si el lease del titular ya caducó', async () => {
+    // Un proceso que murió con el lock tomado no puede dejar al usuario sin
+    // sincronizar para siempre.
+    const { service } = buildService({
+      token: 'tok-muerto',
+      takenAt: hace(30 * 60 * 1000),
+    });
+
+    const token = await service.acquireSubscriptionSyncLock('uid-1', LEASE_MS);
+
+    expect(token).not.toBeNull();
+    expect(token).not.toBe('tok-muerto');
+  });
+
+  it('lo concede si la marca almacenada es ilegible', async () => {
+    const { service } = buildService({
+      token: 'tok-previo',
+      takenAt: 'no-es-fecha',
+    });
+
+    const token = await service.acquireSubscriptionSyncLock('uid-1', LEASE_MS);
+
+    expect(token).not.toBeNull();
+  });
+
+  it('evalúa el lease sobre una marca en formato Timestamp', async () => {
+    const { service } = buildService({
+      token: 'tok-previo',
+      takenAt: { toDate: () => new Date(Date.now() - 5 * 1000) },
+    });
+
+    const token = await service.acquireSubscriptionSyncLock('uid-1', LEASE_MS);
+
+    expect(token).toBeNull();
+  });
+
+  it('libera solo si el token sigue siendo el del titular', async () => {
+    const { service, docData } = buildService({
+      token: 'tok-mio',
+      takenAt: hace(1000),
+    });
+
+    await service.releaseSubscriptionSyncLock('uid-1', 'tok-mio');
+
+    expect(docData.subscriptionSyncLock).toBeNull();
+  });
+
+  it('no libera el lock que otro ciclo tomó tras darlo por caducado', async () => {
+    const { service, update, docData } = buildService({
+      token: 'tok-de-otro',
+      takenAt: hace(1000),
+    });
+
+    await service.releaseSubscriptionSyncLock('uid-1', 'tok-mio');
+
+    expect(update).not.toHaveBeenCalled();
+    expect((docData.subscriptionSyncLock as any).token).toBe('tok-de-otro');
+  });
+});

--- a/src/modules/cache/firestore.service.spec.ts
+++ b/src/modules/cache/firestore.service.spec.ts
@@ -506,3 +506,113 @@ describe('FirestoreService — subscriptionSyncLock', () => {
     expect((docData.subscriptionSyncLock as any).token).toBe('tok-de-otro');
   });
 });
+
+/**
+ * Al caducar un lease su titular no se entera: una respuesta de Stripe bloqueada
+ * más tiempo que el lease puede reanudarse y pisar lo que el nuevo titular ya
+ * aplicó. El token viaja hasta la escritura y se comprueba en la misma
+ * transacción (issue #77).
+ */
+describe('FirestoreService — updateUserSubscriptionState con fencing token', () => {
+  function buildService(docData: Record<string, unknown>) {
+    const update = jest
+      .fn()
+      .mockImplementation((_ref: unknown, data: Record<string, unknown>) => {
+        Object.assign(docData, data);
+      });
+
+    const ref = { id: 'uid-1' };
+    const service: any = Object.create(FirestoreService.prototype);
+    service.usersCollection = 'users';
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    service.firestore = {
+      collection: () => ({ doc: () => ref }),
+      runTransaction: (fn: (t: unknown) => Promise<unknown>) =>
+        fn({
+          get: async () => ({ data: () => docData }),
+          update,
+        }),
+    };
+
+    return { service, update, docData };
+  }
+
+  it('aplica la escritura si el lease sigue siendo del titular', async () => {
+    const { service, docData } = buildService({
+      plan: 'pro',
+      subscriptionSyncLock: {
+        token: 'tok-mio',
+        takenAt: new Date().toISOString(),
+      },
+    });
+
+    const aplicada = await service.updateUserSubscriptionState(
+      'uid-1',
+      { plan: 'promax' },
+      new Date(),
+      'tok-mio',
+    );
+
+    expect(aplicada).toBe(true);
+    expect(docData.plan).toBe('promax');
+  });
+
+  it('descarta la escritura de un titular al que ya relevaron', async () => {
+    const { service, update, docData } = buildService({
+      plan: 'promax',
+      subscriptionSyncLock: {
+        token: 'tok-del-relevo',
+        takenAt: new Date().toISOString(),
+      },
+    });
+
+    // Sello más fresco que el del relevo: sin fencing, ganaría igualmente.
+    const aplicada = await service.updateUserSubscriptionState(
+      'uid-1',
+      { plan: 'pro' },
+      new Date(Date.now() + 60 * 1000),
+      'tok-caducado',
+    );
+
+    expect(aplicada).toBe(false);
+    expect(update).not.toHaveBeenCalled();
+    expect(docData.plan).toBe('promax');
+  });
+
+  it('descarta la escritura si el lock ya no existe', async () => {
+    // Liberado por el relevo, o expirado y limpiado: en ninguno de los dos casos
+    // este ciclo sigue siendo el titular.
+    const { service, update } = buildService({ plan: 'promax' });
+
+    const aplicada = await service.updateUserSubscriptionState(
+      'uid-1',
+      { plan: 'pro' },
+      new Date(),
+      'tok-caducado',
+    );
+
+    expect(aplicada).toBe(false);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('sin token se comporta como antes', async () => {
+    // Las escrituras que no nacen de un ciclo con lease —ninguna hoy, pero el
+    // parámetro es opcional— no deben quedar bloqueadas por un lock ajeno.
+    const { service, docData } = buildService({
+      plan: 'pro',
+      subscriptionSyncLock: {
+        token: 'de-otro',
+        takenAt: new Date().toISOString(),
+      },
+    });
+
+    const aplicada = await service.updateUserSubscriptionState(
+      'uid-1',
+      { plan: 'promax' },
+      new Date(),
+    );
+
+    expect(aplicada).toBe(true);
+    expect(docData.plan).toBe('promax');
+  });
+});

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -733,19 +733,39 @@ export class FirestoreService {
    * compara contra el `subscriptionSyncedAt` almacenado y la escritura se
    * descarta si el documento ya refleja una lectura posterior.
    *
-   * Devuelve `true` si se aplicó y `false` si se descartó por obsoleta, para que
-   * quien llame no dispare efectos secundarios (emails de degradación) por un
-   * cambio que no ocurrió.
+   * `lockToken` es el fencing token del ciclo que escribe. Al caducar un lease
+   * su titular no se entera: puede reanudarse minutos después —una respuesta de
+   * Stripe bloqueada más tiempo que el lease— y pisar lo que el nuevo titular ya
+   * aplicó. Comprobarlo aquí dentro, en la misma transacción que la escritura,
+   * es lo único que corta ese caso; hacerlo fuera dejaría la ventana abierta
+   * entre la comprobación y la escritura.
+   *
+   * Devuelve `true` si se aplicó y `false` si se descartó, para que quien llame
+   * no dispare efectos secundarios (emails de degradación) por un cambio que no
+   * ocurrió.
    */
   async updateUserSubscriptionState(
     userId: string,
     data: Record<string, unknown>,
     readAt: Date,
+    lockToken?: string,
   ): Promise<boolean> {
     const ref = this.firestore.collection(this.usersCollection).doc(userId);
 
     return this.firestore.runTransaction(async (transaction) => {
       const snapshot = await transaction.get(ref);
+
+      if (lockToken) {
+        const vigente = snapshot.data()?.subscriptionSyncLock?.token;
+        if (vigente !== lockToken) {
+          this.logger.warn(
+            `Descartada escritura de suscripción de ${userId}: el lease ya no es ` +
+              `suyo (token ${lockToken}, vigente ${vigente ?? 'ninguno'}).`,
+          );
+          return false;
+        }
+      }
+
       const stored = snapshot.data()?.subscriptionSyncedAt;
 
       // Defensivo con el formato: se escribe como ISO string, pero un documento

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Firestore, FieldValue } from '@google-cloud/firestore';
 import { ConfigService } from '@nestjs/config';
+import { randomUUID } from 'node:crypto';
 import {
   DEFAULT_PLAN_LIMITS,
   PLAN_ORDER,
@@ -770,6 +771,81 @@ export class FirestoreService {
         updatedAt: new Date(),
       });
       return true;
+    });
+  }
+
+  /**
+   * Toma en exclusiva el ciclo relectura→escritura de la suscripción de un
+   * usuario. Devuelve el token del titular, o `null` si otro lo tiene vivo.
+   *
+   * El sello de `updateUserSubscriptionState` ordena por el instante en que la
+   * respuesta de Stripe llegó aquí, que NO es cuándo Stripe observó el estado:
+   * la observación ocurre en un punto desconocido dentro de `[envío,
+   * respuesta]`. Por eso una relectura que vio el plan viejo pero respondió
+   * tarde podía sellar más fresco que otra que vio el nuevo, y revertir un plan
+   * pagado (issue #77). Un reloj local no puede ordenar observaciones remotas, y
+   * el objeto `Subscription` de Stripe no expone versión monotónica, así que la
+   * salida es no solapar los ciclos: sin concurrencia, la última lectura es
+   * siempre la más reciente.
+   *
+   * El sello se conserva igualmente como defensa para los ciclos que mueran con
+   * el lease tomado.
+   */
+  async acquireSubscriptionSyncLock(
+    userId: string,
+    leaseMs: number,
+  ): Promise<string | null> {
+    const ref = this.firestore.collection(this.usersCollection).doc(userId);
+
+    return this.firestore.runTransaction(async (transaction) => {
+      const snapshot = await transaction.get(ref);
+      const stored = snapshot.data()?.subscriptionSyncLock;
+
+      // Defensivo con el formato, igual que el resto de marcas del documento.
+      const takenAtMs = stored?.takenAt
+        ? new Date(stored.takenAt?.toDate?.() ?? stored.takenAt).getTime()
+        : NaN;
+
+      // Un lease caducado se da por muerto: el proceso que lo tomó ya no puede
+      // seguir vivo, y no liberarlo dejaría al usuario sin sincronizar.
+      if (
+        stored?.token &&
+        Number.isFinite(takenAtMs) &&
+        Date.now() - takenAtMs < leaseMs
+      ) {
+        return null;
+      }
+
+      const token = randomUUID();
+      transaction.update(ref, {
+        subscriptionSyncLock: { token, takenAt: new Date().toISOString() },
+        updatedAt: new Date(),
+      });
+      return token;
+    });
+  }
+
+  /**
+   * Libera el ciclo SOLO si el token sigue siendo el del titular.
+   *
+   * Un borrado incondicional podría soltar el lease que otro ciclo tomó tras
+   * darlo por caducado, y volverían a solaparse.
+   */
+  async releaseSubscriptionSyncLock(
+    userId: string,
+    token: string,
+  ): Promise<void> {
+    const ref = this.firestore.collection(this.usersCollection).doc(userId);
+
+    await this.firestore.runTransaction(async (transaction) => {
+      const snapshot = await transaction.get(ref);
+      if (snapshot.data()?.subscriptionSyncLock?.token !== token) {
+        return;
+      }
+      transaction.update(ref, {
+        subscriptionSyncLock: null,
+        updatedAt: new Date(),
+      });
     });
   }
 

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -846,6 +846,36 @@ export class FirestoreService {
   }
 
   /**
+   * Renueva el lease SOLO si el token sigue siendo el del titular. Devuelve
+   * `false` si ya lo relevaron.
+   *
+   * Permite dimensionar el lease por el tramo más largo entre renovaciones en
+   * lugar de por el ciclo completo. El camino del upgrade puede encadenar tres
+   * llamadas a Stripe —revalidación, update y, si el update acaba en error
+   * indeterminado, la relectura que reconcilia—; renovar antes de esa tercera
+   * evita tener que cubrir las tres de golpe con una ventana que bloquearía al
+   * usuario casi veinte minutos si el proceso muriera.
+   */
+  async renewSubscriptionSyncLock(
+    userId: string,
+    token: string,
+  ): Promise<boolean> {
+    const ref = this.firestore.collection(this.usersCollection).doc(userId);
+
+    return this.firestore.runTransaction(async (transaction) => {
+      const snapshot = await transaction.get(ref);
+      if (snapshot.data()?.subscriptionSyncLock?.token !== token) {
+        return false;
+      }
+      transaction.update(ref, {
+        subscriptionSyncLock: { token, takenAt: new Date().toISOString() },
+        updatedAt: new Date(),
+      });
+      return true;
+    });
+  }
+
+  /**
    * Libera el ciclo SOLO si el token sigue siendo el del titular.
    *
    * Un borrado incondicional podría soltar el lease que otro ciclo tomó tras

--- a/src/modules/payments/payments.controller.ts
+++ b/src/modules/payments/payments.controller.ts
@@ -87,6 +87,21 @@ export class PaymentsController {
     status: 400,
     description: 'Invalid upgrade request (no subscription, wrong plan, etc.)',
   })
+  @ApiResponse({
+    status: 409,
+    description:
+      'Another change to this subscription is already in progress (a concurrent ' +
+      'upgrade or an incoming Stripe webhook). Nothing was charged: the request is ' +
+      'rejected before touching Stripe. The client should show the returned message ' +
+      'and let the user retry in a moment.',
+  })
+  @ApiResponse({
+    status: 503,
+    description:
+      'The change went through in Stripe but confirming it is taking longer than ' +
+      'usual. The payment WAS processed — the client must not present this as a ' +
+      'failed charge; the plan is synced shortly after by webhook.',
+  })
   async upgradeSubscription(
     @CurrentUser() user: FirebaseUser,
     @Body() dto: UpgradeSubscriptionDto,

--- a/src/modules/payments/payments.controller.ts
+++ b/src/modules/payments/payments.controller.ts
@@ -98,9 +98,15 @@ export class PaymentsController {
   @ApiResponse({
     status: 503,
     description:
-      'The change went through in Stripe but confirming it is taking longer than ' +
-      'usual. The payment WAS processed — the client must not present this as a ' +
-      'failed charge; the plan is synced shortly after by webhook.',
+      'Temporarily unavailable. The status alone does NOT tell whether money moved — ' +
+      'the client must branch on the `error` code:\n\n' +
+      '- `UPGRADE_APPLIED_SYNC_PENDING` (with `data.paymentProcessed: true`): the change ' +
+      'went through and WAS CHARGED in Stripe; only confirming it is taking longer than ' +
+      'usual, and a webhook syncs the plan shortly after. Never present this as a failed ' +
+      'charge or invite the user to pay again.\n' +
+      '- Any other code (e.g. `SERVICE_UNAVAILABLE`): nothing was charged, or it could not ' +
+      'be determined. These are the tax-profile sync failure and the indeterminate ' +
+      'reconciliation. Do not claim a payment was made.',
   })
   async upgradeSubscription(
     @CurrentUser() user: FirebaseUser,

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -538,6 +538,52 @@ describe('PaymentsService — upgradeSubscription', () => {
     expect(respuesta.data.paymentProcessed).toBe(true);
   });
 
+  it('una excepción al persistir tampoco oculta el cobro', async () => {
+    // Firestore caído después de que Stripe confirmara: el cargo existe, así que
+    // escapar como 500 genérico haría que el cliente lea "error" sobre dinero
+    // que sí se movió.
+    const { service, updateUserSubscriptionState } = buildService({
+      subscription: activeSubscription,
+    });
+    updateUserSubscriptionState.mockRejectedValue(new Error('Firestore caído'));
+
+    const error = await service
+      .upgradeSubscription('uid-1', 'promax')
+      .catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(ServiceUnavailableException);
+    const respuesta = (error as ServiceUnavailableException).getResponse() as {
+      error: string;
+      data: { paymentProcessed: boolean };
+    };
+    expect(respuesta.error).toBe('UPGRADE_APPLIED_SYNC_PENDING');
+    expect(respuesta.data.paymentProcessed).toBe(true);
+  });
+
+  it('el camino reconciliado libera la clave si el fencing descarta la escritura', async () => {
+    // Terminó: retenerla marcaría un intento vivo y bloquearía otros destinos
+    // durante todo el lease.
+    const { service, userDoc, retrieve, updateUserSubscriptionState } =
+      buildService({
+        subscription: activeSubscription,
+        updateError: { type: 'StripeConnectionError', message: 'network' },
+      });
+    retrieve
+      .mockResolvedValueOnce(activeSubscription)
+      .mockResolvedValueOnce(activeSubscription)
+      .mockResolvedValueOnce({
+        status: 'active',
+        items: { data: [{ id: 'si_123', price: { id: PROMAX_MXN } }] },
+      });
+    updateUserSubscriptionState.mockResolvedValue(false);
+
+    await expect(
+      service.upgradeSubscription('uid-1', 'promax'),
+    ).rejects.toBeInstanceOf(ServiceUnavailableException);
+
+    expect(userDoc.upgradeIdempotency).toBeNull();
+  });
+
   it('los 503 anteriores al cobro NO llevan el discriminador de pago procesado', async () => {
     // Si el sync fiscal falla no se ha cobrado nada; confundirlo con el caso de
     // arriba haría que el cliente informara de un cargo que no existe.
@@ -1227,15 +1273,17 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
     const updateUserSubscriptionState = jest
       .fn()
       .mockResolvedValue(overrides.aplicada ?? true);
-    const getUserByStripeCustomerId = jest.fn().mockResolvedValue(
-      overrides.user ?? {
-        id: 'uid-1',
-        email: 'cliente@example.com',
-        plan: 'promax',
-        country: 'MX',
-        stripeSubscriptionId: 'sub_123',
-      },
-    );
+    const usuario = overrides.user ?? {
+      id: 'uid-1',
+      email: 'cliente@example.com',
+      plan: 'promax',
+      country: 'MX',
+      stripeSubscriptionId: 'sub_123',
+    };
+    const getUserByStripeCustomerId = jest.fn().mockResolvedValue(usuario);
+    // Se relee dentro del lease para comprobar que el evento sigue siendo del
+    // contrato vigente.
+    const getUserById = jest.fn().mockResolvedValue(usuario);
     const queueSubscriptionDowngradedEmail = jest
       .fn()
       .mockResolvedValue(undefined);
@@ -1244,6 +1292,7 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
     service.stripe = { subscriptions: { retrieve } };
     service.firestoreService = {
       getUserByStripeCustomerId,
+      getUserById,
       updateUserSubscriptionState,
       acquireSubscriptionSyncLock,
       releaseSubscriptionSyncLock,
@@ -1262,6 +1311,7 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
       queueSubscriptionDowngradedEmail,
       acquireSubscriptionSyncLock,
       releaseSubscriptionSyncLock,
+      getUserById,
     };
   }
 
@@ -1410,6 +1460,9 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
       getUserByStripeCustomerId: jest
         .fn()
         .mockResolvedValue({ id: 'uid-1', plan: 'pro', country: 'MX' }),
+      getUserById: jest
+        .fn()
+        .mockResolvedValue({ id: 'uid-1', plan: 'pro', country: 'MX' }),
       updateUserSubscriptionState,
       // Lock permisivo a propósito: aquí se ejercita el sello, no el lock.
       acquireSubscriptionSyncLock: jest.fn().mockResolvedValue('tok'),
@@ -1495,6 +1548,39 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
     await expect(
       service.handleSubscriptionUpdated(subscriptionCon(PROMAX_MXN)),
     ).resolves.toBeUndefined();
+    expect(updateUserSubscriptionState).toHaveBeenCalled();
+  });
+
+  /**
+   * El mutex ordena las ejecuciones pero no demuestra pertenencia: un evento
+   * retrasado de una suscripción anterior puede adquirir el lease cuando ya es
+   * otra la vigente, y aplicarlo dejaría al cliente en el contrato equivocado.
+   */
+  it('ignora el evento si el usuario ya tiene activa otra suscripción', async () => {
+    const { service, retrieve, updateUserSubscriptionState, getUserById } =
+      buildService({ current: subscriptionCon(PROMAX_MXN) });
+    getUserById.mockResolvedValue({
+      id: 'uid-1',
+      plan: 'promax',
+      stripeSubscriptionId: 'sub_nueva',
+    });
+
+    await service.handleSubscriptionUpdated(subscriptionCon(PRO_MXN));
+
+    expect(retrieve).not.toHaveBeenCalled();
+    expect(updateUserSubscriptionState).not.toHaveBeenCalled();
+  });
+
+  it('acepta el evento si el usuario aún no tiene suscripción registrada', async () => {
+    // Es el alta cuyo checkout todavía no aterrizó: descartar aquí perdería la
+    // sincronización, y no hay contrato anterior con el que chocar.
+    const { service, updateUserSubscriptionState, getUserById } = buildService({
+      current: subscriptionCon(PROMAX_MXN),
+    });
+    getUserById.mockResolvedValue({ id: 'uid-1', plan: 'free' });
+
+    await service.handleSubscriptionUpdated(subscriptionCon(PROMAX_MXN));
+
     expect(updateUserSubscriptionState).toHaveBeenCalled();
   });
 

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -583,6 +583,53 @@ describe('PaymentsService — upgradeSubscription', () => {
     expect(update).not.toHaveBeenCalled();
   });
 
+  it('un fallo al renovar el lease no escapa como error genérico', async () => {
+    // Venimos de un update que PUEDE haber cobrado: un 500 opaco rompería el
+    // contrato de "revisa tu facturación antes de reintentar".
+    const { service, updateUser, renewSubscriptionSyncLock } = buildService({
+      subscription: activeSubscription,
+      updateError: { type: 'StripeConnectionError', message: 'network error' },
+    });
+    renewSubscriptionSyncLock.mockRejectedValue(new Error('Firestore caído'));
+
+    const error = await service
+      .upgradeSubscription('uid-1', 'promax')
+      .catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(ServiceUnavailableException);
+    expect(error.message).toContain('could not confirm');
+    // Y sin el discriminador: no se sabe si hubo cargo, así que no se afirma.
+    expect(JSON.stringify(error.getResponse())).not.toContain(
+      'paymentProcessed',
+    );
+    expect(escriturasDePlan(updateUser)).toHaveLength(0);
+  });
+
+  it('libera la clave cuando la reconciliación encuentra un pending update', async () => {
+    // Es un desenlace definitivo: hay una factura esperando. Conservar la clave
+    // haría que un intento posterior recibiera de Stripe la respuesta cacheada,
+    // que ofrece una factura ya anulada cuando el pending expira.
+    const { service, userDoc, retrieve } = buildService({
+      subscription: activeSubscription,
+      updateError: { type: 'StripeConnectionError', message: 'timeout' },
+    });
+    retrieve
+      .mockResolvedValueOnce(activeSubscription)
+      .mockResolvedValueOnce(activeSubscription)
+      .mockResolvedValueOnce({
+        status: 'active',
+        pending_update: { expires_at: 1234567890 },
+        items: { data: [{ id: 'si_123', price: { id: PRO_MXN } }] },
+        latest_invoice: { hosted_invoice_url: 'https://pay.stripe.com/x' },
+      });
+
+    await expect(
+      service.upgradeSubscription('uid-1', 'promax'),
+    ).rejects.toThrow();
+
+    expect(userDoc.upgradeIdempotency).toBeNull();
+  });
+
   it('no reconcilia si el lease ya no es nuestro', async () => {
     // Reconciliar exigiría una tercera llamada a Stripe; si nos relevaron, la
     // escritura se descartaría igual y quien tenga el ciclo leerá el estado real.
@@ -1458,6 +1505,152 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
 
     await service.handleSubscriptionUpdated(subscriptionCon(PROMAX_MXN));
 
+    expect(updateUserSubscriptionState).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * El alta y la baja también escriben el plan, así que comparten el mutex con el
+ * upgrade y con `subscription.updated`. El alta además relee Stripe: fuera del
+ * mutex, un checkout retrasado podía leer PRO, dejar que el upgrade escribiera
+ * PROMAX y luego restaurar PRO (issue #77).
+ */
+describe('PaymentsService — alta y baja bajo el mutex', () => {
+  const PRO_MXN = 'price_pro_mxn';
+
+  function buildService(overrides: { lockToken?: string | null } = {}) {
+    const retrieve = jest.fn().mockResolvedValue({
+      id: 'sub_123',
+      status: 'active',
+      items: { data: [{ id: 'si_1', price: { id: PRO_MXN } }] },
+    });
+    const updateUserSubscriptionState = jest.fn().mockResolvedValue(true);
+    const updateUser = jest.fn().mockResolvedValue(undefined);
+    const acquireSubscriptionSyncLock = jest
+      .fn()
+      .mockResolvedValue(
+        overrides.lockToken === undefined ? 'tok-1' : overrides.lockToken,
+      );
+    const releaseSubscriptionSyncLock = jest.fn().mockResolvedValue(undefined);
+
+    const service: any = Object.create(PaymentsService.prototype);
+    service.stripe = { subscriptions: { retrieve } };
+    service.firestoreService = {
+      getUserById: jest.fn().mockResolvedValue({ id: 'uid-1', plan: 'free' }),
+      getUserByStripeCustomerId: jest
+        .fn()
+        .mockResolvedValue({ id: 'uid-1', plan: 'pro', email: 'a@b.c' }),
+      updateUser,
+      updateUserSubscriptionState,
+      acquireSubscriptionSyncLock,
+      releaseSubscriptionSyncLock,
+      saveSubscriptionEvent: jest.fn().mockResolvedValue(undefined),
+      saveTransaction: jest.fn().mockResolvedValue(undefined),
+    };
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    service.MAX_RETRIES = 3;
+    service.proPriceIdMxn = PRO_MXN;
+    service.proPriceId = PRO_MXN;
+    service.emailService = {
+      queueSubscriptionDowngradedEmail: jest.fn().mockResolvedValue(undefined),
+    };
+    service.exchangeRateService = {
+      convertUsdToMxn: jest
+        .fn()
+        .mockResolvedValue({ amountMxn: 100, rate: 20 }),
+    };
+    service.ga4Service = {
+      trackPurchase: jest.fn().mockResolvedValue(undefined),
+    };
+    service.billingService = {
+      syncTaxProfileToStripe: jest.fn().mockResolvedValue(undefined),
+    };
+
+    return {
+      service,
+      retrieve,
+      updateUserSubscriptionState,
+      updateUser,
+      acquireSubscriptionSyncLock,
+      releaseSubscriptionSyncLock,
+    };
+  }
+
+  const session = {
+    id: 'cs_1',
+    metadata: { firebaseUid: 'uid-1' },
+    subscription: 'sub_123',
+    currency: 'mxn',
+    amount_total: 10000,
+    customer_details: {},
+  };
+
+  it('el alta escribe el plan sellado y con el token del ciclo', async () => {
+    const { service, updateUserSubscriptionState } = buildService();
+
+    await service.handleCheckoutCompleted(session);
+
+    expect(updateUserSubscriptionState).toHaveBeenCalledWith(
+      'uid-1',
+      expect.objectContaining({ plan: 'pro' }),
+      expect.any(Date),
+      'tok-1',
+    );
+  });
+
+  it('el alta no relee Stripe ni escribe si otro ciclo tiene el mutex', async () => {
+    const { service, retrieve, updateUserSubscriptionState } = buildService({
+      lockToken: null,
+    });
+
+    await expect(
+      service.handleCheckoutCompleted(session),
+    ).rejects.toBeInstanceOf(ConflictException);
+    expect(retrieve).not.toHaveBeenCalled();
+    expect(updateUserSubscriptionState).not.toHaveBeenCalled();
+  });
+
+  it('el alta libera el mutex al terminar', async () => {
+    const { service, releaseSubscriptionSyncLock } = buildService();
+
+    await service.handleCheckoutCompleted(session);
+
+    expect(releaseSubscriptionSyncLock).toHaveBeenCalledWith('uid-1', 'tok-1');
+  });
+
+  it('la baja escribe el plan sellado, no con updateUser a secas', async () => {
+    const { service, updateUserSubscriptionState, updateUser } = buildService();
+
+    await service.handleSubscriptionDeleted({
+      id: 'sub_123',
+      customer: 'cus_1',
+      items: { data: [{ price: { id: PRO_MXN } }] },
+    });
+
+    expect(updateUserSubscriptionState).toHaveBeenCalledWith(
+      'uid-1',
+      expect.objectContaining({ plan: 'free' }),
+      expect.any(Date),
+      'tok-1',
+    );
+    // Sin sello ni token, podía pisar un upgrade recién confirmado.
+    expect(
+      updateUser.mock.calls.filter(([, data]) => data && 'plan' in data),
+    ).toHaveLength(0);
+  });
+
+  it('la baja no escribe si otro ciclo tiene el mutex', async () => {
+    const { service, updateUserSubscriptionState } = buildService({
+      lockToken: null,
+    });
+
+    await expect(
+      service.handleSubscriptionDeleted({
+        id: 'sub_123',
+        customer: 'cus_1',
+        items: { data: [{ price: { id: PRO_MXN } }] },
+      }),
+    ).rejects.toBeInstanceOf(ConflictException);
     expect(updateUserSubscriptionState).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -1663,6 +1663,10 @@ describe('PaymentsService — alta y baja bajo el mutex', () => {
     service.MAX_RETRIES = 3;
     service.proPriceIdMxn = PRO_MXN;
     service.proPriceId = PRO_MXN;
+    // Sin el precio de PROMAX, comparar contratos falla por configuración y el
+    // handler pide reentrega en vez de decidir.
+    service.promaxPriceIdMxn = PROMAX_MXN;
+    service.promaxPriceId = PROMAX_MXN;
     service.emailService = {
       queueSubscriptionDowngradedEmail: jest.fn().mockResolvedValue(undefined),
     };
@@ -1685,6 +1689,7 @@ describe('PaymentsService — alta y baja bajo el mutex', () => {
       updateUser,
       acquireSubscriptionSyncLock,
       releaseSubscriptionSyncLock,
+      firestoreService: service.firestoreService,
     };
   }
 
@@ -1798,19 +1803,85 @@ describe('PaymentsService — alta y baja bajo el mutex', () => {
     );
   });
 
-  it('no adopta si no puede leer el contrato vigente para compararlo', async () => {
-    // Sin poder comparar no se toca algo que puede estar vivo.
+  /**
+   * "No puedo decidir" no es "decido que no". Tragarse el fallo daría 200,
+   * Stripe daría el evento por entregado y un cliente cuyo contrato sí debía
+   * adoptarse se quedaría sin el plan que pagó, sin reintento posible.
+   */
+  it('pide reentrega si no puede leer el contrato vigente, sin contabilizar nada', async () => {
+    const { service, updateUserSubscriptionState, firestoreService } =
+      buildService({
+        usuario: {
+          id: 'uid-1',
+          plan: 'promax',
+          stripeSubscriptionId: 'sub_promax',
+        },
+        vigenteEnStripe: undefined,
+      });
+
+    await expect(service.handleCheckoutCompleted(session)).rejects.toThrow();
+
+    expect(updateUserSubscriptionState).not.toHaveBeenCalled();
+    // La contabilidad va detrás de la decisión: si se hubiera registrado aquí,
+    // la reentrega la duplicaría.
+    expect(firestoreService.saveTransaction).not.toHaveBeenCalled();
+  });
+
+  it('la reentrega tras el fallo adopta y contabiliza una sola vez', async () => {
+    let primeraLectura = true;
+    const { service, updateUserSubscriptionState, firestoreService, retrieve } =
+      buildService({
+        usuario: {
+          id: 'uid-1',
+          plan: 'pro',
+          stripeSubscriptionId: 'sub_viejo',
+        },
+        vigenteEnStripe: {
+          id: 'sub_viejo',
+          status: 'canceled',
+          created: 1000,
+          items: { data: [{ id: 'si_0', price: { id: PRO_MXN } }] },
+        },
+      });
+
+    const original = retrieve.getMockImplementation();
+    retrieve.mockImplementation(async (id: string) => {
+      if (id === 'sub_viejo' && primeraLectura) {
+        primeraLectura = false;
+        throw new Error('timeout');
+      }
+      return original(id);
+    });
+
+    // Primera entrega: falla y no deja rastro.
+    await expect(service.handleCheckoutCompleted(session)).rejects.toThrow();
+    expect(firestoreService.saveTransaction).not.toHaveBeenCalled();
+
+    // Reentrega de Stripe: ahora sí compara, adopta y contabiliza.
+    await service.handleCheckoutCompleted(session);
+
+    expect(updateUserSubscriptionState).toHaveBeenCalledTimes(1);
+    expect(firestoreService.saveTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('pide reentrega si no puede resolver el plan del contrato vigente', async () => {
+    // Un price ID sin mapear: si se configura dentro de la ventana de
+    // reintentos, el alta se aplica sola.
     const { service, updateUserSubscriptionState } = buildService({
       usuario: {
         id: 'uid-1',
-        plan: 'promax',
-        stripeSubscriptionId: 'sub_promax',
+        plan: 'pro',
+        stripeSubscriptionId: 'sub_otro',
       },
-      vigenteEnStripe: undefined,
+      vigenteEnStripe: {
+        id: 'sub_otro',
+        status: 'active',
+        created: 1000,
+        items: { data: [{ id: 'si_0', price: { id: 'price_desconocido' } }] },
+      },
     });
 
-    await service.handleCheckoutCompleted(session);
-
+    await expect(service.handleCheckoutCompleted(session)).rejects.toThrow();
     expect(updateUserSubscriptionState).not.toHaveBeenCalled();
   });
 

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -147,16 +147,35 @@ describe('PaymentsService — upgradeSubscription', () => {
         return true;
       });
 
-    // El upgrade entra en el mismo mutex que el webhook (issue #77): los dos
-    // observan Stripe y escriben el plan.
+    /**
+     * El upgrade entra en el mismo mutex que el webhook (issue #77): los dos
+     * observan Stripe y escriben el plan.
+     *
+     * Con estado real, no concediendo siempre el mismo token: un mock permisivo
+     * dejaría entrar a dos ciclos a la vez, que es justo lo que el mutex impide,
+     * y las pruebas de concurrencia estarían midiendo un mundo que no existe.
+     */
+    let lockVivo: string | null = null;
     const acquireSubscriptionSyncLock = jest
       .fn()
-      .mockResolvedValue(
-        overrides.syncLockToken === undefined
-          ? 'sync-tok'
-          : overrides.syncLockToken,
-      );
-    const releaseSubscriptionSyncLock = jest.fn().mockResolvedValue(undefined);
+      .mockImplementation(async () => {
+        if (overrides.syncLockToken === null) {
+          return null;
+        }
+        if (lockVivo) {
+          return null;
+        }
+        lockVivo = overrides.syncLockToken ?? 'sync-tok';
+        return lockVivo;
+      });
+    const releaseSubscriptionSyncLock = jest
+      .fn()
+      .mockImplementation(async (_id: string, token: string) => {
+        // Compare-and-delete, igual que la implementación real.
+        if (lockVivo === token) {
+          lockVivo = null;
+        }
+      });
 
     const service: any = Object.create(PaymentsService.prototype);
     service.stripe = { subscriptions: { retrieve, update } };
@@ -306,18 +325,32 @@ describe('PaymentsService — upgradeSubscription', () => {
     expect(getUserById).toHaveBeenCalledTimes(2);
   });
 
-  it('dos upgrades concurrentes comparten clave y no duplican la mutación', async () => {
+  /**
+   * Antes del mutex (issue #77), dos upgrades concurrentes llegaban los dos a
+   * Stripe y solo la clave compartida evitaba el doble cargo. Ahora el segundo
+   * ni siquiera entra: el mutex lo rechaza con 409 antes de mover dinero. Esa es
+   * la garantía fuerte, y la clave queda como red de seguridad para los
+   * reintentos secuenciales, que sí comparten clave.
+   */
+  it('dos upgrades concurrentes: uno pasa y el otro recibe 409 sin tocar Stripe', async () => {
     const { service, update } = buildService({
       subscription: activeSubscription,
     });
 
-    await Promise.all([
+    const resultados = await Promise.allSettled([
       service.upgradeSubscription('uid-1', 'promax'),
       service.upgradeSubscription('uid-1', 'promax'),
     ]);
 
-    // Misma clave ⇒ Stripe deduplica y solo se cobra una vez.
-    expect(claveUsada(update, 0)).toBe(claveUsada(update, 1));
+    const cumplidos = resultados.filter((r) => r.status === 'fulfilled');
+    const rechazados = resultados.filter((r) => r.status === 'rejected');
+    expect(cumplidos).toHaveLength(1);
+    expect(rechazados).toHaveLength(1);
+    expect((rechazados[0] as PromiseRejectedResult).reason).toBeInstanceOf(
+      ConflictException,
+    );
+    // Una sola mutación: el rechazo ocurre antes de llamar a Stripe.
+    expect(update).toHaveBeenCalledTimes(1);
   });
 
   /**
@@ -399,6 +432,81 @@ describe('PaymentsService — upgradeSubscription', () => {
     );
     // Lo que importa: la suscripción no baja de promax a pro.
     expect(update).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Firestore refleja lo que los webhooks alcanzaron a escribir, no lo que
+   * Stripe tiene ahora. Un upgrade que dejó un `pending_update` esperando pago
+   * NO cambia el plan en Firestore, así que releer solo el documento no lo ve; y
+   * lanzar otro update reemplazaría ese pending update, anulando su factura y
+   * dejando al cliente con un enlace de pago muerto.
+   */
+  it('aborta si Stripe tiene un pending update, aunque Firestore no lo refleje', async () => {
+    const { service, update, retrieve } = buildService({
+      subscription: activeSubscription,
+    });
+    retrieve.mockResolvedValueOnce(activeSubscription).mockResolvedValueOnce({
+      status: 'active',
+      items: { data: [{ id: 'si_123' }] },
+      pending_update: { expires_at: 123 },
+      latest_invoice: { hosted_invoice_url: 'https://pay.stripe.com/x' },
+    });
+
+    await expect(
+      service.upgradeSubscription('uid-1', 'promax'),
+    ).rejects.toThrow();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('aborta si Stripe ya tiene la suscripción en el plan de destino', async () => {
+    // La comprobación que de verdad impide bajar de plan: el plan efectivo lo
+    // dicta el precio que Stripe tiene puesto, no el documento.
+    const { service, update, retrieve } = buildService({
+      subscription: activeSubscription,
+    });
+    retrieve.mockResolvedValueOnce(activeSubscription).mockResolvedValueOnce({
+      status: 'active',
+      items: { data: [{ id: 'si_123', price: { id: PROMAX_MXN } }] },
+    });
+
+    await expect(
+      service.upgradeSubscription('uid-1', 'promax'),
+    ).rejects.toThrow(BadRequestException);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('aborta si la suscripción dejó de estar activa mientras se preparaba', async () => {
+    const { service, update, retrieve } = buildService({
+      subscription: activeSubscription,
+    });
+    retrieve
+      .mockResolvedValueOnce(activeSubscription)
+      .mockResolvedValueOnce({ status: 'past_due', items: { data: [{}] } });
+
+    await expect(
+      service.upgradeSubscription('uid-1', 'promax'),
+    ).rejects.toThrow(BadRequestException);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  /**
+   * El cobro ya pasó y no se puede deshacer, pero la escritura se descartó
+   * porque otro ciclo relevó el lease. Responder éxito dejaría al cliente con el
+   * producto sin reconocerle el plan que acaba de pagar.
+   */
+  it('no afirma éxito si el fencing descarta la escritura tras cobrar', async () => {
+    const { service, updateUserSubscriptionState } = buildService({
+      subscription: activeSubscription,
+    });
+    updateUserSubscriptionState.mockResolvedValue(false);
+
+    const error = await service
+      .upgradeSubscription('uid-1', 'promax')
+      .catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(ServiceUnavailableException);
+    // El mensaje reconoce el cobro: negarlo sería mentir sobre dinero cobrado.
+    expect(error.message).toContain('went through');
   });
 
   it('aborta si la suscripción cambió mientras se preparaba el upgrade', async () => {
@@ -628,11 +736,15 @@ describe('PaymentsService — upgradeSubscription', () => {
       subscription: activeSubscription,
       updateError: { type: 'StripeConnectionError', message: 'network error' },
     });
-    // Al releer, la suscripción ya está en el precio nuevo: Stripe sí lo aplicó.
-    retrieve.mockResolvedValueOnce(activeSubscription).mockResolvedValueOnce({
-      status: 'active',
-      items: { data: [{ id: 'si_123', price: { id: PROMAX_MXN } }] },
-    });
+    // Tres lecturas: la inicial, la revalidación dentro del mutex y la de la
+    // reconciliación, que ya ve el precio nuevo — Stripe sí lo aplicó.
+    retrieve
+      .mockResolvedValueOnce(activeSubscription)
+      .mockResolvedValueOnce(activeSubscription)
+      .mockResolvedValueOnce({
+        status: 'active',
+        items: { data: [{ id: 'si_123', price: { id: PROMAX_MXN } }] },
+      });
 
     const result = await service.upgradeSubscription('uid-1', 'promax');
 
@@ -645,11 +757,15 @@ describe('PaymentsService — upgradeSubscription', () => {
       subscription: activeSubscription,
       updateError: { type: 'StripeConnectionError', message: 'network error' },
     });
-    // Al releer sigue en el precio viejo: el cambio no llegó a aplicarse.
-    retrieve.mockResolvedValueOnce(activeSubscription).mockResolvedValueOnce({
-      status: 'active',
-      items: { data: [{ id: 'si_123', price: { id: 'price_pro_mxn' } }] },
-    });
+    // Tercera lectura —la de la reconciliación— sigue en el precio viejo: el
+    // cambio no llegó a aplicarse.
+    retrieve
+      .mockResolvedValueOnce(activeSubscription)
+      .mockResolvedValueOnce(activeSubscription)
+      .mockResolvedValueOnce({
+        status: 'active',
+        items: { data: [{ id: 'si_123', price: { id: 'price_pro_mxn' } }] },
+      });
 
     await expect(
       service.upgradeSubscription('uid-1', 'promax'),
@@ -782,6 +898,8 @@ describe('PaymentsService — upgradeSubscription', () => {
       updateError: { type: 'StripeAPIError', message: 'api error' },
     });
     retrieve
+      .mockResolvedValueOnce(activeSubscription)
+      // Revalidación dentro del mutex; la que falla es la de la reconciliación.
       .mockResolvedValueOnce(activeSubscription)
       .mockRejectedValueOnce(new Error('still down'));
 

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -16,6 +16,8 @@ import { PaymentsService } from './payments.service.js';
  */
 describe('PaymentsService — upgradeSubscription', () => {
   const PROMAX_MXN = 'price_promax_mxn';
+  const PRO_MXN = 'price_pro_mxn';
+  const LITE_MXN = 'price_lite_mxn';
 
   /**
    * El constructor de PaymentsService abre conexiones (Stripe, Firestore) que
@@ -176,6 +178,12 @@ describe('PaymentsService — upgradeSubscription', () => {
           lockVivo = null;
         }
       });
+    // Renueva solo si el token sigue siendo el del titular.
+    const renewSubscriptionSyncLock = jest
+      .fn()
+      .mockImplementation(
+        async (_id: string, token: string) => lockVivo === token,
+      );
 
     const service: any = Object.create(PaymentsService.prototype);
     service.stripe = { subscriptions: { retrieve, update } };
@@ -187,9 +195,13 @@ describe('PaymentsService — upgradeSubscription', () => {
       releaseUpgradeIdempotency,
       acquireSubscriptionSyncLock,
       releaseSubscriptionSyncLock,
+      renewSubscriptionSyncLock,
     };
     service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
     service.promaxPriceIdMxn = PROMAX_MXN;
+    // Sin estos, el precio vigente no se resuelve y el upgrade falla cerrado.
+    service.proPriceIdMxn = PRO_MXN;
+    service.litePriceIdMxn = LITE_MXN;
     // El upgrade emite y cobra la factura de la proración dentro del update, así
     // que propaga el perfil fiscal antes y en modo estricto.
     service.billingService = { syncTaxProfileToStripe: syncTaxProfileToStripe };
@@ -207,6 +219,7 @@ describe('PaymentsService — upgradeSubscription', () => {
       releaseUpgradeIdempotency,
       acquireSubscriptionSyncLock,
       releaseSubscriptionSyncLock,
+      renewSubscriptionSyncLock,
     };
   }
 
@@ -222,9 +235,17 @@ describe('PaymentsService — upgradeSubscription', () => {
     return update.mock.calls[llamada]?.[2]?.idempotencyKey;
   }
 
+  // Con precio: el upgrade falla cerrado si no puede resolver de qué plan parte,
+  // así que una suscripción sin `price` ya no es un fixture realista.
   const activeSubscription = {
     status: 'active',
-    items: { data: [{ id: 'si_123' }] },
+    items: { data: [{ id: 'si_123', price: { id: PRO_MXN } }] },
+  };
+
+  /** Para los casos que arrancan en Lite, donde ambos destinos son válidos. */
+  const liteSubscription = {
+    status: 'active',
+    items: { data: [{ id: 'si_123', price: { id: LITE_MXN } }] },
   };
 
   it('sube el plan y aplica el precio de la moneda del usuario', async () => {
@@ -361,12 +382,11 @@ describe('PaymentsService — upgradeSubscription', () => {
    */
   it('rechaza un segundo upgrade a otro destino mientras el primero sigue en curso', async () => {
     const { service, update, userDoc } = buildService({
-      subscription: activeSubscription,
+      subscription: liteSubscription,
     });
     // Desde lite ambos destinos son upgrades válidos: el caso de las dos
     // pestañas con botones distintos.
     userDoc.plan = 'lite';
-    service.proPriceIdMxn = 'price_pro_mxn';
 
     const resultados = await Promise.allSettled([
       service.upgradeSubscription('uid-1', 'pro'),
@@ -384,10 +404,9 @@ describe('PaymentsService — upgradeSubscription', () => {
 
   it('permite cambiar de destino cuando el intento anterior ya no puede estar vivo', async () => {
     const { service, update, userDoc } = buildService({
-      subscription: activeSubscription,
+      subscription: liteSubscription,
     });
     userDoc.plan = 'lite';
-    service.proPriceIdMxn = 'price_pro_mxn';
     // Intento anterior a otro plan, de hace media hora: el lease expiró hace
     // mucho. Sigue dentro del TTL de 24 h, y ahí está la trampa — usar el TTL
     // para excluir dejaría al cliente sin poder cambiar de plan durante un día.
@@ -416,10 +435,9 @@ describe('PaymentsService — upgradeSubscription', () => {
    */
   it('revalida el plan dentro del mutex y aborta si otro cambio ya subió más', async () => {
     const { service, update, userDoc, getUserById } = buildService({
-      subscription: activeSubscription,
+      subscription: liteSubscription,
     });
     userDoc.plan = 'lite';
-    service.proPriceIdMxn = 'price_pro_mxn';
 
     // La primera lectura ve lite; para cuando se revalida, otro upgrade ya
     // dejó al usuario en promax.
@@ -507,6 +525,80 @@ describe('PaymentsService — upgradeSubscription', () => {
     expect(error).toBeInstanceOf(ServiceUnavailableException);
     // El mensaje reconoce el cobro: negarlo sería mentir sobre dinero cobrado.
     expect(error.message).toContain('went through');
+
+    // Y el discriminador, que es lo que el cliente debe mirar: este endpoint
+    // devuelve 503 también SIN cobro —sync fiscal fallido, reconciliación
+    // indeterminada—, así que deducirlo del status sería afirmar un cargo
+    // inexistente en dos de los tres casos.
+    const respuesta = (error as ServiceUnavailableException).getResponse() as {
+      error: string;
+      data: { paymentProcessed: boolean };
+    };
+    expect(respuesta.error).toBe('UPGRADE_APPLIED_SYNC_PENDING');
+    expect(respuesta.data.paymentProcessed).toBe(true);
+  });
+
+  it('los 503 anteriores al cobro NO llevan el discriminador de pago procesado', async () => {
+    // Si el sync fiscal falla no se ha cobrado nada; confundirlo con el caso de
+    // arriba haría que el cliente informara de un cargo que no existe.
+    const { service } = buildService({
+      subscription: activeSubscription,
+      syncTaxProfileToStripe: jest.fn().mockRejectedValue(new Error('caído')),
+    });
+
+    const error = await service
+      .upgradeSubscription('uid-1', 'promax')
+      .catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(ServiceUnavailableException);
+    const respuesta = (error as ServiceUnavailableException).getResponse();
+    expect(JSON.stringify(respuesta)).not.toContain('paymentProcessed');
+    expect(JSON.stringify(respuesta)).not.toContain(
+      'UPGRADE_APPLIED_SYNC_PENDING',
+    );
+  });
+
+  /**
+   * Mismo caso de configuración que el webhook trata como CRITICAL sin tocar el
+   * plan: si no se sabe de qué plan se parte, no se puede afirmar que esto sea
+   * una subida, y facturar a ciegas es peor que rechazar.
+   */
+  it('falla cerrado si el precio vigente en Stripe no mapea a ningún plan', async () => {
+    const { service, update, retrieve } = buildService({
+      subscription: activeSubscription,
+    });
+    retrieve.mockResolvedValueOnce(activeSubscription).mockResolvedValueOnce({
+      status: 'active',
+      items: {
+        data: [{ id: 'si_123', price: { id: 'price_que_nadie_conoce' } }],
+      },
+    });
+
+    const error = await service
+      .upgradeSubscription('uid-1', 'promax')
+      .catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(ServiceUnavailableException);
+    expect(error.message).toContain('Nothing was charged');
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('no reconcilia si el lease ya no es nuestro', async () => {
+    // Reconciliar exigiría una tercera llamada a Stripe; si nos relevaron, la
+    // escritura se descartaría igual y quien tenga el ciclo leerá el estado real.
+    const { service, updateUser, renewSubscriptionSyncLock } = buildService({
+      subscription: activeSubscription,
+      updateError: { type: 'StripeConnectionError', message: 'network error' },
+    });
+    renewSubscriptionSyncLock.mockResolvedValue(false);
+
+    const error = await service
+      .upgradeSubscription('uid-1', 'promax')
+      .catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(ServiceUnavailableException);
+    expect(error.message).toContain('could not confirm');
+    expect(escriturasDePlan(updateUser)).toHaveLength(0);
   });
 
   it('aborta si la suscripción cambió mientras se preparaba el upgrade', async () => {
@@ -780,19 +872,25 @@ describe('PaymentsService — upgradeSubscription', () => {
    * cliente sin el enlace con el que ya podía pagar.
    */
   it('si el timeout dejó un pending update, devuelve su enlace en vez de un error genérico', async () => {
-    const { service, updateUser, retrieve } = buildService({
+    const { service, updateUser, retrieve, update } = buildService({
       subscription: activeSubscription,
       updateError: { type: 'StripeConnectionError', message: 'timeout' },
     });
-    retrieve.mockResolvedValueOnce(activeSubscription).mockResolvedValueOnce({
-      status: 'active',
-      pending_update: { expires_at: 1234567890 },
-      items: { data: [{ id: 'si_123', price: { id: 'price_pro_mxn' } }] },
-      latest_invoice: {
-        id: 'in_pendiente',
-        hosted_invoice_url: 'https://invoice.stripe.com/i/pendiente',
-      },
-    });
+    // El pending va en la TERCERA lectura, la de la reconciliación. Si se deja
+    // en la segunda lo consume la revalidación del mutex, el update nunca se
+    // llama y este test pasaría sin llegar a reconciliar nada.
+    retrieve
+      .mockResolvedValueOnce(activeSubscription)
+      .mockResolvedValueOnce(activeSubscription)
+      .mockResolvedValueOnce({
+        status: 'active',
+        pending_update: { expires_at: 1234567890 },
+        items: { data: [{ id: 'si_123', price: { id: 'price_pro_mxn' } }] },
+        latest_invoice: {
+          id: 'in_pendiente',
+          hosted_invoice_url: 'https://invoice.stripe.com/i/pendiente',
+        },
+      });
 
     const error = await service
       .upgradeSubscription('uid-1', 'promax')
@@ -800,6 +898,8 @@ describe('PaymentsService — upgradeSubscription', () => {
 
     expect(error.message).toContain('has not been changed');
     expect(error.message).toContain('https://invoice.stripe.com/i/pendiente');
+    // Sin esto, el test volvería a pasar por el camino equivocado sin avisar.
+    expect(update).toHaveBeenCalled();
     expect(escriturasDePlan(updateUser)).toHaveLength(0);
     // Sin expandir la factura no habría enlace que devolver.
     expect(retrieve).toHaveBeenLastCalledWith(

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -32,6 +32,8 @@ describe('PaymentsService — upgradeSubscription', () => {
      */
     updateResult?: unknown;
     syncTaxProfileToStripe?: jest.Mock;
+    /** `null` simula que otro ciclo tiene el mutex de sincronización. */
+    syncLockToken?: string | null;
   }) {
     const retrieve = overrides.retrieveError
       ? jest.fn().mockRejectedValue(overrides.retrieveError)
@@ -145,6 +147,17 @@ describe('PaymentsService — upgradeSubscription', () => {
         return true;
       });
 
+    // El upgrade entra en el mismo mutex que el webhook (issue #77): los dos
+    // observan Stripe y escriben el plan.
+    const acquireSubscriptionSyncLock = jest
+      .fn()
+      .mockResolvedValue(
+        overrides.syncLockToken === undefined
+          ? 'sync-tok'
+          : overrides.syncLockToken,
+      );
+    const releaseSubscriptionSyncLock = jest.fn().mockResolvedValue(undefined);
+
     const service: any = Object.create(PaymentsService.prototype);
     service.stripe = { subscriptions: { retrieve, update } };
     service.firestoreService = {
@@ -153,6 +166,8 @@ describe('PaymentsService — upgradeSubscription', () => {
       updateUserSubscriptionState,
       acquireUpgradeIdempotency,
       releaseUpgradeIdempotency,
+      acquireSubscriptionSyncLock,
+      releaseSubscriptionSyncLock,
     };
     service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
     service.promaxPriceIdMxn = PROMAX_MXN;
@@ -171,6 +186,8 @@ describe('PaymentsService — upgradeSubscription', () => {
       userDoc,
       acquireUpgradeIdempotency,
       releaseUpgradeIdempotency,
+      acquireSubscriptionSyncLock,
+      releaseSubscriptionSyncLock,
     };
   }
 
@@ -284,7 +301,9 @@ describe('PaymentsService — upgradeSubscription', () => {
       7 * 60 * 1000,
     );
     // La clave no se decide a partir del usuario leído antes de la transacción.
-    expect(getUserById).toHaveBeenCalledTimes(1);
+    // Dos lecturas: la inicial y la revalidación dentro del mutex, que existe
+    // porque entre ambas cabe otro cambio ya aplicado (issue #77).
+    expect(getUserById).toHaveBeenCalledTimes(2);
   });
 
   it('dos upgrades concurrentes comparten clave y no duplican la mutación', async () => {
@@ -354,6 +373,73 @@ describe('PaymentsService — upgradeSubscription', () => {
     expect(update).toHaveBeenCalledTimes(1);
     // Clave nueva: la del intento caducado no protege de nada aquí.
     expect(claveUsada(update, 0)).not.toBe('upgrade_uid-1_viejo');
+  });
+
+  /**
+   * El plan se valida antes de la sincronización fiscal, y en ese hueco otro
+   * cambio puede completarse. Sin revalidar dentro del mutex, un lite→pro
+   * demorado entraría después de un lite→promax ya aplicado y BAJARÍA la
+   * suscripción, violando la garantía de upgrade estricto (issue #77).
+   */
+  it('revalida el plan dentro del mutex y aborta si otro cambio ya subió más', async () => {
+    const { service, update, userDoc, getUserById } = buildService({
+      subscription: activeSubscription,
+    });
+    userDoc.plan = 'lite';
+    service.proPriceIdMxn = 'price_pro_mxn';
+
+    // La primera lectura ve lite; para cuando se revalida, otro upgrade ya
+    // dejó al usuario en promax.
+    getUserById
+      .mockResolvedValueOnce({ ...userDoc, plan: 'lite' })
+      .mockResolvedValueOnce({ ...userDoc, plan: 'promax' });
+
+    await expect(service.upgradeSubscription('uid-1', 'pro')).rejects.toThrow(
+      BadRequestException,
+    );
+    // Lo que importa: la suscripción no baja de promax a pro.
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('aborta si la suscripción cambió mientras se preparaba el upgrade', async () => {
+    const { service, update, userDoc, getUserById } = buildService({
+      subscription: activeSubscription,
+    });
+
+    getUserById
+      .mockResolvedValueOnce({ ...userDoc })
+      .mockResolvedValueOnce({ ...userDoc, stripeSubscriptionId: 'sub_otra' });
+
+    await expect(
+      service.upgradeSubscription('uid-1', 'promax'),
+    ).rejects.toThrow(ConflictException);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('no toca Stripe si otro ciclo tiene el mutex de sincronización', async () => {
+    // Un webhook en curso puede estar observando el estado ahora mismo.
+    const { service, update } = buildService({
+      subscription: activeSubscription,
+      syncLockToken: null,
+    });
+
+    await expect(
+      service.upgradeSubscription('uid-1', 'promax'),
+    ).rejects.toThrow(ConflictException);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('libera el mutex de sincronización al terminar', async () => {
+    const { service, releaseSubscriptionSyncLock } = buildService({
+      subscription: activeSubscription,
+    });
+
+    await service.upgradeSubscription('uid-1', 'promax');
+
+    expect(releaseSubscriptionSyncLock).toHaveBeenCalledWith(
+      'uid-1',
+      'sync-tok',
+    );
   });
 
   it('libera la clave comparando, sin pisar la de un intento posterior', async () => {
@@ -812,6 +898,9 @@ describe('PaymentsService — upgradeSubscription', () => {
       'uid-1',
       { plan: 'promax' },
       expect.any(Date),
+      // Fencing token: si este ciclo se demoró más que el lease y otro lo
+      // relevó, la escritura se descarta en la propia transacción.
+      'sync-tok',
     );
     // Posterior a la respuesta de Stripe: el dato no es válido antes de que
     // Stripe lo devolviera.
@@ -923,6 +1012,7 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
       'uid-1',
       expect.objectContaining({ plan: 'promax' }),
       expect.any(Date),
+      'tok-1',
     );
   });
 

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -853,10 +853,22 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
     /** `false` simula que otra escritura más fresca ya ganó. */
     aplicada?: boolean;
     user?: Record<string, unknown>;
+    /** `null` simula que otro ciclo tiene el lock tomado. */
+    lockToken?: string | null;
+    releaseError?: unknown;
   }) {
     const retrieve = overrides.retrieveError
       ? jest.fn().mockRejectedValue(overrides.retrieveError)
       : jest.fn().mockResolvedValue(overrides.current);
+
+    const acquireSubscriptionSyncLock = jest
+      .fn()
+      .mockResolvedValue(
+        overrides.lockToken === undefined ? 'tok-1' : overrides.lockToken,
+      );
+    const releaseSubscriptionSyncLock = overrides.releaseError
+      ? jest.fn().mockRejectedValue(overrides.releaseError)
+      : jest.fn().mockResolvedValue(undefined);
 
     const updateUserSubscriptionState = jest
       .fn()
@@ -879,6 +891,8 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
     service.firestoreService = {
       getUserByStripeCustomerId,
       updateUserSubscriptionState,
+      acquireSubscriptionSyncLock,
+      releaseSubscriptionSyncLock,
     };
     service.emailService = { queueSubscriptionDowngradedEmail };
     service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
@@ -892,6 +906,8 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
       retrieve,
       updateUserSubscriptionState,
       queueSubscriptionDowngradedEmail,
+      acquireSubscriptionSyncLock,
+      releaseSubscriptionSyncLock,
     };
   }
 
@@ -989,11 +1005,15 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
   });
 
   /**
-   * El sello debe representar el estado OBSERVADO, no el momento en que salió la
-   * petición. Sellar al inicio invierte la garantía justo en el caso que el fix
-   * persigue: una relectura lenta que acaba viendo el plan nuevo llevaría un
-   * sello menor que otra posterior que vio el viejo, y la guarda descartaría la
-   * lectura buena dejando el plan obsoleto en Firestore.
+   * Defensa en profundidad. El lock por usuario (issue #77) impide que dos
+   * ciclos se solapen, así que esta carrera ya no debería darse en producción;
+   * el sello sigue cubriendo los ciclos que mueran con el lease tomado, y debe
+   * representar el estado OBSERVADO y no el momento en que salió la petición.
+   * Sellar al inicio invertía la garantía: una relectura lenta que acaba viendo
+   * el plan nuevo llevaría un sello menor que otra posterior que vio el viejo.
+   *
+   * Por eso este test concede el lock a los dos ciclos: verifica la capa de
+   * abajo, no la serialización.
    */
   it('gana la relectura que observó el estado más reciente aunque su petición saliera antes', async () => {
     const espera = (ms: number) =>
@@ -1036,6 +1056,9 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
         .fn()
         .mockResolvedValue({ id: 'uid-1', plan: 'pro', country: 'MX' }),
       updateUserSubscriptionState,
+      // Lock permisivo a propósito: aquí se ejercita el sello, no el lock.
+      acquireSubscriptionSyncLock: jest.fn().mockResolvedValue('tok'),
+      releaseSubscriptionSyncLock: jest.fn().mockResolvedValue(undefined),
     };
     service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
     service.MAX_RETRIES = 3;
@@ -1061,6 +1084,63 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
     // Con el sello tomado al inicio, esta escritura se habría descartado por
     // llevar un sello menor y el cliente se quedaba en PRO habiendo pagado.
     expect(doc.plan).toBe('promax');
+  });
+
+  /**
+   * El sello ordena por la llegada de la respuesta a Cloud Run, no por cuándo
+   * Stripe observó el estado, y entre ambos instantes cabe una red lenta. La
+   * salida es no solapar los ciclos (issue #77).
+   */
+  it('no relee ni escribe si otro ciclo tiene el lock del usuario', async () => {
+    const { service, retrieve, updateUserSubscriptionState } = buildService({
+      current: subscriptionCon(PROMAX_MXN),
+      lockToken: null,
+    });
+
+    // Lanza para que Stripe reentregue: esperar aquí agotaría el plazo de
+    // respuesta del webhook y Stripe lo reintentaría igualmente.
+    await expect(
+      service.handleSubscriptionUpdated(subscriptionCon(PRO_MXN)),
+    ).rejects.toBeInstanceOf(ConflictException);
+    expect(retrieve).not.toHaveBeenCalled();
+    expect(updateUserSubscriptionState).not.toHaveBeenCalled();
+  });
+
+  it('libera el lock al terminar', async () => {
+    const { service, releaseSubscriptionSyncLock } = buildService({
+      current: subscriptionCon(PROMAX_MXN),
+    });
+
+    await service.handleSubscriptionUpdated(subscriptionCon(PROMAX_MXN));
+
+    expect(releaseSubscriptionSyncLock).toHaveBeenCalledWith('uid-1', 'tok-1');
+  });
+
+  it('libera el lock aunque el ciclo falle a mitad', async () => {
+    // Sin el `finally`, una relectura fallida dejaría al usuario sin sincronizar
+    // hasta que caducara el lease.
+    const { service, releaseSubscriptionSyncLock } = buildService({
+      retrieveError: new Error('Stripe caído'),
+    });
+
+    await expect(
+      service.handleSubscriptionUpdated(subscriptionCon(PRO_MXN)),
+    ).rejects.toThrow('Stripe caído');
+    expect(releaseSubscriptionSyncLock).toHaveBeenCalledWith('uid-1', 'tok-1');
+  });
+
+  it('no convierte un fallo al liberar el lock en un fallo del webhook', async () => {
+    // El lease caduca solo; provocar una reentrega de algo ya aplicado sería
+    // peor que dejarlo expirar.
+    const { service, updateUserSubscriptionState } = buildService({
+      current: subscriptionCon(PROMAX_MXN),
+      releaseError: new Error('Firestore caído'),
+    });
+
+    await expect(
+      service.handleSubscriptionUpdated(subscriptionCon(PROMAX_MXN)),
+    ).resolves.toBeUndefined();
+    expect(updateUserSubscriptionState).toHaveBeenCalled();
   });
 
   it('no toca el plan si el precio vigente no mapea a ninguno', async () => {

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -1604,11 +1604,35 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
 describe('PaymentsService — alta y baja bajo el mutex', () => {
   const PRO_MXN = 'price_pro_mxn';
 
-  function buildService(overrides: { lockToken?: string | null } = {}) {
-    const retrieve = jest.fn().mockResolvedValue({
+  const PROMAX_MXN = 'price_promax_mxn';
+
+  function buildService(
+    overrides: {
+      lockToken?: string | null;
+      /** Suscripción que trae el checkout. */
+      delCheckout?: unknown;
+      /** Usuario tal como se lee DENTRO del lease. */
+      usuario?: Record<string, unknown>;
+      /** Suscripción que Stripe devuelve para el contrato ya registrado. */
+      vigenteEnStripe?: unknown;
+    } = {},
+  ) {
+    const delCheckout = overrides.delCheckout ?? {
       id: 'sub_123',
       status: 'active',
+      created: 2000,
       items: { data: [{ id: 'si_1', price: { id: PRO_MXN } }] },
+    };
+    const retrieve = jest.fn().mockImplementation(async (id: string) => {
+      if (id === 'sub_123') {
+        return delCheckout;
+      }
+      // Stripe lanza ante un ID que no puede leer; devolver undefined no
+      // modelaría nada que ocurra de verdad.
+      if (!overrides.vigenteEnStripe) {
+        throw new Error('No such subscription');
+      }
+      return overrides.vigenteEnStripe;
     });
     const updateUserSubscriptionState = jest.fn().mockResolvedValue(true);
     const updateUser = jest.fn().mockResolvedValue(undefined);
@@ -1622,7 +1646,9 @@ describe('PaymentsService — alta y baja bajo el mutex', () => {
     const service: any = Object.create(PaymentsService.prototype);
     service.stripe = { subscriptions: { retrieve } };
     service.firestoreService = {
-      getUserById: jest.fn().mockResolvedValue({ id: 'uid-1', plan: 'free' }),
+      getUserById: jest
+        .fn()
+        .mockResolvedValue(overrides.usuario ?? { id: 'uid-1', plan: 'free' }),
       getUserByStripeCustomerId: jest
         .fn()
         .mockResolvedValue({ id: 'uid-1', plan: 'pro', email: 'a@b.c' }),
@@ -1704,6 +1730,90 @@ describe('PaymentsService — alta y baja bajo el mutex', () => {
     expect(releaseSubscriptionSyncLock).toHaveBeenCalledWith('uid-1', 'tok-1');
   });
 
+  /**
+   * `checkout.session.completed` acredita un alta que ocurrió, no que sea el
+   * contrato vigente: Stripe lo reentrega y no garantiza el orden, así que puede
+   * llegar días tarde describiendo una suscripción ya muerta o una duplicada
+   * inferior a la que el cliente tiene viva.
+   */
+  it('no fija el plan si la suscripción del checkout ya está cancelada', async () => {
+    const { service, updateUserSubscriptionState } = buildService({
+      delCheckout: {
+        id: 'sub_123',
+        status: 'canceled',
+        created: 2000,
+        items: { data: [{ id: 'si_1', price: { id: PRO_MXN } }] },
+      },
+    });
+
+    await service.handleCheckoutCompleted(session);
+
+    expect(updateUserSubscriptionState).not.toHaveBeenCalled();
+  });
+
+  it('no degrada un contrato vivo superior al del checkout reentregado', async () => {
+    const { service, updateUserSubscriptionState } = buildService({
+      usuario: {
+        id: 'uid-1',
+        plan: 'promax',
+        stripeSubscriptionId: 'sub_promax',
+      },
+      vigenteEnStripe: {
+        id: 'sub_promax',
+        status: 'active',
+        created: 3000,
+        items: { data: [{ id: 'si_2', price: { id: PROMAX_MXN } }] },
+      },
+    });
+
+    await service.handleCheckoutCompleted(session);
+
+    // El checkout trae PRO; quitarle PROMAX al cliente sería degradarlo por un
+    // evento viejo.
+    expect(updateUserSubscriptionState).not.toHaveBeenCalled();
+  });
+
+  it('adopta el checkout si el contrato anterior está terminado', async () => {
+    const { service, updateUserSubscriptionState } = buildService({
+      usuario: {
+        id: 'uid-1',
+        plan: 'pro',
+        stripeSubscriptionId: 'sub_viejo',
+      },
+      vigenteEnStripe: {
+        id: 'sub_viejo',
+        status: 'canceled',
+        created: 1000,
+        items: { data: [{ id: 'si_0', price: { id: PRO_MXN } }] },
+      },
+    });
+
+    await service.handleCheckoutCompleted(session);
+
+    expect(updateUserSubscriptionState).toHaveBeenCalledWith(
+      'uid-1',
+      expect.objectContaining({ plan: 'pro' }),
+      expect.any(Date),
+      'tok-1',
+    );
+  });
+
+  it('no adopta si no puede leer el contrato vigente para compararlo', async () => {
+    // Sin poder comparar no se toca algo que puede estar vivo.
+    const { service, updateUserSubscriptionState } = buildService({
+      usuario: {
+        id: 'uid-1',
+        plan: 'promax',
+        stripeSubscriptionId: 'sub_promax',
+      },
+      vigenteEnStripe: undefined,
+    });
+
+    await service.handleCheckoutCompleted(session);
+
+    expect(updateUserSubscriptionState).not.toHaveBeenCalled();
+  });
+
   it('la baja escribe el plan sellado, no con updateUser a secas', async () => {
     const { service, updateUserSubscriptionState, updateUser } = buildService();
 
@@ -1723,6 +1833,31 @@ describe('PaymentsService — alta y baja bajo el mutex', () => {
     expect(
       updateUser.mock.calls.filter(([, data]) => data && 'plan' in data),
     ).toHaveLength(0);
+  });
+
+  it('la baja notifica el plan leído dentro del lease, no el del snapshot', async () => {
+    // Si un `updated` pendiente escribió PROMAX entre la lectura inicial y el
+    // lease, la baja se aplica bien pero notificarla como PRO sería falso.
+    const { service } = buildService({
+      usuario: {
+        id: 'uid-1',
+        plan: 'promax',
+        stripeSubscriptionId: 'sub_123',
+      },
+    });
+    const email = service.emailService.queueSubscriptionDowngradedEmail;
+
+    await service.handleSubscriptionDeleted({
+      id: 'sub_123',
+      customer: 'cus_1',
+      items: { data: [{ price: { id: PRO_MXN } }] },
+    });
+
+    expect(email).toHaveBeenCalledWith(
+      expect.anything(),
+      'promax',
+      expect.anything(),
+    );
   });
 
   it('la baja no escribe si otro ciclo tiene el mutex', async () => {

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -1342,13 +1342,19 @@ export class PaymentsService {
         vigente.stripeSubscriptionId,
       );
     } catch (error) {
-      // Sin poder comparar no se toca un contrato que puede estar vivo.
+      // "No puedo decidir" NO es "decido que no": devolver `false` aquí daría
+      // 200, Stripe daría el evento por entregado y un cliente cuyo contrato SÍ
+      // debía adoptarse se quedaría sin el plan que pagó, para siempre. Se
+      // propaga para que Stripe reentregue; la contabilidad va después de este
+      // punto, así que tampoco se registra dos veces.
       this.logger.error(
-        `CRITICAL: no se pudo leer la suscripción vigente ` +
-          `${vigente.stripeSubscriptionId} de ${userId} para decidir el alta de ` +
-          `${delCheckout.id}. No se adopta. Detalle: ${(error as Error).message}`,
+        `No se pudo leer la suscripción vigente ${vigente.stripeSubscriptionId} ` +
+          `de ${userId} para decidir el alta de ${delCheckout.id}. Se pide ` +
+          `reentrega. Detalle: ${(error as Error).message}`,
       );
-      return false;
+      throw new ServiceUnavailableException(
+        'Could not compare subscriptions to resolve the checkout',
+      );
     }
 
     if (!PaymentsService.ESTADOS_VIVOS.includes(actual.status)) {
@@ -1367,15 +1373,28 @@ export class PaymentsService {
       ? this.getPlanFromPriceId(actual.items.data[0].price.id)
       : null;
 
-    const adopta = !planActual
-      ? false
-      : PLAN_ORDER[planDelCheckout] > PLAN_ORDER[planActual] ||
-        (PLAN_ORDER[planDelCheckout] === PLAN_ORDER[planActual] &&
-          (delCheckout.created ?? 0) > (actual.created ?? 0));
+    if (!planActual) {
+      // Mismo caso: no se sabe con qué se está comparando. Se pide reentrega en
+      // vez de decidir a ciegas — si el price ID que falta se configura dentro
+      // de la ventana de reintentos, el alta se aplica sola.
+      this.logger.error(
+        `CRITICAL: no se pudo resolver el plan de la suscripción vigente ` +
+          `${actual.id} de ${userId}. Se pide reentrega del checkout ` +
+          `${delCheckout.id}. Revisar STRIPE_*_PRICE_ID.`,
+      );
+      throw new ServiceUnavailableException(
+        'Could not resolve the current plan to compare subscriptions',
+      );
+    }
+
+    const adopta =
+      PLAN_ORDER[planDelCheckout] > PLAN_ORDER[planActual] ||
+      (PLAN_ORDER[planDelCheckout] === PLAN_ORDER[planActual] &&
+        (delCheckout.created ?? 0) > (actual.created ?? 0));
 
     this.logger.error(
       `CRITICAL: ${userId} tiene DOS suscripciones vivas — ${actual.id} ` +
-        `(${planActual ?? 'plan desconocido'}, ${actual.status}) y ${delCheckout.id} ` +
+        `(${planActual}, ${actual.status}) y ${delCheckout.id} ` +
         `(${planDelCheckout}, ${delCheckout.status}). Se ${adopta ? 'adopta' : 'mantiene'} ` +
         `el contrato ${adopta ? 'del checkout' : 'anterior'}. Revisar y cancelar la duplicada.`,
     );

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -28,7 +28,7 @@ import type {
   SubscriptionEvent,
 } from '../../common/interfaces/finance.interface.js';
 import { PLAN_ORDER } from '../../common/interfaces/user.interface.js';
-import type { PlanType } from '../../common/interfaces/user.interface.js';
+import type { PlanType, User } from '../../common/interfaces/user.interface.js';
 import { randomUUID } from 'node:crypto';
 
 type PaidPlanType = 'lite' | 'pro' | 'promax' | 'enterprise';
@@ -576,6 +576,16 @@ export class PaymentsService {
    * poder cambiar de plan durante un día por un intento que quedó a medias.
    */
   private static readonly UPGRADE_LEASE_MS = 7 * 60 * 1000;
+
+  /**
+   * Lease del ciclo relectura→escritura de la suscripción (issue #77).
+   *
+   * Mismo cálculo que el del upgrade: dentro hay una llamada a Stripe
+   * —`subscriptions.retrieve`— cuyo peor caso son 360 s con el SDK en sus
+   * valores por defecto, más las escrituras a Firestore. Siete minutos lo
+   * cubren, y el `finally` que lo libera hace que casi nunca llegue a caducar.
+   */
+  private static readonly SUBSCRIPTION_SYNC_LEASE_MS = 7 * 60 * 1000;
 
   /**
    * Clave de idempotencia del intento de upgrade, estable entre reintentos.
@@ -1226,6 +1236,56 @@ export class PaymentsService {
     }
   }
 
+  /**
+   * Serializa el ciclo relectura→escritura de un usuario y lo ejecuta.
+   *
+   * Sin esto, dos ciclos solapados pueden aterrizar en orden inverso al de los
+   * estados que observaron: el sello mide cuándo llegó la respuesta a Cloud Run,
+   * no cuándo Stripe observó el estado, y entre ambos instantes cabe una red
+   * lenta (issue #77). Con los ciclos serializados, la última lectura es siempre
+   * la más reciente.
+   *
+   * Si otro ciclo lo tiene tomado se lanza, y Stripe reentrega el webhook con su
+   * backoff. Esperar aquí sería peor: bloquearía el manejador hasta agotar el
+   * plazo de respuesta del webhook, y Stripe lo reintentaría igualmente.
+   */
+  private async withSubscriptionSyncLock<T>(
+    userId: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const token = await this.firestoreService.acquireSubscriptionSyncLock(
+      userId,
+      PaymentsService.SUBSCRIPTION_SYNC_LEASE_MS,
+    );
+
+    if (!token) {
+      this.logger.warn(
+        `Sincronización de suscripción de ${userId} ya en curso; se rechaza el ` +
+          `webhook para que Stripe lo reentregue.`,
+      );
+      throw new ConflictException(
+        'Subscription sync already in progress for this user',
+      );
+    }
+
+    try {
+      return await operation();
+    } finally {
+      // En `finally` a propósito: un ciclo que lanza a mitad —relectura fallida,
+      // Firestore caído— no debe dejar el lease tomado hasta que caduque.
+      try {
+        await this.firestoreService.releaseSubscriptionSyncLock(userId, token);
+      } catch (error) {
+        // El lease caduca solo; no vale la pena convertir esto en un fallo del
+        // webhook y provocar una reentrega de algo que ya se aplicó.
+        this.logger.warn(
+          `No se pudo liberar el lock de sincronización de ${userId}: ` +
+            `${(error as Error).message}`,
+        );
+      }
+    }
+  }
+
   async handleSubscriptionUpdated(
     subscription: Stripe.Subscription,
   ): Promise<void> {
@@ -1238,6 +1298,17 @@ export class PaymentsService {
       return;
     }
 
+    // El lock abarca la relectura Y la escritura: separarlos volvería a permitir
+    // que dos ciclos observen estados distintos y aterricen en orden inverso.
+    await this.withSubscriptionSyncLock(user.id, () =>
+      this.syncSubscriptionState(user, subscription),
+    );
+  }
+
+  private async syncSubscriptionState(
+    user: User,
+    subscription: Stripe.Subscription,
+  ): Promise<void> {
     // El snapshot del evento NO es fuente de verdad. Stripe no garantiza el
     // orden de entrega, y el upgrade con `pending_if_incomplete` emite dos
     // eventos: uno con el precio ANTERIOR cuando el cambio queda pendiente de

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -578,14 +578,22 @@ export class PaymentsService {
   private static readonly UPGRADE_LEASE_MS = 7 * 60 * 1000;
 
   /**
-   * Lease del ciclo relectura→escritura de la suscripción (issue #77).
+   * Lease del mutex de sincronización de la suscripción (issue #77).
    *
-   * Mismo cálculo que el del upgrade: dentro hay una llamada a Stripe
-   * —`subscriptions.retrieve`— cuyo peor caso son 360 s con el SDK en sus
-   * valores por defecto, más las escrituras a Firestore. Siete minutos lo
-   * cubren, y el `finally` que lo libera hace que casi nunca llegue a caducar.
+   * Lo dimensiona el ciclo más largo que protege, que es el del upgrade: dentro
+   * del lease hace DOS llamadas a Stripe —la relectura que revalida el estado
+   * vigente y el `subscriptions.update`—, a 360 s de peor caso cada una con el
+   * SDK en sus valores por defecto (3 × 80 s de timeout + 2 × 60 s de
+   * `Retry-After`). Son 720 s; trece minutos dejan un minuto de margen. El ciclo
+   * del webhook solo hace una y va sobrado.
+   *
+   * Que sea holgado importa poco en la práctica: el `finally` lo libera, así que
+   * solo llega a contar cuando el proceso muere con el lease tomado. Y quedarse
+   * corto ya no corrompe nada —el fencing token descarta la escritura del
+   * titular relevado—, pero sí obligaría al cliente a reintentar, así que más
+   * vale que sobre.
    */
-  private static readonly SUBSCRIPTION_SYNC_LEASE_MS = 7 * 60 * 1000;
+  private static readonly SUBSCRIPTION_SYNC_LEASE_MS = 13 * 60 * 1000;
 
   /**
    * Clave de idempotencia del intento de upgrade, estable entre reintentos.
@@ -759,12 +767,17 @@ export class PaymentsService {
 
     // El cambio sí se aplicó: sincronizamos Firestore para no dejar al cliente
     // pagando un plan que el producto no le reconoce.
-    await this.firestoreService.updateUserSubscriptionState(
+    const persisted = await this.firestoreService.updateUserSubscriptionState(
       userId,
       { plan: targetPlan },
       readAt,
       lockToken,
     );
+
+    if (!persisted) {
+      this.throwUnsyncedUpgradeError(targetPlan, context);
+    }
+
     this.logger.log(
       `Upgrade reconciliado tras error indeterminado: el cambio sí se aplicó — ${context}.`,
     );
@@ -773,6 +786,32 @@ export class PaymentsService {
       success: true,
       message: `Successfully upgraded to ${targetPlan.toUpperCase()}. Proration has been applied.`,
     };
+  }
+
+  /**
+   * El cambio se aplicó y se cobró en Stripe, pero la escritura del plan se
+   * descartó: este ciclo se demoró más que el lease y otro lo relevó.
+   *
+   * NO se puede responder éxito —el producto seguiría sin reconocer el plan que
+   * el cliente acaba de pagar— ni repetir la mutación, que ya está hecha. Se
+   * avisa de que el cobro pasó y que el plan tardará un momento: el webhook
+   * `customer.subscription.updated` llega detrás y sincroniza bajo su propio
+   * ciclo, que es el mecanismo de reparación natural.
+   */
+  private throwUnsyncedUpgradeError(
+    targetPlan: string,
+    context: string,
+  ): never {
+    this.logger.error(
+      `CRITICAL: el upgrade a ${targetPlan} se aplicó en Stripe pero la escritura ` +
+        `del plan se descartó por relevo del lease — ${context}. Firestore queda ` +
+        `pendiente de que lo sincronice el webhook.`,
+    );
+    throw new ServiceUnavailableException(
+      `Your payment for ${targetPlan.toUpperCase()} went through, but confirming it is ` +
+        `taking longer than usual. Your plan will be available shortly — please refresh ` +
+        `in a moment before trying again.`,
+    );
   }
 
   /**
@@ -913,11 +952,68 @@ export class PaymentsService {
           );
         }
 
+        // Firestore no basta: refleja lo que los webhooks han alcanzado a
+        // escribir, no lo que Stripe tiene AHORA. Si otro upgrade dejó un
+        // `pending_update` esperando pago, el plan en Firestore sigue igual
+        // —ese camino no lo toca— y sin releer de Stripe lanzaríamos un update
+        // que reemplaza ese pending update, anula su factura y emite otra,
+        // dejando al cliente con el enlace de pago que ya tenía apuntando a una
+        // factura muerta.
+        let vigente: Stripe.Subscription;
+        try {
+          vigente = await this.stripe.subscriptions.retrieve(
+            user.stripeSubscriptionId,
+            { expand: ['latest_invoice'] },
+          );
+        } catch (error) {
+          this.throwStripeApiError(
+            error,
+            'subscriptions.retrieve',
+            upgradeContext,
+          );
+        }
+
+        if (vigente.pending_update) {
+          this.throwPendingPaymentError(vigente, upgradeContext);
+        }
+
+        if (vigente.status !== 'active') {
+          this.logger.warn(
+            `Upgrade bloqueado: la suscripción pasó a '${vigente.status}' ` +
+              `mientras se preparaba — ${upgradeContext}`,
+          );
+          throw new BadRequestException(
+            this.inactiveSubscriptionMessage(vigente.status),
+          );
+        }
+
+        // El plan efectivo lo dicta el precio que Stripe tiene puesto, no el
+        // documento: es la comprobación que de verdad impide bajar de plan.
+        const vigenteItem = vigente.items.data[0];
+        const planVigente = vigenteItem?.price?.id
+          ? this.getPlanFromPriceId(vigenteItem.price.id)
+          : null;
+
+        if (planVigente && PLAN_ORDER[targetPlan] <= PLAN_ORDER[planVigente]) {
+          this.logger.warn(
+            `Upgrade abortado: Stripe ya tiene la suscripción en ${planVigente} ` +
+              `— ${upgradeContext}.`,
+          );
+          throw new BadRequestException(
+            `Cannot upgrade from ${planVigente.toUpperCase()} to ${targetPlan.toUpperCase()}.`,
+          );
+        }
+
+        if (!vigenteItem?.id) {
+          throw new BadRequestException('Could not find subscription item');
+        }
+
         return this.applyUpgrade({
           userId,
           user,
           targetPlan,
-          subscriptionItemId,
+          // El item vigente, no el del snapshot previo al sync fiscal.
+          subscriptionItemId: vigenteItem.id,
           newPriceId,
           upgradeContext,
           lockToken,
@@ -1053,15 +1149,23 @@ export class PaymentsService {
     // camino, y sin un reloj común una lectura suya anterior a este cambio
     // podría aterrizar después y revertir el plan recién pagado (issue #74).
     // Cualquier lectura previa a esta respuesta es, por definición, más vieja.
-    await this.firestoreService.updateUserSubscriptionState(
+    const persisted = await this.firestoreService.updateUserSubscriptionState(
       userId,
       { plan: targetPlan },
       confirmedAt,
       lockToken,
     );
+
     // La clave se libera aparte y comparando: borrarla en la misma escritura
-    // sería incondicional y podría pisar la de un intento posterior.
+    // sería incondicional y podría pisar la de un intento posterior. Va antes de
+    // comprobar el resultado porque el cobro ya pasó pase lo que pase: un
+    // reintento no debe repetir la mutación, y la revalidación de arriba lo
+    // abortaría de todas formas.
     await this.clearUpgradeIdempotencyKey(userId, idempotencyKey);
+
+    if (!persisted) {
+      this.throwUnsyncedUpgradeError(targetPlan, upgradeContext);
+    }
 
     this.logger.log(
       `User ${userId} upgraded from ${user.plan.toUpperCase()} to ${targetPlan.toUpperCase()}`,

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -816,14 +816,30 @@ export class PaymentsService {
 
     // El cambio sí se aplicó: sincronizamos Firestore para no dejar al cliente
     // pagando un plan que el producto no le reconoce.
-    const persisted = await this.firestoreService.updateUserSubscriptionState(
-      userId,
-      { plan: targetPlan },
-      readAt,
-      lockToken,
-    );
+    //
+    // Se captura el RECHAZO además del `false`: si Firestore cae aquí, el cobro
+    // ya está confirmado y dejar escapar la excepción daría un 500 genérico
+    // sobre un cargo real. Los dos desenlaces son el mismo para el cliente.
+    let persisted = false;
+    try {
+      persisted = await this.firestoreService.updateUserSubscriptionState(
+        userId,
+        { plan: targetPlan },
+        readAt,
+        lockToken,
+      );
+    } catch (persistError) {
+      this.logger.error(
+        `No se pudo escribir el plan reconciliado — ${context}. ` +
+          `Detalle: ${(persistError as Error).message}`,
+      );
+    }
 
     if (!persisted) {
+      // Desenlace definitivo con cobro hecho: la clave sale de circulación o
+      // seguiría marcando un intento vivo y bloquearía otros destinos durante
+      // todo el lease, pese a que este ya terminó.
+      await this.clearUpgradeIdempotencyKey(userId, idempotencyKey);
       this.throwUnsyncedUpgradeError(targetPlan, context);
     }
 
@@ -1224,12 +1240,23 @@ export class PaymentsService {
     // camino, y sin un reloj común una lectura suya anterior a este cambio
     // podría aterrizar después y revertir el plan recién pagado (issue #74).
     // Cualquier lectura previa a esta respuesta es, por definición, más vieja.
-    const persisted = await this.firestoreService.updateUserSubscriptionState(
-      userId,
-      { plan: targetPlan },
-      confirmedAt,
-      lockToken,
-    );
+    // El rechazo se trata igual que el `false`: llegados aquí Stripe ya cobró y
+    // confirmó, así que una caída de Firestore no puede convertirse en un 500
+    // genérico —el cliente leería "error" sobre un cargo que sí ocurrió—.
+    let persisted = false;
+    try {
+      persisted = await this.firestoreService.updateUserSubscriptionState(
+        userId,
+        { plan: targetPlan },
+        confirmedAt,
+        lockToken,
+      );
+    } catch (persistError) {
+      this.logger.error(
+        `No se pudo escribir el plan tras el cobro — ${upgradeContext}. ` +
+          `Detalle: ${(persistError as Error).message}`,
+      );
+    }
 
     // La clave se libera aparte y comparando: borrarla en la misma escritura
     // sería incondicional y podría pisar la de un intento posterior. Va antes de
@@ -1301,6 +1328,28 @@ export class PaymentsService {
     const plan = await this.withSubscriptionSyncLock(
       userId,
       async (lockToken) => {
+        // El usuario se relee dentro del lease: el leído fuera pudo esperar aquí
+        // mientras otro ciclo cambiaba el contrato, y el aviso de duplicado —y
+        // la decisión de adoptar esta suscripción— deben partir de datos
+        // vigentes, no de los de hace unos minutos.
+        const vigente =
+          (await this.firestoreService.getUserById(userId)) ?? user;
+
+        if (
+          vigente?.stripeSubscriptionId &&
+          vigente.stripeSubscriptionId !== subscriptionId
+        ) {
+          // Se adopta igualmente: un checkout completado es un alta real y esta
+          // es la suscripción por la que el cliente acaba de pagar. Lo que se
+          // corrige es que la traza salga de una lectura fresca.
+          this.logger.warn(
+            `DUPLICATE CHECKOUT (revalidado en el lease): el usuario ${userId} ` +
+              `tenía ${vigente.stripeSubscriptionId} y el checkout trae ` +
+              `${subscriptionId}. Se adopta la nueva; la anterior puede quedar ` +
+              `huérfana en Stripe.`,
+          );
+        }
+
         let resuelto: PaidPlanType | null = null;
         let periodStart: Date | undefined;
         let periodEnd: Date | undefined;
@@ -1608,10 +1657,30 @@ export class PaymentsService {
   }
 
   private async syncSubscriptionState(
-    user: User,
+    userPrevio: User,
     subscription: Stripe.Subscription,
     lockToken: string,
   ): Promise<void> {
+    // El mutex ordena las ejecuciones, pero no demuestra que el evento siga
+    // siendo del contrato vigente: uno retrasado de una suscripción anterior
+    // puede adquirir el lease cuando ya es otra la buena. El usuario se relee
+    // DENTRO del lease, porque el leído fuera pudo quedarse viejo esperándolo.
+    const user =
+      (await this.firestoreService.getUserById(userPrevio.id)) ?? userPrevio;
+
+    // Sin `stripeSubscriptionId` es un alta cuyo checkout aún no ha aterrizado:
+    // ahí no hay con qué comparar y descartar perdería la sincronización.
+    if (
+      user.stripeSubscriptionId &&
+      user.stripeSubscriptionId !== subscription.id
+    ) {
+      this.logger.warn(
+        `Ignorado subscription.updated de ${subscription.id}: el usuario ` +
+          `${user.id} tiene activa ${user.stripeSubscriptionId}.`,
+      );
+      return;
+    }
+
     // El snapshot del evento NO es fuente de verdad. Stripe no garantiza el
     // orden de entrega, y el upgrade con `pending_if_incomplete` emite dos
     // eventos: uno con el precio ANTERIOR cuando el cambio queda pendiente de
@@ -1759,6 +1828,9 @@ export class PaymentsService {
 
     // FIX: Only process if the deleted subscription matches the user's current subscription
     // This prevents orphan/duplicate subscription deletions from affecting the user's active plan
+    //
+    // Esta comprobación previa solo evita trabajo: la que decide es la de dentro
+    // del lease, porque entre esta lectura y el lock puede cambiar el contrato.
     if (
       user.stripeSubscriptionId &&
       user.stripeSubscriptionId !== subscription.id
@@ -1806,8 +1878,26 @@ export class PaymentsService {
     // competir, así que el sello se toma justo antes de escribir.
     const aplicado = await this.withSubscriptionSyncLock(
       user.id,
-      (lockToken) =>
-        this.withRetry(
+      async (lockToken) => {
+        // Revalidación dentro del lease: un `deleted` retrasado de un contrato
+        // anterior podría adquirirlo cuando ya hay otro vigente y dejar al
+        // cliente en Free habiendo pagado.
+        const fresh =
+          (await this.firestoreService.getUserById(user.id)) ?? user;
+
+        if (
+          fresh.stripeSubscriptionId &&
+          fresh.stripeSubscriptionId !== subscription.id
+        ) {
+          this.logger.warn(
+            `Ignorado subscription.deleted de ${subscription.id} dentro del ` +
+              `lease: el usuario ${user.id} ya tiene activa ` +
+              `${fresh.stripeSubscriptionId}.`,
+          );
+          return false;
+        }
+
+        return this.withRetry(
           () =>
             this.firestoreService.updateUserSubscriptionState(
               user.id,
@@ -1819,7 +1909,8 @@ export class PaymentsService {
               lockToken,
             ),
           `handleSubscriptionDeleted(${user.id})`,
-        ),
+        );
+      },
       'la baja de la suscripción',
     );
 

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -718,6 +718,7 @@ export class PaymentsService {
     expectedPriceId: string,
     context: string,
     lockToken: string,
+    idempotencyKey: string,
   ): Promise<{ success: boolean; message: string } | null> {
     const type = (error as { type?: string }).type;
     if (type !== 'StripeConnectionError' && type !== 'StripeAPIError') {
@@ -734,10 +735,25 @@ export class PaymentsService {
     // aquí evita dimensionarlo por las tres de golpe —una ventana que dejaría al
     // usuario bloqueado casi veinte minutos si el proceso muriera— y evita que
     // el fencing acabe descartando una escritura que sí es legítima.
-    const renovado = await this.firestoreService.renewSubscriptionSyncLock(
-      userId,
-      lockToken,
-    );
+    let renovado = false;
+    try {
+      renovado = await this.firestoreService.renewSubscriptionSyncLock(
+        userId,
+        lockToken,
+      );
+    } catch (renewError) {
+      // Escapar aquí daría un 500 genérico, y venimos de un update que PUEDE
+      // haber cobrado: el contrato de este camino es pedir que se revise la
+      // facturación antes de reintentar, no un error opaco.
+      this.logger.error(
+        `CRITICAL: no se pudo renovar el lease para reconciliar — ${context}. ` +
+          `Detalle: ${(renewError as Error).message}`,
+      );
+      throw new ServiceUnavailableException(
+        'We could not confirm whether your plan change went through. Please check your billing ' +
+          'settings before trying again, or contact support@zplpdf.com.',
+      );
+    }
 
     if (!renovado) {
       // Ya nos relevaron: la escritura se descartaría igualmente, y quien tenga
@@ -782,6 +798,11 @@ export class PaymentsService {
     // reemplaza el pending update existente y anula su factura, dejando al
     // cliente sin el enlace con el que ya podía pagar o autenticar.
     if (current.pending_update) {
+      // Definitivo, igual que en el camino principal: hay una factura esperando.
+      // Conservar la clave haría que un intento posterior —tras expirar el
+      // pending, dentro de las 24 h de TTL— recibiera de Stripe la respuesta
+      // cacheada del primero, que ofrece una factura ya anulada.
+      await this.clearUpgradeIdempotencyKey(userId, idempotencyKey);
       this.throwPendingPaymentError(current, context);
     }
 
@@ -1143,6 +1164,7 @@ export class PaymentsService {
         newPriceId,
         upgradeContext,
         lockToken,
+        idempotencyKey,
       );
       if (reconciled) {
         // La reconciliación es un desenlace definitivo: se sabe que el cambio
@@ -1272,34 +1294,87 @@ export class PaymentsService {
       | 'mxn';
     const amount = session.amount_total || 0;
 
-    // Get plan and period from subscription
-    let plan: PaidPlanType | null = null;
-    let subscriptionPeriodStart: Date | undefined;
-    let subscriptionPeriodEnd: Date | undefined;
-    try {
-      const subscription =
-        await this.stripe.subscriptions.retrieve(subscriptionId);
-      const priceId = subscription.items.data[0]?.price?.id;
-      if (priceId) {
-        plan = this.getPlanFromPriceId(priceId);
-      }
-      const period = this.resolveBillingPeriod(subscription);
-      subscriptionPeriodStart = period.start;
-      subscriptionPeriodEnd = period.end;
-    } catch (error) {
-      this.logger.warn(`Failed to get subscription details: ${error.message}`);
-    }
+    // El alta cierra el mismo ciclo observar→escribir que el upgrade y el
+    // webhook de `updated`: relee la suscripción en Stripe y escribe el plan.
+    // Fuera del mutex, un checkout retrasado podía leer PRO, dejar que el
+    // upgrade escribiera PROMAX y luego restaurar PRO (issue #77).
+    const plan = await this.withSubscriptionSyncLock(
+      userId,
+      async (lockToken) => {
+        let resuelto: PaidPlanType | null = null;
+        let periodStart: Date | undefined;
+        let periodEnd: Date | undefined;
+        // Si la relectura falla no se escribe nada, así que este valor solo se
+        // usa cuando hay estado observado detrás.
+        let readAt = new Date();
 
-    // Si no se pudo resolver el plan desde el price ID, NO asignar uno por defecto:
-    // hacerlo regalaría un plan (potencialmente superior) por mala configuración.
-    // Abortamos y registramos error crítico; Stripe reintentará el webhook.
-    if (!plan) {
-      this.logger.error(
-        `CRITICAL: No se pudo determinar el plan para checkout de user ${userId} ` +
-          `(session ${session.id}, sub ${subscriptionId}). Plan NO asignado. Revisar STRIPE_*_PRICE_ID.`,
-      );
-      throw new Error(`Cannot resolve plan for checkout session ${session.id}`);
-    }
+        try {
+          const subscription =
+            await this.stripe.subscriptions.retrieve(subscriptionId);
+          readAt = new Date();
+          const priceId = subscription.items.data[0]?.price?.id;
+          if (priceId) {
+            resuelto = this.getPlanFromPriceId(priceId);
+          }
+          const period = this.resolveBillingPeriod(subscription);
+          periodStart = period.start;
+          periodEnd = period.end;
+        } catch (error) {
+          this.logger.warn(
+            `Failed to get subscription details: ${error.message}`,
+          );
+        }
+
+        // Si no se pudo resolver el plan desde el price ID, NO asignar uno por
+        // defecto: hacerlo regalaría un plan (potencialmente superior) por mala
+        // configuración. Abortamos y registramos error crítico; Stripe
+        // reintentará el webhook.
+        if (!resuelto) {
+          this.logger.error(
+            `CRITICAL: No se pudo determinar el plan para checkout de user ${userId} ` +
+              `(session ${session.id}, sub ${subscriptionId}). Plan NO asignado. Revisar STRIPE_*_PRICE_ID.`,
+          );
+          throw new Error(
+            `Cannot resolve plan for checkout session ${session.id}`,
+          );
+        }
+
+        // IMPORTANT: Only include period fields if they have values - Firestore rejects undefined
+        const subscriptionData: Record<string, unknown> = {
+          plan: resuelto,
+          stripeSubscriptionId: subscriptionId,
+        };
+        if (periodStart) {
+          subscriptionData.subscriptionPeriodStart = periodStart;
+        }
+        if (periodEnd) {
+          subscriptionData.subscriptionPeriodEnd = periodEnd;
+        }
+
+        const applied = await this.withRetry(
+          () =>
+            this.firestoreService.updateUserSubscriptionState(
+              userId,
+              subscriptionData,
+              readAt,
+              lockToken,
+            ),
+          `handleCheckoutCompleted(${userId})`,
+        );
+
+        if (!applied) {
+          // El documento ya refleja algo más fresco. No es un fallo: el alta se
+          // dio por buena en Stripe y el estado vigente es el que hay.
+          this.logger.warn(
+            `Alta de ${userId} no escrita: el documento ya refleja una lectura ` +
+              `posterior o el lease cambió de manos.`,
+          );
+        }
+
+        return resuelto;
+      },
+      'el alta de la suscripción',
+    );
 
     // Calculate MXN amount for transactions
     let amountMxn = amount / 100;
@@ -1319,34 +1394,24 @@ export class PaymentsService {
       }
     }
 
-    // Update user plan with retry
-    // IMPORTANT: Only include period fields if they have values - Firestore rejects undefined
-    const updateData: Record<string, unknown> = {
-      plan,
-      stripeSubscriptionId: subscriptionId,
-    };
-    if (subscriptionPeriodStart) {
-      updateData.subscriptionPeriodStart = subscriptionPeriodStart;
-    }
-    if (subscriptionPeriodEnd) {
-      updateData.subscriptionPeriodEnd = subscriptionPeriodEnd;
-    }
-
-    // Update country/city from billing address if available and not already set by Stripe
+    // La geo va aparte del estado de suscripción y fuera del mutex: no compite
+    // por el plan, así que no debe descartarse junto con él si llega un sello
+    // más fresco.
     if (billingCountry && (!user?.country || user.countrySource === 'ip')) {
-      updateData.country = billingCountry;
-      updateData.city = billingCity;
-      updateData.countrySource = 'stripe';
-      updateData.countryDetectedAt = new Date();
+      await this.withRetry(
+        () =>
+          this.firestoreService.updateUser(userId, {
+            country: billingCountry,
+            city: billingCity,
+            countrySource: 'stripe',
+            countryDetectedAt: new Date(),
+          } as Partial<User>),
+        `handleCheckoutCompleted(geo ${userId})`,
+      );
       this.logger.log(
         `Updated user ${userId} geo to ${billingCountry}/${billingCity || 'unknown'} from Stripe billing`,
       );
     }
-
-    await this.withRetry(
-      () => this.firestoreService.updateUser(userId, updateData),
-      `handleCheckoutCompleted(${userId})`,
-    );
 
     this.logger.log(`User ${userId} upgraded to ${plan} plan`);
 
@@ -1734,15 +1799,37 @@ export class PaymentsService {
         ? user.plan
         : 'pro';
 
-    // Downgrade to free plan with retry
-    await this.withRetry(
-      () =>
-        this.firestoreService.updateUser(user.id, {
-          plan: 'free',
-          stripeSubscriptionId: null,
-        }),
-      `handleSubscriptionDeleted(${user.id})`,
+    // La baja también escribe el plan, así que entra en el mutex y por la
+    // escritura sellada: con `updateUser` a secas podía pisar un upgrade recién
+    // confirmado sin que nada lo comparase (issue #77). No relee Stripe —el
+    // evento ya es terminal—, y dentro del mutex no hay otro ciclo con el que
+    // competir, así que el sello se toma justo antes de escribir.
+    const aplicado = await this.withSubscriptionSyncLock(
+      user.id,
+      (lockToken) =>
+        this.withRetry(
+          () =>
+            this.firestoreService.updateUserSubscriptionState(
+              user.id,
+              {
+                plan: 'free',
+                stripeSubscriptionId: null,
+              },
+              new Date(),
+              lockToken,
+            ),
+          `handleSubscriptionDeleted(${user.id})`,
+        ),
+      'la baja de la suscripción',
     );
+
+    if (!aplicado) {
+      this.logger.warn(
+        `Baja de ${user.id} no escrita: el documento ya refleja una lectura ` +
+          `posterior o el lease cambió de manos.`,
+      );
+      return;
+    }
 
     this.logger.log(
       `User ${user.id} downgraded to Free plan (was ${canceledPlan})`,

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -821,6 +821,7 @@ export class PaymentsService {
     // ya está confirmado y dejar escapar la excepción daría un 500 genérico
     // sobre un cargo real. Los dos desenlaces son el mismo para el cliente.
     let persisted = false;
+    let falloAlEscribir = false;
     try {
       persisted = await this.firestoreService.updateUserSubscriptionState(
         userId,
@@ -829,6 +830,7 @@ export class PaymentsService {
         lockToken,
       );
     } catch (persistError) {
+      falloAlEscribir = true;
       this.logger.error(
         `No se pudo escribir el plan reconciliado — ${context}. ` +
           `Detalle: ${(persistError as Error).message}`,
@@ -840,7 +842,11 @@ export class PaymentsService {
       // seguiría marcando un intento vivo y bloquearía otros destinos durante
       // todo el lease, pese a que este ya terminó.
       await this.clearUpgradeIdempotencyKey(userId, idempotencyKey);
-      this.throwUnsyncedUpgradeError(targetPlan, context);
+      this.throwUnsyncedUpgradeError(
+        targetPlan,
+        context,
+        falloAlEscribir ? 'fallo al escribir en Firestore' : 'relevo del lease',
+      );
     }
 
     this.logger.log(
@@ -866,10 +872,15 @@ export class PaymentsService {
   private throwUnsyncedUpgradeError(
     targetPlan: string,
     context: string,
+    causa: 'relevo del lease' | 'fallo al escribir en Firestore',
   ): never {
+    // La causa se pasa en lugar de asumirse: a este punto se llega tanto por
+    // fencing como por una caída de Firestore, y dar por buena una de las dos
+    // en el log dejaría a quien atienda el incidente —uno con dinero de por
+    // medio— persiguiendo un relevo que quizá no ocurrió.
     this.logger.error(
       `CRITICAL: el upgrade a ${targetPlan} se aplicó en Stripe pero la escritura ` +
-        `del plan se descartó por relevo del lease — ${context}. Firestore queda ` +
+        `del plan no se confirmó (${causa}) — ${context}. Firestore queda ` +
         `pendiente de que lo sincronice el webhook.`,
     );
     // Con código propio y `paymentProcessed`, porque el status HTTP no
@@ -1244,6 +1255,7 @@ export class PaymentsService {
     // confirmó, así que una caída de Firestore no puede convertirse en un 500
     // genérico —el cliente leería "error" sobre un cargo que sí ocurrió—.
     let persisted = false;
+    let falloAlEscribir = false;
     try {
       persisted = await this.firestoreService.updateUserSubscriptionState(
         userId,
@@ -1252,6 +1264,7 @@ export class PaymentsService {
         lockToken,
       );
     } catch (persistError) {
+      falloAlEscribir = true;
       this.logger.error(
         `No se pudo escribir el plan tras el cobro — ${upgradeContext}. ` +
           `Detalle: ${(persistError as Error).message}`,
@@ -1266,7 +1279,11 @@ export class PaymentsService {
     await this.clearUpgradeIdempotencyKey(userId, idempotencyKey);
 
     if (!persisted) {
-      this.throwUnsyncedUpgradeError(targetPlan, upgradeContext);
+      this.throwUnsyncedUpgradeError(
+        targetPlan,
+        upgradeContext,
+        falloAlEscribir ? 'fallo al escribir en Firestore' : 'relevo del lease',
+      );
     }
 
     this.logger.log(
@@ -1277,6 +1294,93 @@ export class PaymentsService {
       success: true,
       message: `Successfully upgraded to ${targetPlan.toUpperCase()}. Proration has been applied.`,
     };
+  }
+
+  /** Estados en los que una suscripción sigue dando derecho al plan. */
+  private static readonly ESTADOS_VIVOS = ['active', 'trialing', 'past_due'];
+
+  /**
+   * Decide si el alta del checkout debe fijar el plan del usuario.
+   *
+   * `checkout.session.completed` acredita un alta que OCURRIÓ, no que sea el
+   * contrato vigente: Stripe lo reentrega ante fallos y no garantiza el orden,
+   * así que puede llegar días tarde y describir una suscripción ya cancelada, o
+   * una duplicada inferior a la que el cliente tiene viva. Adoptarlo a ciegas
+   * degradaría un plan superior y en curso.
+   *
+   * El pago se contabiliza igual: lo que se separa aquí es el entitlement.
+   */
+  private async puedeAdoptarseElCheckout(
+    userId: string,
+    vigente: User | null,
+    delCheckout: Stripe.Subscription | null,
+    planDelCheckout: PaidPlanType,
+  ): Promise<boolean> {
+    if (!delCheckout) {
+      return false;
+    }
+
+    if (!PaymentsService.ESTADOS_VIVOS.includes(delCheckout.status)) {
+      this.logger.warn(
+        `Checkout de ${userId} no adoptado: la suscripción ${delCheckout.id} ya ` +
+          `está en '${delCheckout.status}'. Se registra el pago, no el plan.`,
+      );
+      return false;
+    }
+
+    // Sin contrato previo, o el mismo: adopción directa.
+    if (
+      !vigente?.stripeSubscriptionId ||
+      vigente.stripeSubscriptionId === delCheckout.id
+    ) {
+      return true;
+    }
+
+    let actual: Stripe.Subscription;
+    try {
+      actual = await this.stripe.subscriptions.retrieve(
+        vigente.stripeSubscriptionId,
+      );
+    } catch (error) {
+      // Sin poder comparar no se toca un contrato que puede estar vivo.
+      this.logger.error(
+        `CRITICAL: no se pudo leer la suscripción vigente ` +
+          `${vigente.stripeSubscriptionId} de ${userId} para decidir el alta de ` +
+          `${delCheckout.id}. No se adopta. Detalle: ${(error as Error).message}`,
+      );
+      return false;
+    }
+
+    if (!PaymentsService.ESTADOS_VIVOS.includes(actual.status)) {
+      this.logger.log(
+        `Checkout de ${userId} adoptado: la anterior ${actual.id} está en ` +
+          `'${actual.status}'.`,
+      );
+      return true;
+    }
+
+    // Dos contratos vivos a la vez: el cliente está pagando dos veces y hace
+    // falta intervención humana. Mientras tanto se le deja el plan más alto —no
+    // se le quita algo que está pagando— y a igualdad gana el más reciente, que
+    // es el que acaba de contratar.
+    const planActual = actual.items.data[0]?.price?.id
+      ? this.getPlanFromPriceId(actual.items.data[0].price.id)
+      : null;
+
+    const adopta = !planActual
+      ? false
+      : PLAN_ORDER[planDelCheckout] > PLAN_ORDER[planActual] ||
+        (PLAN_ORDER[planDelCheckout] === PLAN_ORDER[planActual] &&
+          (delCheckout.created ?? 0) > (actual.created ?? 0));
+
+    this.logger.error(
+      `CRITICAL: ${userId} tiene DOS suscripciones vivas — ${actual.id} ` +
+        `(${planActual ?? 'plan desconocido'}, ${actual.status}) y ${delCheckout.id} ` +
+        `(${planDelCheckout}, ${delCheckout.status}). Se ${adopta ? 'adopta' : 'mantiene'} ` +
+        `el contrato ${adopta ? 'del checkout' : 'anterior'}. Revisar y cancelar la duplicada.`,
+    );
+
+    return adopta;
   }
 
   async handleCheckoutCompleted(
@@ -1302,17 +1406,6 @@ export class PaymentsService {
     const subscriptionId = session.subscription as string;
     const user = await this.firestoreService.getUserById(userId);
 
-    // Log if user already has a different subscription (indicates duplicate checkout)
-    if (
-      user?.stripeSubscriptionId &&
-      user.stripeSubscriptionId !== subscriptionId
-    ) {
-      this.logger.warn(
-        `DUPLICATE CHECKOUT DETECTED: User ${userId} already has subscription ${user.stripeSubscriptionId}. ` +
-          `New subscription from checkout: ${subscriptionId}. ` +
-          `User plan: ${user.plan}. Previous subscription may be orphaned in Stripe.`,
-      );
-    }
     const billingCountry =
       session.customer_details?.address?.country || undefined;
     const billingCity = session.customer_details?.address?.city || undefined;
@@ -1325,7 +1418,7 @@ export class PaymentsService {
     // webhook de `updated`: relee la suscripción en Stripe y escribe el plan.
     // Fuera del mutex, un checkout retrasado podía leer PRO, dejar que el
     // upgrade escribiera PROMAX y luego restaurar PRO (issue #77).
-    const plan = await this.withSubscriptionSyncLock(
+    const alta = await this.withSubscriptionSyncLock(
       userId,
       async (lockToken) => {
         // El usuario se relee dentro del lease: el leído fuera pudo esperar aquí
@@ -1335,37 +1428,23 @@ export class PaymentsService {
         const vigente =
           (await this.firestoreService.getUserById(userId)) ?? user;
 
-        if (
-          vigente?.stripeSubscriptionId &&
-          vigente.stripeSubscriptionId !== subscriptionId
-        ) {
-          // Se adopta igualmente: un checkout completado es un alta real y esta
-          // es la suscripción por la que el cliente acaba de pagar. Lo que se
-          // corrige es que la traza salga de una lectura fresca.
-          this.logger.warn(
-            `DUPLICATE CHECKOUT (revalidado en el lease): el usuario ${userId} ` +
-              `tenía ${vigente.stripeSubscriptionId} y el checkout trae ` +
-              `${subscriptionId}. Se adopta la nueva; la anterior puede quedar ` +
-              `huérfana en Stripe.`,
-          );
-        }
-
         let resuelto: PaidPlanType | null = null;
         let periodStart: Date | undefined;
         let periodEnd: Date | undefined;
+        let delCheckout: Stripe.Subscription | null = null;
         // Si la relectura falla no se escribe nada, así que este valor solo se
         // usa cuando hay estado observado detrás.
         let readAt = new Date();
 
         try {
-          const subscription =
+          delCheckout =
             await this.stripe.subscriptions.retrieve(subscriptionId);
           readAt = new Date();
-          const priceId = subscription.items.data[0]?.price?.id;
+          const priceId = delCheckout.items.data[0]?.price?.id;
           if (priceId) {
             resuelto = this.getPlanFromPriceId(priceId);
           }
-          const period = this.resolveBillingPeriod(subscription);
+          const period = this.resolveBillingPeriod(delCheckout);
           periodStart = period.start;
           periodEnd = period.end;
         } catch (error) {
@@ -1386,6 +1465,22 @@ export class PaymentsService {
           throw new Error(
             `Cannot resolve plan for checkout session ${session.id}`,
           );
+        }
+
+        // El evento acredita un alta HISTÓRICA, no que sea el contrato vigente:
+        // Stripe puede reentregarlo días después y fuera de orden, y para
+        // entonces esa suscripción puede estar cancelada o ser una duplicada
+        // inferior a la que el cliente tiene viva. La contabilidad del pago va
+        // aparte y se registra igual; lo que se decide aquí es el entitlement.
+        const adoptable = await this.puedeAdoptarseElCheckout(
+          userId,
+          vigente,
+          delCheckout,
+          resuelto,
+        );
+
+        if (!adoptable) {
+          return { plan: resuelto, adoptado: false };
         }
 
         // IMPORTANT: Only include period fields if they have values - Firestore rejects undefined
@@ -1420,10 +1515,11 @@ export class PaymentsService {
           );
         }
 
-        return resuelto;
+        return { plan: resuelto, adoptado: true };
       },
       'el alta de la suscripción',
     );
+    const plan = alta.plan;
 
     // Calculate MXN amount for transactions
     let amountMxn = amount / 100;
@@ -1462,7 +1558,12 @@ export class PaymentsService {
       );
     }
 
-    this.logger.log(`User ${userId} upgraded to ${plan} plan`);
+    this.logger.log(
+      alta.adoptado
+        ? `User ${userId} upgraded to ${plan} plan`
+        : `Checkout de ${userId} contabilizado como ${plan} SIN fijar el plan: ` +
+            `el contrato del evento no es el vigente.`,
+    );
 
     // Segunda pasada, para las facturas siguientes. La primera ya se propagó
     // antes de abrir el checkout —Stripe congela los datos fiscales al finalizar
@@ -1865,18 +1966,12 @@ export class PaymentsService {
       return;
     }
 
-    // Get the plan that was canceled (from user's current plan before downgrade)
-    const canceledPlan =
-      user.plan === 'lite' || user.plan === 'pro' || user.plan === 'promax'
-        ? user.plan
-        : 'pro';
-
     // La baja también escribe el plan, así que entra en el mutex y por la
     // escritura sellada: con `updateUser` a secas podía pisar un upgrade recién
     // confirmado sin que nada lo comparase (issue #77). No relee Stripe —el
     // evento ya es terminal—, y dentro del mutex no hay otro ciclo con el que
     // competir, así que el sello se toma justo antes de escribir.
-    const aplicado = await this.withSubscriptionSyncLock(
+    const resultado = await this.withSubscriptionSyncLock(
       user.id,
       async (lockToken) => {
         // Revalidación dentro del lease: un `deleted` retrasado de un contrato
@@ -1894,10 +1989,21 @@ export class PaymentsService {
               `lease: el usuario ${user.id} ya tiene activa ` +
               `${fresh.stripeSubscriptionId}.`,
           );
-          return false;
+          return { aplicado: false as const };
         }
 
-        return this.withRetry(
+        // El plan cancelado sale de la lectura de DENTRO del lease: si un
+        // `subscription.updated` pendiente escribió PROMAX entre la lectura
+        // inicial y esta, la baja se aplicaría bien pero se registraría y se
+        // notificaría como PRO.
+        const canceladoAhora =
+          fresh.plan === 'lite' ||
+          fresh.plan === 'pro' ||
+          fresh.plan === 'promax'
+            ? fresh.plan
+            : 'pro';
+
+        const escrito = await this.withRetry(
           () =>
             this.firestoreService.updateUserSubscriptionState(
               user.id,
@@ -1910,11 +2016,15 @@ export class PaymentsService {
             ),
           `handleSubscriptionDeleted(${user.id})`,
         );
+
+        return { aplicado: escrito, canceledPlan: canceladoAhora };
       },
       'la baja de la suscripción',
     );
 
-    if (!aplicado) {
+    const canceledPlan = resultado.canceledPlan ?? 'pro';
+
+    if (!resultado.aplicado) {
       this.logger.warn(
         `Baja de ${user.id} no escrita: el documento ya refleja una lectura ` +
           `posterior o el lease cambió de manos.`,

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -704,6 +704,7 @@ export class PaymentsService {
     subscriptionId: string,
     expectedPriceId: string,
     context: string,
+    lockToken: string,
   ): Promise<{ success: boolean; message: string } | null> {
     const type = (error as { type?: string }).type;
     if (type !== 'StripeConnectionError' && type !== 'StripeAPIError') {
@@ -762,6 +763,7 @@ export class PaymentsService {
       userId,
       { plan: targetPlan },
       readAt,
+      lockToken,
     );
     this.logger.log(
       `Upgrade reconciliado tras error indeterminado: el cambio sí se aplicó — ${context}.`,
@@ -868,13 +870,86 @@ export class PaymentsService {
       );
     }
 
-    // La clave se toma DESPUÉS de la sincronización fiscal y justo antes de la
-    // única llamada que mueve dinero. Tomarla al principio metía dentro del
-    // candado las tres llamadas del perfil fiscal, y el peor caso pasaba a ser
-    // cuatro veces el de una sola —el SDK reintenta hasta 3 veces con 80 s de
-    // timeout—, imposible de cubrir con un lease razonable. El sync no cobra
-    // nada y es idempotente, así que dejarlo fuera no arriesga un doble cargo;
-    // además, así un fallo suyo ya no retiene una clave que nadie liberará.
+    // El upgrade entra en el MISMO mutex que el webhook: los dos observan el
+    // estado en Stripe y escriben el plan, así que serializar solo los webhooks
+    // dejaba abierta la carrera cruzada. Un webhook podía leer PRO, quedarse su
+    // respuesta en tránsito mientras el upgrade confirmaba PROMAX, y al llegar
+    // sellar más fresco y revertirlo.
+    //
+    // Va después de la sincronización fiscal por lo mismo que la clave: el sync
+    // suma tres llamadas a Stripe y meterlas dentro haría el peor caso cuatro
+    // veces mayor, imposible de cubrir con un lease razonable.
+    return this.withSubscriptionSyncLock(
+      userId,
+      async (lockToken) => {
+        // Revalidación DENTRO del lease. El plan se validó antes del sync
+        // fiscal, y en ese hueco otro cambio pudo completarse: sin releer, un
+        // lite→pro demorado entraría después de un lite→promax ya aplicado y
+        // BAJARÍA la suscripción, violando la garantía de upgrade estricto.
+        const fresh = await this.firestoreService.getUserById(userId);
+
+        if (!fresh) {
+          throw new BadRequestException('User not found');
+        }
+
+        if (fresh.stripeSubscriptionId !== user.stripeSubscriptionId) {
+          this.logger.warn(
+            `Upgrade abortado: la suscripción cambió mientras se preparaba — ` +
+              `${upgradeContext}.`,
+          );
+          throw new ConflictException(
+            'Your subscription changed while this request was being prepared. ' +
+              'Please review your plan and try again.',
+          );
+        }
+
+        if (PLAN_ORDER[targetPlan] <= PLAN_ORDER[fresh.plan]) {
+          this.logger.warn(
+            `Upgrade abortado: el plan pasó a ${fresh.plan} mientras se ` +
+              `preparaba — ${upgradeContext}.`,
+          );
+          throw new BadRequestException(
+            `Cannot upgrade from ${fresh.plan.toUpperCase()} to ${targetPlan.toUpperCase()}.`,
+          );
+        }
+
+        return this.applyUpgrade({
+          userId,
+          user,
+          targetPlan,
+          subscriptionItemId,
+          newPriceId,
+          upgradeContext,
+          lockToken,
+        });
+      },
+      'el cambio de plan',
+    );
+  }
+
+  /**
+   * Ejecuta la mutación en Stripe y la escritura del plan. Se llama SIEMPRE
+   * dentro del mutex de sincronización, con el plan ya revalidado.
+   */
+  private async applyUpgrade({
+    userId,
+    user,
+    targetPlan,
+    subscriptionItemId,
+    newPriceId,
+    upgradeContext,
+    lockToken,
+  }: {
+    userId: string;
+    user: User;
+    targetPlan: 'pro' | 'promax';
+    subscriptionItemId: string;
+    newPriceId: string;
+    upgradeContext: string;
+    lockToken: string;
+  }): Promise<{ success: boolean; message: string }> {
+    // La clave se toma justo antes de la única llamada que mueve dinero: así un
+    // fallo previo no retiene una clave que nadie liberará.
     const idempotencyKey = await this.getUpgradeIdempotencyKey(
       userId,
       targetPlan,
@@ -918,6 +993,7 @@ export class PaymentsService {
         user.stripeSubscriptionId,
         newPriceId,
         upgradeContext,
+        lockToken,
       );
       if (reconciled) {
         // La reconciliación es un desenlace definitivo: se sabe que el cambio
@@ -981,6 +1057,7 @@ export class PaymentsService {
       userId,
       { plan: targetPlan },
       confirmedAt,
+      lockToken,
     );
     // La clave se libera aparte y comparando: borrarla en la misma escritura
     // sería incondicional y podría pisar la de un intento posterior.
@@ -1251,7 +1328,8 @@ export class PaymentsService {
    */
   private async withSubscriptionSyncLock<T>(
     userId: string,
-    operation: () => Promise<T>,
+    operation: (lockToken: string) => Promise<T>,
+    contexto = 'webhook',
   ): Promise<T> {
     const token = await this.firestoreService.acquireSubscriptionSyncLock(
       userId,
@@ -1260,16 +1338,18 @@ export class PaymentsService {
 
     if (!token) {
       this.logger.warn(
-        `Sincronización de suscripción de ${userId} ya en curso; se rechaza el ` +
-          `webhook para que Stripe lo reentregue.`,
+        `Sincronización de suscripción de ${userId} ya en curso; se rechaza ` +
+          `${contexto}.`,
       );
       throw new ConflictException(
-        'Subscription sync already in progress for this user',
+        'Another change to this subscription is already in progress. Please try again in a moment.',
       );
     }
 
     try {
-      return await operation();
+      // El token viaja hasta la escritura: si este ciclo se demora más que el
+      // lease y otro lo releva, la transacción de escritura lo descarta.
+      return await operation(token);
     } finally {
       // En `finally` a propósito: un ciclo que lanza a mitad —relectura fallida,
       // Firestore caído— no debe dejar el lease tomado hasta que caduque.
@@ -1300,14 +1380,15 @@ export class PaymentsService {
 
     // El lock abarca la relectura Y la escritura: separarlos volvería a permitir
     // que dos ciclos observen estados distintos y aterricen en orden inverso.
-    await this.withSubscriptionSyncLock(user.id, () =>
-      this.syncSubscriptionState(user, subscription),
+    await this.withSubscriptionSyncLock(user.id, (lockToken) =>
+      this.syncSubscriptionState(user, subscription, lockToken),
     );
   }
 
   private async syncSubscriptionState(
     user: User,
     subscription: Stripe.Subscription,
+    lockToken: string,
   ): Promise<void> {
     // El snapshot del evento NO es fuente de verdad. Stripe no garantiza el
     // orden de entrega, y el upgrade con `pending_if_incomplete` emite dos
@@ -1363,6 +1444,7 @@ export class PaymentsService {
             user.id,
             activeUpdateData,
             readAt,
+            lockToken,
           ),
         `handleSubscriptionUpdated(${user.id})`,
       );
@@ -1384,6 +1466,7 @@ export class PaymentsService {
               stripeSubscriptionId: null,
             },
             readAt,
+            lockToken,
           ),
         `handleSubscriptionUpdated(${user.id})`,
       );
@@ -1430,6 +1513,7 @@ export class PaymentsService {
               stripeSubscriptionId: current.id,
             },
             readAt,
+            lockToken,
           ),
         `handleSubscriptionUpdated(${user.id})`,
       );

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -27,6 +27,7 @@ import type {
   StripeTransaction,
   SubscriptionEvent,
 } from '../../common/interfaces/finance.interface.js';
+import { ErrorCodes } from '../../common/constants/error-codes.js';
 import { PLAN_ORDER } from '../../common/interfaces/user.interface.js';
 import type { PlanType, User } from '../../common/interfaces/user.interface.js';
 import { randomUUID } from 'node:crypto';
@@ -580,12 +581,16 @@ export class PaymentsService {
   /**
    * Lease del mutex de sincronización de la suscripción (issue #77).
    *
-   * Lo dimensiona el ciclo más largo que protege, que es el del upgrade: dentro
-   * del lease hace DOS llamadas a Stripe —la relectura que revalida el estado
-   * vigente y el `subscriptions.update`—, a 360 s de peor caso cada una con el
-   * SDK en sus valores por defecto (3 × 80 s de timeout + 2 × 60 s de
-   * `Retry-After`). Son 720 s; trece minutos dejan un minuto de margen. El ciclo
-   * del webhook solo hace una y va sobrado.
+   * Lo dimensiona el tramo más largo ENTRE RENOVACIONES, no el ciclo completo.
+   * El más largo es el del upgrade: la relectura que revalida el estado vigente
+   * y el `subscriptions.update`, a 360 s de peor caso cada una con el SDK en sus
+   * valores por defecto (3 × 80 s de timeout + 2 × 60 s de `Retry-After`). Son
+   * 720 s; trece minutos dejan un minuto de margen.
+   *
+   * La reconciliación añade una tercera llamada, pero renueva el lease antes de
+   * hacerla: cubrir las tres de golpe exigiría casi veinte minutos, y esa sería
+   * la ventana durante la que un proceso muerto bloquearía al usuario. El ciclo
+   * del webhook hace una sola llamada y va sobrado.
    *
    * Que sea holgado importa poco en la práctica: el `finally` lo libera, así que
    * solo llega a contar cuando el proceso muere con el lease tomado. Y quedarse
@@ -724,6 +729,29 @@ export class PaymentsService {
         `para saber si el cambio llegó a aplicarse.`,
     );
 
+    // Este camino añade una tercera llamada a Stripe dentro del mismo ciclo, y
+    // las dos anteriores ya pueden haber consumido casi todo el lease. Renovarlo
+    // aquí evita dimensionarlo por las tres de golpe —una ventana que dejaría al
+    // usuario bloqueado casi veinte minutos si el proceso muriera— y evita que
+    // el fencing acabe descartando una escritura que sí es legítima.
+    const renovado = await this.firestoreService.renewSubscriptionSyncLock(
+      userId,
+      lockToken,
+    );
+
+    if (!renovado) {
+      // Ya nos relevaron: la escritura se descartaría igualmente, y quien tenga
+      // el ciclo ahora leerá el estado real. Se avisa sin afirmar nada.
+      this.logger.error(
+        `CRITICAL: no se pudo reconciliar el upgrade porque el lease ya no es ` +
+          `nuestro — ${context}. Revisar la suscripción en Stripe a mano.`,
+      );
+      throw new ServiceUnavailableException(
+        'We could not confirm whether your plan change went through. Please check your billing ' +
+          'settings before trying again, or contact support@zplpdf.com.',
+      );
+    }
+
     let current: Stripe.Subscription;
     try {
       current = await this.stripe.subscriptions.retrieve(subscriptionId, {
@@ -807,11 +835,19 @@ export class PaymentsService {
         `del plan se descartó por relevo del lease — ${context}. Firestore queda ` +
         `pendiente de que lo sincronice el webhook.`,
     );
-    throw new ServiceUnavailableException(
-      `Your payment for ${targetPlan.toUpperCase()} went through, but confirming it is ` +
+    // Con código propio y `paymentProcessed`, porque el status HTTP no
+    // distingue: este endpoint devuelve 503 también ANTES de cobrar —si falla la
+    // sincronización fiscal— y cuando la reconciliación no logra averiguar si
+    // hubo cargo. Un cliente que dedujera "cobrado" del 503 a secas afirmaría un
+    // cobro inexistente en dos de los tres casos.
+    throw new ServiceUnavailableException({
+      error: ErrorCodes.UPGRADE_APPLIED_SYNC_PENDING,
+      message:
+        `Your payment for ${targetPlan.toUpperCase()} went through, but confirming it is ` +
         `taking longer than usual. Your plan will be available shortly — please refresh ` +
         `in a moment before trying again.`,
-    );
+      data: { paymentProcessed: true, targetPlan },
+    });
   }
 
   /**
@@ -990,11 +1026,32 @@ export class PaymentsService {
         // El plan efectivo lo dicta el precio que Stripe tiene puesto, no el
         // documento: es la comprobación que de verdad impide bajar de plan.
         const vigenteItem = vigente.items.data[0];
-        const planVigente = vigenteItem?.price?.id
+
+        if (!vigenteItem?.id) {
+          throw new BadRequestException('Could not find subscription item');
+        }
+
+        const planVigente = vigenteItem.price?.id
           ? this.getPlanFromPriceId(vigenteItem.price.id)
           : null;
 
-        if (planVigente && PLAN_ORDER[targetPlan] <= PLAN_ORDER[planVigente]) {
+        // Falla cerrado: sin saber de qué plan se parte no se puede afirmar que
+        // esto sea una subida, y facturar a ciegas es peor que rechazar. Es el
+        // mismo caso de configuración que el webhook trata como CRITICAL sin
+        // tocar el plan; `getPlanFromPriceId` ya lo registró.
+        if (!planVigente) {
+          this.logger.error(
+            `CRITICAL: upgrade abortado por no poder resolver el plan del precio ` +
+              `vigente '${vigenteItem.price?.id ?? 'sin precio'}' — ${upgradeContext}. ` +
+              `Revisar STRIPE_*_PRICE_ID.`,
+          );
+          throw new ServiceUnavailableException(
+            'We could not verify your current plan. Nothing was charged. ' +
+              'Please try again later or contact support@zplpdf.com.',
+          );
+        }
+
+        if (PLAN_ORDER[targetPlan] <= PLAN_ORDER[planVigente]) {
           this.logger.warn(
             `Upgrade abortado: Stripe ya tiene la suscripción en ${planVigente} ` +
               `— ${upgradeContext}.`,
@@ -1002,10 +1059,6 @@ export class PaymentsService {
           throw new BadRequestException(
             `Cannot upgrade from ${planVigente.toUpperCase()} to ${targetPlan.toUpperCase()}.`,
           );
-        }
-
-        if (!vigenteItem?.id) {
-          throw new BadRequestException('Could not find subscription item');
         }
 
         return this.applyUpgrade({


### PR DESCRIPTION
Cierra #77.

## Problema

El sello de `updateUserSubscriptionState` ordena las escrituras por `readAt`, el instante en que la respuesta de `subscriptions.retrieve` llega a Cloud Run. Ese instante no es cuándo Stripe observó el estado.

1. La relectura **L1** se procesa en Stripe y ve el plan viejo, pero su respuesta sufre retraso de red.
2. La relectura **L2** se procesa después, ve el plan nuevo y responde rápido. Escribe.
3. La respuesta de L1 llega más tarde y recibe un `readAt` **mayor**.
4. La guarda la acepta por más "fresca" y **revierte el plan pagado**.

## Por qué no basta con mover el sello

La observación ocurre en un punto desconocido dentro de `[envío, respuesta]`:

- Sellar al **envío** falla cuando una petición lenta acaba observando el estado nuevo — el bug corregido en el PR #75.
- Sellar a la **respuesta** falla cuando una petición lenta observó el viejo y responde tarde — este issue.

Un reloj local no ordena observaciones remotas: solo acota el intervalo que las contiene. Y el objeto `Subscription` de Stripe no expone versión monotónica que usar en su lugar.

## Solución

No solapar los ciclos. Un lock por usuario abarca la relectura **y** la escritura, así que con los ciclos serializados la última lectura es siempre la más reciente y el sello ya no tiene que ordenar nada. Se conserva igualmente como defensa para los ciclos que mueran con el lease tomado.

El cuerpo del handler se extrae a `syncSubscriptionState`, que corre dentro de `withSubscriptionSyncLock`. Separar la relectura de la escritura volvería a abrir el hueco, así que el lock cubre las dos.

## Decisiones

- **Rechazar, no esperar.** Si el lock está tomado se lanza y Stripe reentrega el webhook con su backoff. Esperar bloquearía el manejador hasta agotar el plazo de respuesta del webhook, y Stripe lo reintentaría igualmente.
- **Liberación en `finally`.** Un ciclo que falla a mitad —relectura fallida, Firestore caído— no debe dejar al usuario sin sincronizar hasta que caduque el lease.
- **Un fallo AL liberar no se propaga.** El lease caduca solo; provocar la reentrega de algo ya aplicado sería peor.
- **Lease de 7 min**, del mismo cálculo fijado en el PR #76: 360 s de peor caso para una llamada al SDK (3 × 80 s + 2 × 60 s de `Retry-After`), más las escrituras. Con el `finally` casi nunca llega a contar.
- **Liberación comparando token**, igual que `releaseUpgradeIdempotency`: un borrado incondicional soltaría el lease que otro ciclo tomó tras darlo por caducado.

## Tests

**244 en verde** (13 suites, +11), `tsc` sin issues, lint limpio.

`firestore.service.spec.ts` cubre el lock: lo concede si nadie lo tiene, lo niega mientras otro lo tenga vivo, lo concede si el lease caducó o si la marca es ilegible, lo evalúa sobre `Timestamp`, y libera solo con el token del titular.

`payments.service.spec.ts` cubre el handler: con el lock tomado **no relee ni escribe** y lanza `ConflictException`; libera al terminar y también cuando el ciclo falla a mitad; y un fallo al liberar no tumba el webhook.

**Verificado por mutación:** sin la comprobación del lease vivo, el lock se concede siempre y fallan los dos casos que lo cubren.

El test de la carrera del #74 pasa a conceder el lock a los dos ciclos, con nota de que ejercita el sello y no la serialización — ese escenario ya no debería darse en producción.

## Alcance

Solo `customer.subscription.updated`, que es donde vive el ciclo leer-de-Stripe→escribir. Los demás handlers (`deleted`, `checkout.session.completed`, `invoice.payment_succeeded`) escriben a partir del propio evento y no tienen esta carrera, aunque no quedan serializados entre sí ni contra este.

🤖 Generated with [Claude Code](https://claude.com/claude-code)