### PR TITLE
fix(payments): recuperar el upgrade ya aplicado y no afirmar nada ante un resultado indeterminado

### DIFF
--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -528,6 +528,35 @@ describe('PaymentsService — upgradeSubscription', () => {
     expect(error.message).toContain('went through');
   });
 
+  it('rechaza la bajada que solo Stripe conoce, sin confundirla con el caso idempotente', async () => {
+    // La recuperación idempotente solo cubre destino == vigente. Si Stripe está
+    // en un plan SUPERIOR al pedido, sigue siendo una bajada y debe rechazarse:
+    // es la única rama que queda viva en esa guarda, y la protección de fondo
+    // del método.
+    //
+    // Firestore dice lite, así que las dos guardas contra el documento dejan
+    // pasar un lite→pro; solo la comprobación contra el precio vigente en Stripe
+    // ve que en realidad es promax→pro.
+    const { service, update, updateUser, userDoc } = buildService({
+      subscription: {
+        status: 'active',
+        items: { data: [{ id: 'si_123', price: { id: PROMAX_MXN } }] },
+      },
+    });
+    userDoc.plan = 'lite';
+
+    const error = await service
+      .upgradeSubscription('uid-1', 'pro')
+      .catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(BadRequestException);
+    // PROMAX, no LITE: prueba que el rechazo viene de la guarda contra Stripe y
+    // no de las anteriores, que habrían dejado pasar este cambio.
+    expect(error.message).toBe('Cannot upgrade from PROMAX to PRO.');
+    expect(update).not.toHaveBeenCalled();
+    expect(escriturasDePlan(updateUser)).toHaveLength(0);
+  });
+
   it('aborta si la suscripción dejó de estar activa mientras se preparaba', async () => {
     const { service, update, retrieve } = buildService({
       subscription: activeSubscription,
@@ -1002,6 +1031,15 @@ describe('PaymentsService — upgradeSubscription', () => {
         targetPlan: 'promax',
         subscriptionId: 'sub_123',
       });
+      // Este throw no pasa por throwStripeApiError, así que el rastro tiene que
+      // dejarlo él: sin esto, el desenlace con un cobro quizá en vuelo sería el
+      // único del flujo sin el mensaje original de Stripe ni nivel `error`.
+      const registrado = service.logger.error.mock.calls
+        .map(([mensaje]: [string]) => mensaje)
+        .join('\n');
+      expect(registrado).toContain(type);
+      expect(registrado).toContain('indeterminate error');
+      expect(registrado).toContain('uid-1');
     },
   );
 

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -476,12 +476,19 @@ describe('PaymentsService — upgradeSubscription', () => {
     expect(update).not.toHaveBeenCalled();
   });
 
-  it('aborta si Stripe ya tiene la suscripción en el plan de destino', async () => {
-    // La comprobación que de verdad impide bajar de plan: el plan efectivo lo
-    // dicta el precio que Stripe tiene puesto, no el documento.
-    const { service, update, retrieve } = buildService({
-      subscription: activeSubscription,
-    });
+  it('sincroniza de forma idempotente si Stripe ya aplicó el destino pero Firestore sigue atrás', async () => {
+    // Caso del reintento tras perder la respuesta del update Y la lectura de
+    // reconciliación: Stripe ya cobró PROMAX, pero el documento todavía dice PRO.
+    const { service, update, retrieve, userDoc, updateUserSubscriptionState } =
+      buildService({
+        subscription: activeSubscription,
+      });
+    userDoc.upgradeIdempotency = {
+      key: 'upgrade_perdido',
+      targetPlan: 'promax',
+      subscriptionId: 'sub_123',
+      createdAt: new Date().toISOString(),
+    };
     retrieve.mockResolvedValueOnce(activeSubscription).mockResolvedValueOnce({
       status: 'active',
       items: { data: [{ id: 'si_123', price: { id: PROMAX_MXN } }] },
@@ -489,8 +496,36 @@ describe('PaymentsService — upgradeSubscription', () => {
 
     await expect(
       service.upgradeSubscription('uid-1', 'promax'),
-    ).rejects.toThrow(BadRequestException);
+    ).resolves.toMatchObject({ success: true });
+
+    expect(updateUserSubscriptionState).toHaveBeenCalledWith(
+      'uid-1',
+      { plan: 'promax' },
+      expect.any(Date),
+      'sync-tok',
+    );
+    expect(userDoc.plan).toBe('promax');
+    expect(userDoc.upgradeIdempotency).toBeNull();
+    // Ya estaba aplicado: repetir la mutación podría volver a facturar.
     expect(update).not.toHaveBeenCalled();
+  });
+
+  it('no afirma éxito si no logra persistir el upgrade ya aplicado', async () => {
+    const { service, retrieve, updateUserSubscriptionState } = buildService({
+      subscription: activeSubscription,
+    });
+    retrieve.mockResolvedValueOnce(activeSubscription).mockResolvedValueOnce({
+      status: 'active',
+      items: { data: [{ id: 'si_123', price: { id: PROMAX_MXN } }] },
+    });
+    updateUserSubscriptionState.mockResolvedValue(false);
+
+    const error = await service
+      .upgradeSubscription('uid-1', 'promax')
+      .catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(ServiceUnavailableException);
+    expect(error.message).toContain('went through');
   });
 
   it('aborta si la suscripción dejó de estar activa mientras se preparaba', async () => {
@@ -937,26 +972,38 @@ describe('PaymentsService — upgradeSubscription', () => {
     expect(updateUser).toHaveBeenCalledWith('uid-1', { plan: 'promax' });
   });
 
-  it('tras un error de conexión en el que NO se aplicó, informa del fallo sin tocar el plan', async () => {
-    const { service, updateUser, retrieve } = buildService({
-      subscription: activeSubscription,
-      updateError: { type: 'StripeConnectionError', message: 'network error' },
-    });
-    // Tercera lectura —la de la reconciliación— sigue en el precio viejo: el
-    // cambio no llegó a aplicarse.
-    retrieve
-      .mockResolvedValueOnce(activeSubscription)
-      .mockResolvedValueOnce(activeSubscription)
-      .mockResolvedValueOnce({
-        status: 'active',
-        items: { data: [{ id: 'si_123', price: { id: 'price_pro_mxn' } }] },
+  it.each(['StripeConnectionError', 'StripeAPIError'])(
+    'tras un %s sin desenlace visible, responde de forma ambigua y conserva la clave',
+    async (type) => {
+      const { service, updateUser, retrieve, userDoc } = buildService({
+        subscription: activeSubscription,
+        updateError: { type, message: 'indeterminate error' },
       });
+      // La lectura inmediata todavía ve PRO, pero eso no demuestra que la
+      // mutación perdida no vaya a terminar o ser reconciliada después.
+      retrieve
+        .mockResolvedValueOnce(activeSubscription)
+        .mockResolvedValueOnce(activeSubscription)
+        .mockResolvedValueOnce({
+          status: 'active',
+          items: { data: [{ id: 'si_123', price: { id: 'price_pro_mxn' } }] },
+        });
 
-    await expect(
-      service.upgradeSubscription('uid-1', 'promax'),
-    ).rejects.toThrow();
-    expect(escriturasDePlan(updateUser)).toHaveLength(0);
-  });
+      const error = await service
+        .upgradeSubscription('uid-1', 'promax')
+        .catch((e: Error) => e);
+
+      expect(error).toBeInstanceOf(ServiceUnavailableException);
+      expect(error.message).toContain('could not confirm');
+      expect(error.message).not.toContain('has not been changed');
+      expect(escriturasDePlan(updateUser)).toHaveLength(0);
+      // El reintento seguro necesita reutilizar exactamente esta clave.
+      expect(userDoc.upgradeIdempotency).toMatchObject({
+        targetPlan: 'promax',
+        subscriptionId: 'sub_123',
+      });
+    },
+  );
 
   /**
    * La petición perdida pudo llegar a crear un pending update. Clasificarlo como

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -1044,11 +1044,13 @@ export class PaymentsService {
         // dejando al cliente con el enlace de pago que ya tenía apuntando a una
         // factura muerta.
         let vigente: Stripe.Subscription;
+        let vigenteReadAt: Date;
         try {
           vigente = await this.stripe.subscriptions.retrieve(
             user.stripeSubscriptionId,
             { expand: ['latest_invoice'] },
           );
+          vigenteReadAt = new Date();
         } catch (error) {
           this.throwStripeApiError(
             error,
@@ -1097,6 +1099,67 @@ export class PaymentsService {
             'We could not verify your current plan. Nothing was charged. ' +
               'Please try again later or contact support@zplpdf.com.',
           );
+        }
+
+        // Recuperación idempotente: un intento anterior pudo aplicar y cobrar el
+        // target en Stripe, perder su respuesta y fallar también al reconciliar.
+        // Firestore seguiría con el plan inferior, así que rechazar aquí como
+        // target→target dejaría al cliente pagando sin entitlement y cada
+        // reintento repetiría el mismo rechazo.
+        if (
+          planVigente === targetPlan &&
+          PLAN_ORDER[fresh.plan] < PLAN_ORDER[targetPlan]
+        ) {
+          let persisted = false;
+          let falloAlEscribir = false;
+          try {
+            persisted = await this.firestoreService.updateUserSubscriptionState(
+              userId,
+              { plan: targetPlan },
+              vigenteReadAt,
+              lockToken,
+            );
+          } catch (persistError) {
+            falloAlEscribir = true;
+            this.logger.error(
+              `No se pudo sincronizar el upgrade ya aplicado — ${upgradeContext}. ` +
+                `Detalle: ${(persistError as Error).message}`,
+            );
+          }
+
+          // Solo corresponde al intento recuperado si coinciden contrato y
+          // destino. El compare-and-delete de Firestore protege además una clave
+          // posterior que pudiera haber reemplazado a esta lectura.
+          const recoveredIdempotency = fresh.upgradeIdempotency;
+          if (
+            recoveredIdempotency?.targetPlan === targetPlan &&
+            recoveredIdempotency.subscriptionId === user.stripeSubscriptionId
+          ) {
+            await this.clearUpgradeIdempotencyKey(
+              userId,
+              recoveredIdempotency.key,
+            );
+          }
+
+          if (!persisted) {
+            this.throwUnsyncedUpgradeError(
+              targetPlan,
+              upgradeContext,
+              falloAlEscribir
+                ? 'fallo al escribir en Firestore'
+                : 'relevo del lease',
+            );
+          }
+
+          this.logger.log(
+            `Upgrade a ${targetPlan} ya aplicado en Stripe sincronizado de forma ` +
+              `idempotente — ${upgradeContext}.`,
+          );
+
+          return {
+            success: true,
+            message: `Successfully upgraded to ${targetPlan.toUpperCase()}. Proration has been applied.`,
+          };
         }
 
         if (PLAN_ORDER[targetPlan] <= PLAN_ORDER[planVigente]) {
@@ -1199,12 +1262,21 @@ export class PaymentsService {
         await this.clearUpgradeIdempotencyKey(userId, idempotencyKey);
         return reconciled;
       }
-      // Solo los errores indeterminados conservan la clave: son los únicos que
-      // el cliente debe reintentar con la misma para no arriesgar otro cargo.
+      // Una lectura inmediata que todavía muestre el plan anterior NO convierte
+      // un error indeterminado en un fallo definitivo: la mutación puede seguir
+      // ejecutándose en Stripe o ser reconciliada después. La clave se conserva
+      // y la respuesta no afirma que el plan haya quedado igual.
       const type = (error as { type?: string }).type;
-      if (type !== 'StripeConnectionError' && type !== 'StripeAPIError') {
-        await this.clearUpgradeIdempotencyKey(userId, idempotencyKey);
+      if (type === 'StripeConnectionError' || type === 'StripeAPIError') {
+        throw new ServiceUnavailableException(
+          'We could not confirm whether your plan change went through. Please check your billing ' +
+            'settings before trying again, or contact support@zplpdf.com.',
+        );
       }
+
+      // Los desenlaces no indeterminados sí liberan la clave: un intento nuevo
+      // no debe recibir de Stripe el error cacheado del anterior.
+      await this.clearUpgradeIdempotencyKey(userId, idempotencyKey);
       this.throwStripeApiError(
         error,
         'subscriptions.update',

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -1268,6 +1268,16 @@ export class PaymentsService {
       // y la respuesta no afirma que el plan haya quedado igual.
       const type = (error as { type?: string }).type;
       if (type === 'StripeConnectionError' || type === 'StripeAPIError') {
+        // Se registra aquí porque este `throw` no pasa por throwStripeApiError,
+        // que es quien normalmente deja el rastro. Sin esto, el desenlace con un
+        // cobro posiblemente en vuelo sería el peor instrumentado de todo el
+        // flujo: solo quedaría el warn de la reconciliación, sin el mensaje
+        // original de Stripe y un nivel por debajo del que disparan las alertas.
+        this.logger.error(
+          `CRITICAL: subscriptions.update quedó indeterminado (${type}) y la reconciliación ` +
+            `no pudo confirmar el desenlace — ${upgradeContext}. La clave de idempotencia se ` +
+            `conserva para el reintento. Detalle: ${(error as { message?: string }).message}`,
+        );
         throw new ServiceUnavailableException(
           'We could not confirm whether your plan change went through. Please check your billing ' +
             'settings before trying again, or contact support@zplpdf.com.',


### PR DESCRIPTION
Dos fugas del camino de upgrade con resultado indeterminado, detectadas en review externo. Independiente de #80 (que solo toca las métricas de email del issue #60).

## 1. Upgrade aplicado en Stripe que Firestore nunca reflejó — P1

Si `subscriptions.update` aplicó y cobró el cambio pero se perdieron **tanto su respuesta como la lectura de reconciliación**, Firestore se quedaba con el plan anterior. En el reintento, Stripe ya devolvía el plan de destino y la guarda `targetPlan <= planVigente` abortaba con `Cannot upgrade from PROMAX to PROMAX` antes de tocar Firestore.

Era un **estado absorbente**: todos los reintentos repetían el mismo rechazo y el cliente seguía pagando un plan que el producto no le reconocía, salvo que el webhook llegara a rescatarlo.

Cuando Stripe ya está en el destino y Firestore sigue por debajo, ahora se sincroniza el plan bajo el lease vigente, sellado con el instante de la lectura por la guarda de frescura del #74. Se libera la clave del intento recuperado con compare-and-delete y se devuelve éxito idempotente. **No se repite la mutación**, así que no hay riesgo de segundo cobro.

## 2. Un resultado indeterminado no es un fallo — P1

Tras un `StripeConnectionError` o `StripeAPIError`, que la relectura inmediata siga mostrando el precio anterior no demuestra que el POST haya fallado: una petición con timeout puede seguir ejecutándose y Stripe define los 5xx como indeterminados. La respuesta acababa diciendo *"Your plan has not been changed"* sobre un cargo que podía aplicarse segundos después.

Había además una inconsistencia interna: los otros tres desenlaces indeterminados de este mismo flujo ya respondían *"We could not confirm whether your plan change went through"*. Ahora este también, y sigue conservando la clave de idempotencia para que el reintento del cliente sea seguro. La resolución definitiva queda en el webhook.

## Verificación

- `npm run build` → **0 issues**
- `npm run lint` → exit 0
- `git diff --check` → limpio
- `npm test` → **282 pruebas, 13 suites, en verde**

Comprobado que las 4 pruebas nuevas **muerden**: revirtiendo el servicio y dejando el spec, las cuatro fallan.

## Repaso posterior, ya resuelto

Tres observaciones salieron del repaso. Las dos primeras están cerradas en el segundo commit; la tercera se mantiene a propósito.

1. **El 503 ambiguo no dejaba rastro** ✅ — el `throw` de los indeterminados no pasa por `throwStripeApiError`, que es quien normalmente registra el fallo, así que el desenlace con un cobro posiblemente en vuelo era el peor instrumentado del flujo: solo el `warn` de la reconciliación, sin el mensaje de Stripe y un nivel por debajo del que disparan las alertas. Ahora emite un `logger.error` con tipo, contexto, el aviso de que la clave se conserva y el detalle original.
2. **La guarda anti-downgrade se quedó sin test** ✅ — tras la recuperación idempotente, `PLAN_ORDER[targetPlan] <= PLAN_ORDER[planVigente]` ya solo se alcanza cuando Stripe está en un plan **superior** al pedido, y es la protección de fondo del método. El test entra con Firestore en lite y Stripe en promax pidiendo pro: las dos guardas contra el documento dejan pasar el cambio y solo la comprobación contra el precio vigente ve que es una bajada. Afirma el mensaje exacto —PROMAX, no LITE— para que no pueda colarse por otro rechazo.
3. **Segunda condición redundante** — `PLAN_ORDER[fresh.plan] < PLAN_ORDER[targetPlan]` ya está garantizada por la guarda previa contra `fresh.plan`. Se mantiene como defensa en profundidad, a propósito.

Tras el segundo commit: build 0 issues, ESLint limpio, `git diff --check` limpio y **283 pruebas en verde**. Comprobado que ambos añadidos muerden: sin el `logger.error` fallan los dos casos indeterminados, y sin la guarda falla el de bajada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
