### PR TITLE
fix(email): contar los descartes de uso alto reordenando el filtro de envío previo

### DIFF
--- a/src/modules/cache/firestore.service.spec.ts
+++ b/src/modules/cache/firestore.service.spec.ts
@@ -697,3 +697,183 @@ describe('FirestoreService — renewSubscriptionSyncLock', () => {
     expect(update).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * `getUsersWithHighUsage` comprobaba `hasUserReceivedEmailInPeriod` ANTES de
+ * evaluar el uso, así que descartaba en silencio y el conteo que se podía sacar
+ * de ahí mezclaba a todo free ya avisado con los que hoy tienen uso alto. Ahora
+ * ese filtro va el último y devuelve `{ users, skipped }` (issue #60).
+ */
+describe('FirestoreService — getUsersWithHighUsage', () => {
+  /** Dos días con 3 conversiones cada uno: cumple el patrón de uso alto. */
+  const USO_ALTO = [
+    ...Array.from({ length: 3 }, () => ({
+      createdAt: new Date('2026-08-04T10:00:00.000Z'),
+    })),
+    ...Array.from({ length: 3 }, () => ({
+      createdAt: new Date('2026-08-05T10:00:00.000Z'),
+    })),
+  ];
+
+  /** Un solo día: no llega a los 2 días consecutivos exigidos. */
+  const USO_BAJO = [{ createdAt: new Date('2026-08-05T10:00:00.000Z') }];
+
+  function usuario(id: string, conversiones = USO_ALTO) {
+    return {
+      id,
+      conversiones,
+      data: {
+        email: `${id}@ejemplo.com`,
+        displayName: `User ${id}`,
+        country: 'MX',
+        plan: 'free',
+        // Con el límite free en 10 PDFs, 6 usados y 3/día de media, la
+        // proyección son 2 días: entra dentro de la ventana de 14.
+        pdfCount: 6,
+        periodStart: new Date('2026-08-01T00:00:00.000Z'),
+        periodEnd: new Date('2026-09-01T00:00:00.000Z'),
+      },
+    };
+  }
+
+  /**
+   * Mockea Firestore por colección. Registra a quién se consultó en cada una
+   * para poder afirmar el ORDEN de los filtros, no solo su resultado.
+   */
+  function buildService(
+    usuarios: ReturnType<typeof usuario>[],
+    yaAvisados: string[] = [],
+  ) {
+    const consultados = {
+      conversiones: [] as string[],
+      emails: [] as string[],
+    };
+    const service: any = Object.create(FirestoreService.prototype);
+    service.usersCollection = 'users';
+    service.historyCollection = 'conversion_history';
+    service.emailQueueCollection = 'email_queue';
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+
+    service.firestore = {
+      collection: (nombre: string) => {
+        const filtros: Array<{ campo: string; valor: unknown }> = [];
+        const q: any = {
+          where: (campo: string, _op: string, valor: unknown) => {
+            filtros.push({ campo, valor });
+            return q;
+          },
+          orderBy: () => q,
+          limit: () => q,
+          get: async () => {
+            if (nombre === 'users') {
+              const docs = usuarios.map((u) => ({
+                id: u.id,
+                data: () => u.data,
+              }));
+              return { docs, empty: docs.length === 0 };
+            }
+
+            const userId = filtros.find((f) => f.campo === 'userId')
+              ?.valor as string;
+
+            if (nombre === 'conversion_history') {
+              consultados.conversiones.push(userId);
+              const docs = (
+                usuarios.find((u) => u.id === userId)?.conversiones ?? []
+              ).map((c) => ({ data: () => c }));
+              return { docs, empty: docs.length === 0 };
+            }
+
+            // email_queue: solo importa si hay o no algún documento.
+            consultados.emails.push(userId);
+            const avisado = yaAvisados.includes(userId);
+            return { docs: avisado ? [{}] : [], empty: !avisado };
+          },
+        };
+        return q;
+      },
+    };
+
+    return { service, consultados };
+  }
+
+  const params = { minPdfsPerDay: 3, consecutiveDays: 2 };
+
+  it('cuenta como descartado a quien tiene uso alto pero ya recibió el email', async () => {
+    // 5 candidatos con uso alto, de los cuales 3 ya fueron avisados.
+    const { service } = buildService(
+      ['a', 'b', 'c', 'd', 'e'].map((id) => usuario(id)),
+      ['a', 'b', 'c'],
+    );
+
+    const resultado = await service.getUsersWithHighUsage(params);
+
+    expect(resultado.users).toHaveLength(2);
+    expect(resultado.skipped.alreadyReceived).toBe(3);
+    expect(resultado.users.map((u: any) => u.userId)).toEqual(['d', 'e']);
+  });
+
+  it('no cuenta como descartado a quien simplemente no tiene uso alto', async () => {
+    // Un no-candidato no es un descarte: si contara, `skipped` acabaría
+    // reportando casi toda la base free y dejaría de significar nada.
+    const { service } = buildService([
+      usuario('activo'),
+      usuario('flojo', USO_BAJO),
+      usuario('inactivo', []),
+    ]);
+
+    const resultado = await service.getUsersWithHighUsage(params);
+
+    expect(resultado.users).toHaveLength(1);
+    expect(resultado.skipped.alreadyReceived).toBe(0);
+  });
+
+  it('ignora a los ya avisados que hoy no tienen uso alto', async () => {
+    // El caso que hacía inservible el conteo con el filtro por delante: un free
+    // avisado el mes pasado y hoy inactivo entraba en `skipped` igual que quien
+    // de verdad merecía el email. Aquí solo cuenta 'activo'.
+    const { service } = buildService(
+      [
+        usuario('activo'),
+        usuario('avisado-y-flojo', USO_BAJO),
+        usuario('avisado-e-inactivo', []),
+      ],
+      ['activo', 'avisado-y-flojo', 'avisado-e-inactivo'],
+    );
+
+    const resultado = await service.getUsersWithHighUsage(params);
+
+    expect(resultado.users).toHaveLength(0);
+    expect(resultado.skipped.alreadyReceived).toBe(1);
+  });
+
+  it('comprueba el envío previo solo para quien cumple el patrón de uso', async () => {
+    // El orden importa: con el filtro delante, esta consulta corría una vez por
+    // usuario free y el conteo mezclaba avisados con y sin uso alto.
+    const { service, consultados } = buildService([
+      usuario('activo'),
+      usuario('flojo', USO_BAJO),
+      usuario('inactivo', []),
+    ]);
+
+    await service.getUsersWithHighUsage(params);
+
+    expect(consultados.emails).toEqual(['activo']);
+    // Las conversiones sí se consultan para todos: es el filtro discriminante.
+    expect(consultados.conversiones).toEqual(['activo', 'flojo', 'inactivo']);
+  });
+
+  it('respeta el tope sin contar como descartados a los que no llegó a examinar', async () => {
+    const { service } = buildService(
+      Array.from({ length: 10 }, (_, i) => usuario(`u${i}`)),
+    );
+
+    const resultado = await service.getUsersWithHighUsage({
+      ...params,
+      limit: 3,
+    });
+
+    expect(resultado.users).toHaveLength(3);
+    expect(resultado.skipped.alreadyReceived).toBe(0);
+  });
+});

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -44,6 +44,8 @@ import type {
   UpdateEmailTemplateData,
   EligibleEmailUser,
   EligibleEmailUsersResult,
+  HighUsageUser,
+  HighUsageUsersResult,
 } from '../email/interfaces/email.interface.js';
 
 // ============== Daily Stats (Aggregated Metrics) ==============
@@ -5639,31 +5641,12 @@ export class FirestoreService {
     minPdfsPerDay: number;
     consecutiveDays: number;
     limit?: number;
-  }): Promise<
-    Array<{
-      userId: string;
-      userEmail: string;
-      displayName?: string;
-      language: string;
-      avgPdfsPerDay: number;
-      pdfsUsed: number;
-      limit: number;
-      projectedDaysToLimit: number;
-      periodEnd: Date;
-    }>
-  > {
+  }): Promise<HighUsageUsersResult> {
     const { minPdfsPerDay, consecutiveDays, limit = 100 } = params;
-    const highUsageUsers: Array<{
-      userId: string;
-      userEmail: string;
-      displayName?: string;
-      language: string;
-      avgPdfsPerDay: number;
-      pdfsUsed: number;
-      limit: number;
-      projectedDaysToLimit: number;
-      periodEnd: Date;
-    }> = [];
+    const highUsageUsers: HighUsageUser[] = [];
+    // Se cuenta aquí porque es donde ocurre el descarte: quien llama solo recibe
+    // la lista final y no puede saber cuántos candidatos se filtraron.
+    const skipped = { alreadyReceived: 0 };
 
     // Get all FREE users
     const usersSnapshot = await this.firestore
@@ -5676,18 +5659,6 @@ export class FirestoreService {
 
       const userData = userDoc.data();
       const userId = userDoc.id;
-
-      // Check if already received high_usage email in current period
-      const periodStart =
-        userData.periodStart?.toDate?.() || userData.periodStart;
-      if (periodStart) {
-        const hasEmail = await this.hasUserReceivedEmailInPeriod(
-          userId,
-          'high_usage',
-          periodStart,
-        );
-        if (hasEmail) continue;
-      }
 
       // Get conversions for the last N days
       const daysAgo = new Date();
@@ -5750,6 +5721,26 @@ export class FirestoreService {
       // Only include if projected to hit limit soon (within 14 days)
       if (projectedDaysToLimit > 14) continue;
 
+      // Deliberadamente el ÚLTIMO filtro. Si se comprueba antes de evaluar el
+      // uso, el descarte alcanza a todo free que ya recibió el email tenga o no
+      // uso alto ahora, y el conteo resultante no dice nada. Aquí solo cuenta a
+      // quien de verdad merecía el email hoy. De paso sale más barato: esta
+      // consulta pasa de correr una vez por usuario free a correr solo para los
+      // pocos que cumplen el patrón de uso.
+      const periodStart =
+        userData.periodStart?.toDate?.() || userData.periodStart;
+      if (periodStart) {
+        const hasEmail = await this.hasUserReceivedEmailInPeriod(
+          userId,
+          'high_usage',
+          periodStart,
+        );
+        if (hasEmail) {
+          skipped.alreadyReceived++;
+          continue;
+        }
+      }
+
       const periodEnd =
         userData.periodEnd?.toDate?.() || userData.periodEnd || new Date();
 
@@ -5766,7 +5757,7 @@ export class FirestoreService {
       });
     }
 
-    return highUsageUsers;
+    return { users: highUsageUsers, skipped };
   }
 
   /**

--- a/src/modules/email/email.service.spec.ts
+++ b/src/modules/email/email.service.spec.ts
@@ -493,3 +493,98 @@ describe('EmailService.schedulePowerUserEmails', () => {
     });
   });
 });
+
+/**
+ * Último de los cinco `schedule*Emails` en poblar `skipped` (issue #60). El
+ * filtrado vive en `getUsersWithHighUsage`, así que aquí solo se comprueba que
+ * el conteo llegue intacto al resultado del cron; el reordenamiento de filtros
+ * que lo hace posible se cubre en firestore.service.spec.ts.
+ */
+describe('EmailService.scheduleHighUsageEmails', () => {
+  let service: EmailService;
+  let firestore: {
+    isTemplateEnabled: jest.Mock;
+    getUsersWithHighUsage: jest.Mock;
+    createEmailQueue: jest.Mock;
+  };
+
+  function highUsageUser(id: string) {
+    return {
+      userId: id,
+      userEmail: `${id}@ejemplo.com`,
+      displayName: `User ${id}`,
+      language: 'es',
+      avgPdfsPerDay: 3,
+      pdfsUsed: 6,
+      limit: 10,
+      projectedDaysToLimit: 2,
+      periodEnd: new Date(2026, 8, 1),
+    };
+  }
+
+  beforeEach(async () => {
+    firestore = {
+      isTemplateEnabled: jest.fn().mockResolvedValue(true),
+      getUsersWithHighUsage: jest.fn(),
+      createEmailQueue: jest.fn().mockResolvedValue('queue-id'),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmailService,
+        PeriodCalculatorService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) =>
+              key === 'RESEND_API_KEY' ? 'test-key' : undefined,
+          },
+        },
+        { provide: FirestoreService, useValue: firestore },
+      ],
+    }).compile();
+
+    service = module.get<EmailService>(EmailService);
+  });
+
+  it('reporta los candidatos de uso alto que ya habían recibido el email', async () => {
+    // 7 con uso alto, 4 ya avisados este período.
+    firestore.getUsersWithHighUsage.mockResolvedValue({
+      users: ['a', 'b', 'c'].map(highUsageUser),
+      skipped: { alreadyReceived: 4 },
+    });
+
+    const result = await service.scheduleHighUsageEmails();
+
+    expect(result.scheduled).toBe(3);
+    expect(result.skipped).toBe(4);
+    expect(firestore.createEmailQueue).toHaveBeenCalledTimes(3);
+  });
+
+  it('distingue "nadie con uso alto" de "todos ya avisados"', async () => {
+    // Los dos casos programan 0 emails; antes se reportaban idénticos.
+    firestore.getUsersWithHighUsage.mockResolvedValue({
+      users: [],
+      skipped: { alreadyReceived: 0 },
+    });
+    const sinCandidatos = await service.scheduleHighUsageEmails();
+
+    firestore.getUsersWithHighUsage.mockResolvedValue({
+      users: [],
+      skipped: { alreadyReceived: 9 },
+    });
+    const yaAvisados = await service.scheduleHighUsageEmails();
+
+    expect(sinCandidatos).toMatchObject({ scheduled: 0, skipped: 0 });
+    expect(yaAvisados).toMatchObject({ scheduled: 0, skipped: 9 });
+  });
+
+  it('no consulta candidatos si el template está deshabilitado', async () => {
+    firestore.isTemplateEnabled.mockResolvedValue(false);
+
+    const result = await service.scheduleHighUsageEmails();
+
+    expect(result).toMatchObject({ scheduled: 0, skipped: 0 });
+    expect(firestore.getUsersWithHighUsage).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/email/email.service.ts
+++ b/src/modules/email/email.service.ts
@@ -868,14 +868,7 @@ export class EmailService {
     }
 
     let scheduled = 0;
-    // Sigue en 0 a propósito, a diferencia de los schedule* de onboarding.
-    // getUsersWithHighUsage descarta por `hasUserReceivedEmailInPeriod` ANTES
-    // de evaluar el criterio de uso alto, así que ese conteo incluiría a todos
-    // los usuarios free que ya recibieron el email tengan o no uso alto ahora:
-    // un número inflado y engañoso. Contarlo bien exige reordenar los filtros,
-    // lo que haría correr la consulta de conversiones (cara) para todo free.
-    // Ver issue #60.
-    const skipped = 0;
+    let skipped = 0;
 
     try {
       // Check if template is enabled
@@ -887,13 +880,18 @@ export class EmailService {
       }
 
       // Get users with high usage patterns (>3 PDFs/day for 2 consecutive days)
-      const highUsageUsers = await this.firestoreService.getUsersWithHighUsage({
+      const highUsage = await this.firestoreService.getUsersWithHighUsage({
         minPdfsPerDay: 3,
         consecutiveDays: 2,
         limit: 100,
       });
 
-      for (const user of highUsageUsers) {
+      // Cuenta a quien cumple el patrón de uso alto pero ya recibió el email en
+      // su período. Sin esto, "nadie tiene uso alto" y "todos ya están avisados"
+      // se reportan igual.
+      skipped = highUsage.skipped.alreadyReceived;
+
+      for (const user of highUsage.users) {
         const variant = this.selectAbVariant(user.userId);
 
         await this.firestoreService.createEmailQueue({

--- a/src/modules/email/interfaces/email.interface.ts
+++ b/src/modules/email/interfaces/email.interface.ts
@@ -237,11 +237,30 @@ export interface HighUsageUser {
   userId: string;
   userEmail: string;
   displayName?: string;
-  language: EmailLanguage;
+  /** Deducido del país del usuario, por eso no está acotado a EmailLanguage. */
+  language: string;
   avgPdfsPerDay: number;
   pdfsUsed: number;
   limit: number;
   projectedDaysToLimit: number;
+  periodEnd: Date;
+}
+
+/**
+ * Candidatos de uso alto descartados, desglosados por motivo.
+ *
+ * Solo entra aquí quien **sí** cumple el patrón de uso alto: los free que no lo
+ * cumplen no son descartes, son no-candidatos. Contarlos metería a casi toda la
+ * base free en `skipped` y lo volvería incomparable con el resto de flujos.
+ */
+export interface HighUsageSkipReasons {
+  /** Ya recibió el email de uso alto en su período de facturación actual. */
+  alreadyReceived: number;
+}
+
+export interface HighUsageUsersResult {
+  users: HighUsageUser[];
+  skipped: HighUsageSkipReasons;
 }
 
 // ============== PRO Retention Interfaces ==============


### PR DESCRIPTION
Cierra #60. Es el **quinto y último** de los `schedule*Emails` que reportaba `skipped: 0`; los otros cuatro se cerraron en #61 (tutorial, help, day 7) y #63 (power user).

## Por qué se quedó fuera antes

#61 lo dejó documentado en código: `getUsersWithHighUsage` comprobaba `hasUserReceivedEmailInPeriod` como **primer** filtro del bucle, antes de mirar el uso. Contar los descartes ahí habría metido en `skipped` a todo usuario free ya avisado tuviera o no uso alto hoy — un número grande que no responde a la pregunta que se le hace.

## El arreglo

Ese filtro pasa a ser el **último**, después de la evaluación de uso, y la función devuelve `{ users, skipped }`:

```ts
if (projectedDaysToLimit > 14) continue;   // ya sabemos que califica

const hasEmail = await this.hasUserReceivedEmailInPeriod(...);
if (hasEmail) { skipped.alreadyReceived++; continue; }
```

`skipped` cuenta ahora solo a quien **sí** cumple el patrón de uso alto y ya recibió el email en su período. Quien no lo cumple no es un descarte, es un no-candidato: contarlo metería a casi toda la base free en `skipped` y lo volvería incomparable con el resto de flujos. Queda razonado en el JSDoc de `HighUsageSkipReasons`.

## Sobre el coste, que era la objeción de #61

El reorden **abarata** el cron en el régimen real, pero conviene dejar dicha la condición en vez de darla por supuesta. `hasUserReceivedEmailInPeriod` es una query con `.limit(1)` —una lectura— y pasa de correr **una vez por usuario free** a correr solo para los pocos que califican. A cambio, la consulta de conversiones corre también para los ya avisados. Con F usuarios free, A avisados en su período y C candidatos que superan el filtro de uso:

| | antes | ahora |
|---|---|---|
| `hasUserReceivedEmailInPeriod` | F | C |
| consulta de conversiones | F − A | F |

El reorden quita F − C consultas y añade A. **El saldo es favorable mientras A ≪ F**, y solo se invierte si A ≳ 0.4·F: que el 40% de toda la base gratuita tenga el aviso de uso alto vivo en su período. Ese aviso exige ≥3 PDFs/día durante dos días con una cuota de 10 al mes —consumir el 60% del mes en dos días—, así que ese régimen describiría una base donde casi todos son power users a punto de convertir, justo lo contrario del perfil para el que existe el email.

Lo que **no** arregla este PR, y conviene no leer entre líneas: `getUsersWithHighUsage` trae todos los usuarios free sin paginar y recorre el bucle con un `await` por usuario. Ese N+1 secuencial es preexistente y no cambia de orden de magnitud aquí —antes también eran ~F consultas secuenciales, solo que dominaba la otra colección—. Tiene issue propio.

## Tipos

`getUsersWithHighUsage` declaraba su forma de retorno inline y duplicada. Pasa a usar `HighUsageUser`, que ya existía en `email.interface.ts` sin usar por nadie; le he añadido el `periodEnd` que faltaba y he aflojado `language` a `string`, que es lo que `detectLanguageFromCountry` devuelve de verdad.

## Hallazgo colateral (no lo toco aquí)

La comprobación de duplicados sigue colgando de `if (periodStart)`: un usuario free **sin `periodStart`** nunca se deduplica y recibiría el email en cada ejecución del cron. Es preexistente y ajeno a este issue de observabilidad, pero conviene decidir si el fallback debe ser "no enviar" en vez de "enviar siempre". Digno de issue propio.

## Verificación

- `npm run build` → **0 issues**.
- `npm run lint` → exit 0, sin modificar archivos.
- `npm test` → **288 pruebas, 13 suites, en verde** (eran 280; +8 nuevas: 5 en `firestore.service.spec.ts` y 3 en `email.service.spec.ts`).

Las 7 nuevas cubren el criterio de aceptación del issue (N candidatos, M ya avisados → `scheduled === N−M`, `skipped === M`) más los casos que fijan la decisión de diseño. **Comprobado que muerden**: restaurando el orden viejo del filtro, fallan `ignora a los ya avisados que hoy no tienen uso alto` y `comprueba el envío previo solo para quien cumple el patrón de uso`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

