### PR TITLE
fix(payments): cancelar el contrato impagado en vez de encerrar al cliente

### DIFF
--- a/src/modules/admin/services/finance.service.ts
+++ b/src/modules/admin/services/finance.service.ts
@@ -322,11 +322,16 @@ export class FinanceService {
         ? (churnedUsers / totalSubscribersAtStart) * 100
         : 0;
 
-    // Obtener eventos de cancelación para MRR churneado
+    // Obtener eventos de cancelación para MRR churneado.
+    //
+    // Los dos tipos, como en el cálculo de churn de más arriba: desde la política
+    // de cobro de #65 la baja por impago se registra como `churned` para poder
+    // distinguirla de la voluntaria, y consultar solo `canceled` dejaría fuera
+    // del MRR churneado justamente las bajas que el cliente no eligió.
     const cancelEvents = await this.firestoreService.getSubscriptionEvents({
       startDate,
       endDate,
-      eventType: 'canceled',
+      eventType: ['canceled', 'churned'],
     });
 
     let churnedMrr = 0;

--- a/src/modules/cache/firestore.service.spec.ts
+++ b/src/modules/cache/firestore.service.spec.ts
@@ -1010,3 +1010,110 @@ describe('FirestoreService — getUsersWithHighUsage', () => {
     });
   });
 });
+
+/**
+ * El evento de baja se escribe DENTRO de la transacción que degrada al usuario.
+ *
+ * Escribirlo después dejaba dos desenlaces malos: si esa segunda escritura
+ * fallaba, la reentrega del webhook encontraba al usuario ya en Free, lo tomaba
+ * por trabajo hecho y la baja no se contabilizaba nunca; y registrándolo antes,
+ * un fencing que descartase la degradación habría contado un churn que no
+ * ocurrió. Dentro de la transacción constan ambas cosas o ninguna.
+ */
+describe('FirestoreService — la baja y su evento van en la misma transacción', () => {
+  function buildService(docData: Record<string, unknown>) {
+    const update = jest
+      .fn()
+      .mockImplementation((_ref: unknown, data: Record<string, unknown>) => {
+        Object.assign(docData, data);
+      });
+    const set = jest.fn();
+    const docs: Record<string, unknown> = {};
+
+    const service: any = Object.create(FirestoreService.prototype);
+    service.usersCollection = 'users';
+    service.subscriptionEventsCollection = 'subscription_events';
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    service.firestore = {
+      collection: (name: string) => ({
+        doc: (id?: string) => {
+          const ref = { collection: name, id };
+          docs[`${name}/${id ?? 'uid-1'}`] = ref;
+          return ref;
+        },
+      }),
+      runTransaction: (fn: (t: unknown) => Promise<boolean>) =>
+        fn({
+          get: async () => ({ data: () => docData }),
+          update,
+          set,
+        }),
+    };
+
+    return { service, update, set };
+  }
+
+  const evento = {
+    id: 'sub_event_20260806_ABCDE',
+    userId: 'uid-1',
+    userEmail: 'cliente@example.com',
+    eventType: 'churned' as const,
+    plan: 'lite' as const,
+    currency: 'mxn' as const,
+    mrr: 0,
+    mrrMxn: 0,
+    stripeSubscriptionId: 'sub_123',
+    createdAt: new Date('2026-08-06T10:00:00.000Z'),
+  };
+
+  it('escribe el evento junto al cambio de plan', async () => {
+    const { service, update, set } = buildService({ plan: 'lite' });
+
+    const aplicada = await service.updateUserSubscriptionState(
+      'uid-1',
+      { plan: 'free', stripeSubscriptionId: null },
+      new Date('2026-08-06T10:00:00.000Z'),
+      undefined,
+      evento,
+    );
+
+    expect(aplicada).toBe(true);
+    expect(update).toHaveBeenCalled();
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ collection: 'subscription_events' }),
+      expect.objectContaining({ eventType: 'churned', plan: 'lite' }),
+    );
+  });
+
+  it('no escribe el evento si el fencing descarta la degradación', async () => {
+    const { service, update, set } = buildService({
+      plan: 'promax',
+      subscriptionSyncedAt: '2026-08-06T10:00:05.000Z',
+    });
+
+    const aplicada = await service.updateUserSubscriptionState(
+      'uid-1',
+      { plan: 'free', stripeSubscriptionId: null },
+      new Date('2026-08-06T10:00:00.000Z'),
+      undefined,
+      evento,
+    );
+
+    // Contarlo aquí habría registrado la baja de un cliente que sigue pagando.
+    expect(aplicada).toBe(false);
+    expect(update).not.toHaveBeenCalled();
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it('no toca la colección de eventos cuando no hay baja que registrar', async () => {
+    const { service, set } = buildService({ plan: 'pro' });
+
+    await service.updateUserSubscriptionState(
+      'uid-1',
+      { plan: 'promax' },
+      new Date('2026-08-06T10:00:00.000Z'),
+    );
+
+    expect(set).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -746,11 +746,24 @@ export class FirestoreService {
    * no dispare efectos secundarios (emails de degradación) por un cambio que no
    * ocurrió.
    */
+  /**
+   * @param subscriptionEvent Evento que debe quedar escrito EN LA MISMA
+   *   transacción que el cambio de plan, o no escribirse en absoluto.
+   *
+   *   Existe para las bajas. Escribirlo después, en una operación aparte, dejaba
+   *   dos desenlaces malos: si esa segunda escritura fallaba, la reentrega del
+   *   webhook encontraba al usuario ya degradado, lo tomaba por trabajo hecho y
+   *   la baja no se contabilizaba nunca; y si la degradación se descartaba por
+   *   fencing, un evento ya escrito habría contado un churn que no ocurrió.
+   *   Dentro de la transacción los dos casos desaparecen: o constan ambas cosas,
+   *   o ninguna.
+   */
   async updateUserSubscriptionState(
     userId: string,
     data: Record<string, unknown>,
     readAt: Date,
     lockToken?: string,
+    subscriptionEvent?: SubscriptionEvent,
   ): Promise<boolean> {
     const ref = this.firestore.collection(this.usersCollection).doc(userId);
 
@@ -792,6 +805,16 @@ export class FirestoreService {
         subscriptionSyncedAt: readAt.toISOString(),
         updatedAt: new Date(),
       });
+
+      if (subscriptionEvent) {
+        transaction.set(
+          this.firestore
+            .collection(this.subscriptionEventsCollection)
+            .doc(subscriptionEvent.id),
+          { ...subscriptionEvent, createdAt: subscriptionEvent.createdAt },
+        );
+      }
+
       return true;
     });
   }
@@ -4306,7 +4329,8 @@ export class FirestoreService {
   async getSubscriptionEvents(filters: {
     startDate?: Date;
     endDate?: Date;
-    eventType?: string;
+    /** Uno o varios tipos; una baja se reparte entre `canceled` y `churned`. */
+    eventType?: string | string[];
     userId?: string;
   }): Promise<SubscriptionEvent[]> {
     try {
@@ -4321,7 +4345,9 @@ export class FirestoreService {
         query = query.where('createdAt', '<=', filters.endDate);
       }
       if (filters.eventType) {
-        query = query.where('eventType', '==', filters.eventType);
+        query = Array.isArray(filters.eventType)
+          ? query.where('eventType', 'in', filters.eventType)
+          : query.where('eventType', '==', filters.eventType);
       }
       if (filters.userId) {
         query = query.where('userId', '==', filters.userId);

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -895,6 +895,33 @@ describe('PaymentsService — upgradeSubscription', () => {
    * precio, deja la suscripción en past_due y responde 200. El plan acababa
    * marcado en Firestore sin haberse pagado.
    */
+  /**
+   * Stripe mantiene `trialing` al cambiar el precio durante una prueba: no la
+   * termina. Exigir `active` en la confirmación aplicaba el precio nuevo y luego
+   * devolvía error sin escribir el plan —contrato y entitlements desincronizados,
+   * y el cliente leyendo que no se cambió nada mientras se le facturaría el plan
+   * superior al acabar la prueba—.
+   *
+   * La salida no es prohibir `trialing` en el upgrade: el checkout lo tiene por
+   * estado vivo y remite aquí, así que rechazarlo reabriría el callejón de #65
+   * con otro estado. Hoy es teórico —no hay `trial_period_days` configurado—,
+   * pero la incoherencia se activaría sola el día que se ofrezcan pruebas.
+   */
+  it('confirma el upgrade que Stripe deja en trialing', async () => {
+    const { service, updateUser } = buildService({
+      subscription: {
+        status: 'trialing',
+        items: { data: [{ id: 'si_123', price: { id: PRO_MXN } }] },
+      },
+      updateResult: { status: 'trialing', id: 'sub_123' },
+    });
+
+    await expect(
+      service.upgradeSubscription('uid-1', 'promax'),
+    ).resolves.toEqual(expect.objectContaining({ success: true }));
+    expect(escriturasDePlan(updateUser)).toHaveLength(1);
+  });
+
   it('no marca el plan si la suscripción no queda activa tras el cambio', async () => {
     const { service, updateUser } = buildService({
       subscription: activeSubscription,
@@ -1331,6 +1358,7 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
       id: 'sub_123',
       status,
       customer: 'cus_123',
+      latest_invoice: 'in_123',
       items: { data: [{ id: 'si_1', price: { id: priceId } }] },
     };
   }
@@ -1377,8 +1405,19 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
       .fn()
       .mockResolvedValue(undefined);
 
+    // La degradación por impago liquida el contrato en Stripe antes de escribir,
+    // así que estos webhooks también pasan por facturas y cancelación.
+    const cancel = jest.fn().mockResolvedValue({ status: 'canceled' });
+    const voidInvoice = jest.fn().mockResolvedValue({ status: 'void' });
+    const invoiceRetrieve = jest
+      .fn()
+      .mockResolvedValue({ id: 'in_123', status: 'open' });
+
     const service: any = Object.create(PaymentsService.prototype);
-    service.stripe = { subscriptions: { retrieve } };
+    service.stripe = {
+      subscriptions: { retrieve, cancel },
+      invoices: { retrieve: invoiceRetrieve, voidInvoice },
+    };
     service.firestoreService = {
       getUserByStripeCustomerId,
       getUserById,
@@ -1401,6 +1440,9 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
       acquireSubscriptionSyncLock,
       releaseSubscriptionSyncLock,
       getUserById,
+      cancel,
+      voidInvoice,
+      invoiceRetrieve,
     };
   }
 
@@ -1520,6 +1562,57 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
       expect.any(Date),
       'tok-1',
     );
+  });
+
+  /**
+   * Limpiar el ID sin cancelar en Stripe dejaba el contrato vivo y sin dueño. Si
+   * este evento se adelantaba a `invoice.payment_failed`, el usuario contrataba de
+   * nuevo —la defensa por customer solo lista `active`, así que no veía la
+   * impagada— y el `payment_failed` posterior descartaba el evento por apuntar a
+   * otro contrato. El viejo sobrevivía y Stripe aún podía cobrarlo.
+   */
+  it('cancela el contrato en Stripe antes de soltar el ID en past_due', async () => {
+    const { service, cancel, voidInvoice, updateUserSubscriptionState } =
+      buildService({ current: subscriptionCon(PRO_MXN, 'past_due') });
+
+    await service.handleSubscriptionUpdated(
+      subscriptionCon(PRO_MXN, 'past_due'),
+    );
+
+    expect(voidInvoice).toHaveBeenCalledWith('in_123');
+    expect(cancel).toHaveBeenCalledWith('sub_123');
+    // Nunca al revés: soltar el ID sin haber cerrado el contrato es lo que
+    // permitía la segunda suscripción cobrable.
+    expect(cancel.mock.invocationCallOrder[0]).toBeLessThan(
+      updateUserSubscriptionState.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('no degrada si la factura se cobró entre el evento y el proceso', async () => {
+    const { service, cancel, updateUserSubscriptionState, invoiceRetrieve } =
+      buildService({ current: subscriptionCon(PRO_MXN, 'past_due') });
+    invoiceRetrieve.mockResolvedValue({ id: 'in_123', status: 'paid' });
+
+    await service.handleSubscriptionUpdated(
+      subscriptionCon(PRO_MXN, 'past_due'),
+    );
+
+    expect(cancel).not.toHaveBeenCalled();
+    expect(updateUserSubscriptionState).not.toHaveBeenCalled();
+  });
+
+  it('no toca Stripe cuando el contrato ya está canceled', async () => {
+    const { service, voidInvoice, updateUserSubscriptionState } = buildService({
+      current: subscriptionCon(PRO_MXN, 'canceled'),
+    });
+
+    await service.handleSubscriptionUpdated(
+      subscriptionCon(PRO_MXN, 'canceled'),
+    );
+
+    // `canceled` es terminal: no hay nada que liquidar, solo degradar.
+    expect(voidInvoice).not.toHaveBeenCalled();
+    expect(updateUserSubscriptionState).toHaveBeenCalled();
   });
 
   /**
@@ -1999,7 +2092,12 @@ describe('PaymentsService — alta y baja bajo el mutex', () => {
   });
 
   it('la baja escribe el plan sellado, no con updateUser a secas', async () => {
-    const { service, updateUserSubscriptionState, updateUser } = buildService();
+    // El usuario tiene que llegar con plan de pago y su contrato: desde #65, un
+    // documento ya en Free y sin suscripción se trata como eco de una baja
+    // aplicada —lo produce la propia cancelación por impago— y no se reescribe.
+    const { service, updateUserSubscriptionState, updateUser } = buildService({
+      usuario: { id: 'uid-1', plan: 'pro', stripeSubscriptionId: 'sub_123' },
+    });
 
     await service.handleSubscriptionDeleted({
       id: 'sub_123',
@@ -2426,5 +2524,200 @@ describe('PaymentsService — createCheckoutSession con contrato impagado', () =
     ).rejects.toBeInstanceOf(BadRequestException);
     expect(cancel).not.toHaveBeenCalled();
     expect(sessionsCreate).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Regresiones del review del PR #84. Los tres primeros comparten raíz: las rutas
+ * de liquidación se escribieron dando por hecho que cada ciclo completa y que el
+ * orden de los webhooks da igual. Ninguna de las dos cosas se sostiene.
+ */
+describe('PaymentsService — liquidación reanudable y sin falsos positivos', () => {
+  function buildService(estadoFactura: string) {
+    const voidInvoice = jest.fn().mockResolvedValue({ status: 'void' });
+    const cancel = jest.fn().mockResolvedValue({ status: 'canceled' });
+
+    const service: any = Object.create(PaymentsService.prototype);
+    service.stripe = {
+      invoices: {
+        retrieve: jest
+          .fn()
+          .mockResolvedValue({ id: 'in_1', status: estadoFactura }),
+        voidInvoice,
+      },
+      subscriptions: {
+        retrieve: jest
+          .fn()
+          .mockResolvedValue({ id: 'sub_1', status: 'past_due' }),
+        cancel,
+      },
+    };
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+
+    return { service, voidInvoice, cancel };
+  }
+
+  it('remata la cancelación cuando un ciclo anterior ya anuló la factura', async () => {
+    const { service, voidInvoice, cancel } = buildService('void');
+
+    const liquidada = await service.liquidarSuscripcionImpagada(
+      'in_1',
+      'sub_1',
+      'test',
+    );
+
+    // La reentrega de Stripe encuentra la factura anulada por el ciclo que murió
+    // antes de cancelar. Abortar aquí dejaba el contrato vivo y sin cobro para
+    // siempre: no hay nada más que lo reintente.
+    expect(voidInvoice).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledWith('sub_1');
+    expect(liquidada).toBe(true);
+  });
+
+  it('trata uncollectible como deuda perdida, no como cobro', async () => {
+    const { service, cancel } = buildService('uncollectible');
+
+    await expect(
+      service.liquidarSuscripcionImpagada('in_1', 'sub_1', 'test'),
+    ).resolves.toBe(true);
+    expect(cancel).toHaveBeenCalled();
+  });
+
+  it('aborta solo cuando la factura está efectivamente pagada', async () => {
+    const { service, voidInvoice, cancel } = buildService('paid');
+
+    const liquidada = await service.liquidarSuscripcionImpagada(
+      'in_1',
+      'sub_1',
+      'test',
+    );
+
+    expect(voidInvoice).not.toHaveBeenCalled();
+    expect(cancel).not.toHaveBeenCalled();
+    expect(liquidada).toBe(false);
+  });
+});
+
+describe('PaymentsService — el checkout no cancela un contrato recuperado', () => {
+  const PRO_MXN = 'price_pro_mxn';
+
+  it('bloquea el alta si el cliente pagó mientras se liquidaba', async () => {
+    const userDoc = {
+      id: 'uid-1',
+      email: 'cliente@example.com',
+      plan: 'pro',
+      country: 'MX',
+      stripeCustomerId: 'cus_123',
+      stripeSubscriptionId: 'sub_vieja',
+    };
+    const cancel = jest.fn().mockResolvedValue({ status: 'canceled' });
+    const sessionsCreate = jest.fn();
+
+    const service: any = Object.create(PaymentsService.prototype);
+    service.stripe = {
+      subscriptions: {
+        // Primera lectura: past_due. La de dentro del bloqueo ya la ve viva.
+        retrieve: jest
+          .fn()
+          .mockResolvedValueOnce({
+            id: 'sub_vieja',
+            status: 'past_due',
+            latest_invoice: 'in_vieja',
+            items: { data: [{ id: 'si_1', price: { id: PRO_MXN } }] },
+          })
+          .mockResolvedValue({
+            id: 'sub_vieja',
+            status: 'active',
+            items: { data: [{ id: 'si_1', price: { id: PRO_MXN } }] },
+          }),
+        cancel,
+        list: jest.fn().mockResolvedValue({ data: [] }),
+      },
+      // El cliente pagó desde el portal entre la lectura y la liquidación.
+      invoices: {
+        retrieve: jest
+          .fn()
+          .mockResolvedValue({ id: 'in_vieja', status: 'paid' }),
+        voidInvoice: jest.fn(),
+      },
+      customers: { retrieve: jest.fn().mockResolvedValue({ id: 'cus_123' }) },
+      checkout: { sessions: { create: sessionsCreate } },
+    };
+    service.firestoreService = {
+      getUserById: jest.fn().mockResolvedValue(userDoc),
+      updateUser: jest.fn().mockResolvedValue(undefined),
+      updateUserSubscriptionState: jest.fn().mockResolvedValue(true),
+      acquireSubscriptionSyncLock: jest.fn().mockResolvedValue('tok-1'),
+      releaseSubscriptionSyncLock: jest.fn().mockResolvedValue(undefined),
+    };
+    service.billingService = {
+      syncTaxProfileToStripe: jest.fn().mockResolvedValue(undefined),
+    };
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    service.MAX_RETRIES = 3;
+    service.proPriceIdMxn = PRO_MXN;
+
+    await expect(
+      service.createCheckoutSession(
+        'uid-1',
+        'cliente@example.com',
+        'https://ok',
+        'https://ko',
+        'MX',
+        'promax',
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    // Ni se cancela la renovación que acaba de saldar, ni se le abre un segundo
+    // cobro el mismo día: se le remite al upgrade, como a cualquier contrato vivo.
+    expect(cancel).not.toHaveBeenCalled();
+    expect(sessionsCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('PaymentsService — el deleted que sigue a la cancelación por impago', () => {
+  const PRO_MXN = 'price_pro_mxn';
+
+  it('no vuelve a avisar ni a contar la baja si ya se degradó', async () => {
+    // Estado tras la degradación por impago: en Free y sin contrato. El `deleted`
+    // que llega es eco de la cancelación que lanzó el propio backend.
+    const usuario = {
+      id: 'uid-1',
+      email: 'cliente@example.com',
+      plan: 'free',
+      country: 'MX',
+      stripeSubscriptionId: null,
+    };
+    const queueSubscriptionDowngradedEmail = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    const saveSubscriptionEvent = jest.fn().mockResolvedValue(undefined);
+    const updateUserSubscriptionState = jest.fn().mockResolvedValue(true);
+
+    const service: any = Object.create(PaymentsService.prototype);
+    service.stripe = { subscriptions: { retrieve: jest.fn() } };
+    service.firestoreService = {
+      getUserByStripeCustomerId: jest.fn().mockResolvedValue(usuario),
+      getUserById: jest.fn().mockResolvedValue(usuario),
+      updateUserSubscriptionState,
+      saveSubscriptionEvent,
+      acquireSubscriptionSyncLock: jest.fn().mockResolvedValue('tok-1'),
+      releaseSubscriptionSyncLock: jest.fn().mockResolvedValue(undefined),
+    };
+    service.emailService = { queueSubscriptionDowngradedEmail };
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    service.MAX_RETRIES = 3;
+
+    await service.handleSubscriptionDeleted({
+      id: 'sub_123',
+      customer: 'cus_1',
+      items: { data: [{ price: { id: PRO_MXN } }] },
+    });
+
+    // Sin este corte el cliente recibía un segundo correo —nombrando PRO aunque
+    // fuera LITE, por el valor por defecto— y el churn se contaba dos veces.
+    expect(queueSubscriptionDowngradedEmail).not.toHaveBeenCalled();
+    expect(saveSubscriptionEvent).not.toHaveBeenCalled();
+    expect(updateUserSubscriptionState).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -1404,6 +1404,7 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
     const queueSubscriptionDowngradedEmail = jest
       .fn()
       .mockResolvedValue(undefined);
+    const saveSubscriptionEvent = jest.fn().mockResolvedValue(undefined);
 
     // La degradación por impago liquida el contrato en Stripe antes de escribir,
     // así que estos webhooks también pasan por facturas y cancelación.
@@ -1424,6 +1425,8 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
       updateUserSubscriptionState,
       acquireSubscriptionSyncLock,
       releaseSubscriptionSyncLock,
+      // La baja se contabiliza en el mismo punto que la escribe y la notifica.
+      saveSubscriptionEvent,
     };
     service.emailService = { queueSubscriptionDowngradedEmail };
     service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
@@ -1443,6 +1446,7 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
       cancel,
       voidInvoice,
       invoiceRetrieve,
+      saveSubscriptionEvent,
     };
   }
 
@@ -2209,6 +2213,7 @@ describe('PaymentsService — handlePaymentFailed', () => {
       .fn()
       .mockResolvedValue(undefined);
     const queuePaymentFailedEmail = jest.fn().mockResolvedValue(undefined);
+    const saveSubscriptionEvent = jest.fn().mockResolvedValue(undefined);
 
     const service: any = Object.create(PaymentsService.prototype);
     service.stripe = {
@@ -2221,6 +2226,7 @@ describe('PaymentsService — handlePaymentFailed', () => {
       updateUserSubscriptionState,
       acquireSubscriptionSyncLock: jest.fn().mockResolvedValue('tok-1'),
       releaseSubscriptionSyncLock: jest.fn().mockResolvedValue(undefined),
+      saveSubscriptionEvent,
     };
     service.emailService = {
       queueSubscriptionDowngradedEmail,
@@ -2236,6 +2242,7 @@ describe('PaymentsService — handlePaymentFailed', () => {
       updateUserSubscriptionState,
       queueSubscriptionDowngradedEmail,
       queuePaymentFailedEmail,
+      saveSubscriptionEvent,
     };
   }
 
@@ -2719,5 +2726,187 @@ describe('PaymentsService — el deleted que sigue a la cancelación por impago'
     expect(queueSubscriptionDowngradedEmail).not.toHaveBeenCalled();
     expect(saveSubscriptionEvent).not.toHaveBeenCalled();
     expect(updateUserSubscriptionState).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Segunda ronda del review del PR #84. Los dos primeros salen del mismo sitio:
+ * tres caminos observan la MISMA baja y cada uno traía su mezcla de escritura,
+ * aviso y registro. De ahí el correo por duplicado y la baja sin contabilizar.
+ */
+describe('PaymentsService — la baja se aplica, avisa y cuenta una sola vez', () => {
+  const PRO_MXN = 'price_pro_mxn';
+
+  function buildService(usuario: Record<string, unknown>) {
+    const queueSubscriptionDowngradedEmail = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    const saveSubscriptionEvent = jest.fn().mockResolvedValue(undefined);
+    const updateUserSubscriptionState = jest.fn().mockResolvedValue(true);
+
+    const service: any = Object.create(PaymentsService.prototype);
+    service.stripe = {
+      subscriptions: {
+        retrieve: jest.fn().mockResolvedValue({
+          id: 'sub_123',
+          status: 'past_due',
+          customer: 'cus_123',
+          latest_invoice: 'in_123',
+          items: { data: [{ id: 'si_1', price: { id: PRO_MXN } }] },
+        }),
+        cancel: jest.fn().mockResolvedValue({ status: 'canceled' }),
+      },
+      invoices: {
+        retrieve: jest.fn().mockResolvedValue({ id: 'in_123', status: 'open' }),
+        voidInvoice: jest.fn().mockResolvedValue({ status: 'void' }),
+      },
+    };
+    service.firestoreService = {
+      getUserByStripeCustomerId: jest.fn().mockResolvedValue(usuario),
+      getUserById: jest.fn().mockResolvedValue(usuario),
+      updateUserSubscriptionState,
+      saveSubscriptionEvent,
+      acquireSubscriptionSyncLock: jest.fn().mockResolvedValue('tok-1'),
+      releaseSubscriptionSyncLock: jest.fn().mockResolvedValue(undefined),
+    };
+    service.emailService = { queueSubscriptionDowngradedEmail };
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    service.MAX_RETRIES = 3;
+    service.proPriceIdMxn = PRO_MXN;
+
+    return {
+      service,
+      queueSubscriptionDowngradedEmail,
+      saveSubscriptionEvent,
+      updateUserSubscriptionState,
+    };
+  }
+
+  const conPlan = {
+    id: 'uid-1',
+    email: 'cliente@example.com',
+    plan: 'lite',
+    country: 'MX',
+    stripeSubscriptionId: 'sub_123',
+  };
+
+  const yaDegradado = {
+    id: 'uid-1',
+    email: 'cliente@example.com',
+    plan: 'free',
+    country: 'MX',
+    stripeSubscriptionId: null,
+  };
+
+  const eventoPastDue = {
+    id: 'sub_123',
+    status: 'past_due',
+    customer: 'cus_123',
+    latest_invoice: 'in_123',
+    items: { data: [{ id: 'si_1', price: { id: PRO_MXN } }] },
+  };
+
+  it('contabiliza la baja por impago, que antes no registraba ningún camino', async () => {
+    const { service, saveSubscriptionEvent } = buildService(conPlan);
+
+    await service.handlePaymentFailed({
+      id: 'in_123',
+      customer: 'cus_123',
+      billing_reason: 'subscription_cycle',
+      parent: { subscription_details: { subscription: 'sub_123' } },
+    });
+
+    expect(saveSubscriptionEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'churned',
+        // El plan sale del documento: con el valor por defecto se nombraba PRO
+        // a un cliente de LITE.
+        plan: 'lite',
+        cancellationReason: 'payment_failed',
+        currency: 'mxn',
+      }),
+    );
+  });
+
+  it('el subscription.updated que sigue al impago no manda un segundo correo', async () => {
+    const { service, queueSubscriptionDowngradedEmail, saveSubscriptionEvent } =
+      buildService(yaDegradado);
+
+    await service.handleSubscriptionUpdated(eventoPastDue);
+
+    // Un impago genera payment_failed Y subscription.updated. Antes cada uno
+    // avisaba por su cuenta y el cliente recibía dos correos por una sola baja.
+    expect(queueSubscriptionDowngradedEmail).not.toHaveBeenCalled();
+    expect(saveSubscriptionEvent).not.toHaveBeenCalled();
+  });
+
+  it('si el updated llega primero, es él quien contabiliza la baja', async () => {
+    const { service, saveSubscriptionEvent, queueSubscriptionDowngradedEmail } =
+      buildService(conPlan);
+
+    await service.handleSubscriptionUpdated(eventoPastDue);
+
+    // El orden de los webhooks no lo decide nadie: gane quien gane, la baja
+    // tiene que quedar contada exactamente una vez.
+    expect(saveSubscriptionEvent).toHaveBeenCalledTimes(1);
+    expect(queueSubscriptionDowngradedEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('no cuenta la baja si el fencing descarta la escritura', async () => {
+    const { service, saveSubscriptionEvent, updateUserSubscriptionState } =
+      buildService(conPlan);
+    updateUserSubscriptionState.mockResolvedValue(false);
+
+    await service.handleSubscriptionUpdated(eventoPastDue);
+
+    // Sin baja escrita no hay baja que contar: registrarla inflaría el churn con
+    // clientes que siguen pagando.
+    expect(saveSubscriptionEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('PaymentsService — reconciliación de un upgrade en trialing', () => {
+  it('reconoce aplicado el cambio que Stripe dejó en trialing', async () => {
+    const service: any = Object.create(PaymentsService.prototype);
+    const updateUserSubscriptionState = jest.fn().mockResolvedValue(true);
+
+    service.stripe = {
+      subscriptions: {
+        retrieve: jest.fn().mockResolvedValue({
+          id: 'sub_123',
+          status: 'trialing',
+          items: { data: [{ id: 'si_1', price: { id: 'price_promax' } }] },
+        }),
+      },
+    };
+    service.firestoreService = {
+      renewSubscriptionSyncLock: jest.fn().mockResolvedValue(true),
+      updateUserSubscriptionState,
+    };
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    service.MAX_RETRIES = 3;
+
+    const res = await service.reconcileIndeterminateUpgrade(
+      Object.assign(new Error('timeout'), { type: 'StripeConnectionError' }),
+      'uid-1',
+      'promax',
+      'sub_123',
+      'price_promax',
+      'ctx',
+      'tok-1',
+      'idem-1',
+    );
+
+    // Es el camino que repara el desenlace indeterminado. Comparando contra
+    // `active` a secas daba por no aplicado un upgrade que sí se hizo, y el
+    // cliente quedaba con el precio nuevo en Stripe y el plan viejo en el
+    // producto, sin nada que lo corrigiera después.
+    expect(res).toEqual(expect.objectContaining({ success: true }));
+    expect(updateUserSubscriptionState).toHaveBeenCalledWith(
+      'uid-1',
+      { plan: 'promax' },
+      expect.any(Date),
+      'tok-1',
+    );
   });
 });

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -1191,14 +1191,18 @@ describe('PaymentsService — upgradeSubscription', () => {
     expect(escriturasDePlan(updateUser)).toHaveLength(0);
   });
 
-  it('en un estado de cobro pide actualizar el método de pago', async () => {
+  // Antes de #65 este caso pedía actualizar la tarjeta. Ya no: el contrato
+  // impagado se cancela en cuanto falla el cobro, así que no queda suscripción
+  // que rescatar con una tarjeta nueva y la única salida real es contratar de
+  // nuevo — que es adonde apunta el mensaje, y por donde el checkout ya deja pasar.
+  it('en un estado de cobro manda a contratar de nuevo, no a cambiar la tarjeta', async () => {
     const { service, update } = buildService({
       subscription: { status: 'past_due', items: { data: [{ id: 'si_123' }] } },
     });
 
     await expect(
       service.upgradeSubscription('uid-1', 'promax'),
-    ).rejects.toThrow(/past_due.*payment method/s);
+    ).rejects.toThrow(/past_due.*subscribe again/s);
     expect(update).not.toHaveBeenCalled();
   });
 
@@ -1491,6 +1495,30 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
       expect.objectContaining({ id: 'uid-1' }),
       'promax',
       'canceled',
+    );
+  });
+
+  /**
+   * Antes de #65, `past_due` tenía su propia rama que conservaba el plan y
+   * reescribía el `stripeSubscriptionId`. Llegando después de que
+   * `handlePaymentFailed` degradara, restauraba el contrato que aquel acababa de
+   * limpiar —y el sello no lo frenaba, porque es una lectura genuinamente
+   * posterior—. Degradando también aquí, el orden de llegada deja de importar.
+   */
+  it('degrada a Free en past_due en vez de conservar el plan sin cobro', async () => {
+    const { service, updateUserSubscriptionState } = buildService({
+      current: subscriptionCon(PRO_MXN, 'past_due'),
+    });
+
+    await service.handleSubscriptionUpdated(
+      subscriptionCon(PRO_MXN, 'past_due'),
+    );
+
+    expect(updateUserSubscriptionState).toHaveBeenCalledWith(
+      'uid-1',
+      { plan: 'free', stripeSubscriptionId: null },
+      expect.any(Date),
+      'tok-1',
     );
   });
 
@@ -2029,5 +2057,374 @@ describe('PaymentsService — alta y baja bajo el mutex', () => {
       }),
     ).rejects.toBeInstanceOf(ConflictException);
     expect(updateUserSubscriptionState).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Política de cobro de #65: el primer cobro fallido de una RENOVACIÓN cancela el
+ * contrato y devuelve al cliente a Free, sin dejar factura impagada detrás.
+ *
+ * Lo que más se prueba aquí no es el camino feliz sino los tres frenos, porque
+ * cancelar de más le quita a alguien algo que pagó: que un upgrade fallido no
+ * toque la suscripción vigente, que una factura ya cobrada detenga todo, y que
+ * la factura de un contrato anterior no se lleve por delante al que está vivo.
+ */
+describe('PaymentsService — handlePaymentFailed', () => {
+  function facturaDeRenovacion(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 'in_123',
+      customer: 'cus_123',
+      billing_reason: 'subscription_cycle',
+      attempt_count: 1,
+      parent: { subscription_details: { subscription: 'sub_123' } },
+      ...overrides,
+    };
+  }
+
+  function buildService(overrides: {
+    /** Estado de la factura al releerla en Stripe (el payload puede estar viejo). */
+    estadoFactura?: string;
+    user?: Record<string, unknown>;
+    /** Estado de la suscripción al releerla antes de cancelar. */
+    estadoSuscripcion?: string;
+  }) {
+    const usuario = overrides.user ?? {
+      id: 'uid-1',
+      email: 'cliente@example.com',
+      plan: 'pro',
+      country: 'MX',
+      stripeSubscriptionId: 'sub_123',
+    };
+
+    const invoiceRetrieve = jest.fn().mockResolvedValue({
+      id: 'in_123',
+      status: overrides.estadoFactura ?? 'open',
+    });
+    const voidInvoice = jest.fn().mockResolvedValue({ status: 'void' });
+    const subscriptionRetrieve = jest.fn().mockResolvedValue({
+      id: 'sub_123',
+      status: overrides.estadoSuscripcion ?? 'past_due',
+    });
+    const cancel = jest.fn().mockResolvedValue({ status: 'canceled' });
+    const updateUserSubscriptionState = jest.fn().mockResolvedValue(true);
+    const queueSubscriptionDowngradedEmail = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    const queuePaymentFailedEmail = jest.fn().mockResolvedValue(undefined);
+
+    const service: any = Object.create(PaymentsService.prototype);
+    service.stripe = {
+      invoices: { retrieve: invoiceRetrieve, voidInvoice },
+      subscriptions: { retrieve: subscriptionRetrieve, cancel },
+    };
+    service.firestoreService = {
+      getUserByStripeCustomerId: jest.fn().mockResolvedValue(usuario),
+      getUserById: jest.fn().mockResolvedValue(usuario),
+      updateUserSubscriptionState,
+      acquireSubscriptionSyncLock: jest.fn().mockResolvedValue('tok-1'),
+      releaseSubscriptionSyncLock: jest.fn().mockResolvedValue(undefined),
+    };
+    service.emailService = {
+      queueSubscriptionDowngradedEmail,
+      queuePaymentFailedEmail,
+    };
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    service.MAX_RETRIES = 3;
+
+    return {
+      service,
+      voidInvoice,
+      cancel,
+      updateUserSubscriptionState,
+      queueSubscriptionDowngradedEmail,
+      queuePaymentFailedEmail,
+    };
+  }
+
+  it('anula la factura, cancela la suscripción y deja al usuario en Free', async () => {
+    const {
+      service,
+      voidInvoice,
+      cancel,
+      updateUserSubscriptionState,
+      queueSubscriptionDowngradedEmail,
+    } = buildService({});
+
+    await service.handlePaymentFailed(facturaDeRenovacion());
+
+    expect(voidInvoice).toHaveBeenCalledWith('in_123');
+    expect(cancel).toHaveBeenCalledWith('sub_123');
+    expect(updateUserSubscriptionState).toHaveBeenCalledWith(
+      'uid-1',
+      { plan: 'free', stripeSubscriptionId: null },
+      expect.any(Date),
+      'tok-1',
+    );
+    expect(queueSubscriptionDowngradedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'uid-1' }),
+      'pro',
+      'payment_failed',
+    );
+  });
+
+  it('anula la factura antes de cancelar, para no dejar deuda sin plan', async () => {
+    const { service, voidInvoice, cancel } = buildService({});
+
+    await service.handlePaymentFailed(facturaDeRenovacion());
+
+    // Si fallara la cancelación queda un contrato sin deuda —recuperable—; al
+    // revés quedaría el cliente sin plan y con una factura viva persiguiéndole.
+    expect(voidInvoice.mock.invocationCallOrder[0]).toBeLessThan(
+      cancel.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('no toca la suscripción vigente si lo que falló fue la proración de un upgrade', async () => {
+    const { service, voidInvoice, cancel, updateUserSubscriptionState } =
+      buildService({});
+
+    await service.handlePaymentFailed(
+      facturaDeRenovacion({ billing_reason: 'subscription_update' }),
+    );
+
+    // El cliente tiene su plan al corriente: lo que no pudo pagar fue la mejora.
+    // Cancelar aquí le quitaría lo que sí pagó, y desharía el `pending_if_incomplete`
+    // con el que #73 protegió justamente este caso.
+    expect(voidInvoice).not.toHaveBeenCalled();
+    expect(cancel).not.toHaveBeenCalled();
+    expect(updateUserSubscriptionState).not.toHaveBeenCalled();
+  });
+
+  it('no degrada nada si lo que falló fue el primer cobro de un alta', async () => {
+    const { service, cancel, updateUserSubscriptionState } = buildService({});
+
+    await service.handlePaymentFailed(
+      facturaDeRenovacion({ billing_reason: 'subscription_create' }),
+    );
+
+    // No hay plan que quitar: nunca llegó a concederse.
+    expect(cancel).not.toHaveBeenCalled();
+    expect(updateUserSubscriptionState).not.toHaveBeenCalled();
+  });
+
+  it('no cancela si la factura ya se cobró entre el evento y el proceso', async () => {
+    const { service, voidInvoice, cancel, updateUserSubscriptionState } =
+      buildService({ estadoFactura: 'paid' });
+
+    await service.handlePaymentFailed(facturaDeRenovacion());
+
+    // El payload describe el instante del fallo; entre medias caben un reintento
+    // que sí cobró o el cliente pagando a mano. Cancelar sobre el payload le
+    // quitaría el plan a quien acaba de pagarlo.
+    expect(voidInvoice).not.toHaveBeenCalled();
+    expect(cancel).not.toHaveBeenCalled();
+    expect(updateUserSubscriptionState).not.toHaveBeenCalled();
+  });
+
+  it('ignora la factura de un contrato que el usuario ya sustituyó', async () => {
+    const { service, voidInvoice, updateUserSubscriptionState } = buildService({
+      user: {
+        id: 'uid-1',
+        email: 'cliente@example.com',
+        plan: 'pro',
+        country: 'MX',
+        stripeSubscriptionId: 'sub_nueva',
+      },
+    });
+
+    await service.handlePaymentFailed(facturaDeRenovacion());
+
+    expect(voidInvoice).not.toHaveBeenCalled();
+    expect(updateUserSubscriptionState).not.toHaveBeenCalled();
+  });
+
+  it('no avisa de la degradación si la escritura la ganó una lectura posterior', async () => {
+    const {
+      service,
+      updateUserSubscriptionState,
+      queueSubscriptionDowngradedEmail,
+    } = buildService({});
+    updateUserSubscriptionState.mockResolvedValue(false);
+
+    await service.handlePaymentFailed(facturaDeRenovacion());
+
+    expect(queueSubscriptionDowngradedEmail).not.toHaveBeenCalled();
+  });
+
+  it('no vuelve a cancelar una suscripción que Stripe ya cerró', async () => {
+    const { service, cancel, updateUserSubscriptionState } = buildService({
+      estadoSuscripcion: 'canceled',
+    });
+
+    await service.handlePaymentFailed(facturaDeRenovacion());
+
+    // Reentrega de Stripe: la anulación ya absorbe el caso normal, pero si la
+    // suscripción se cerró por otra vía tampoco hay que llamar de nuevo.
+    expect(cancel).not.toHaveBeenCalled();
+    // El plan sí se escribe: el cliente no está pagando.
+    expect(updateUserSubscriptionState).toHaveBeenCalled();
+  });
+});
+
+/**
+ * La salida del callejón de #65 vista desde el checkout: el cliente cuyo contrato
+ * quedó impagado tiene que poder contratar de nuevo, y hacerlo sin acabar con dos
+ * suscripciones vivas.
+ */
+describe('PaymentsService — createCheckoutSession con contrato impagado', () => {
+  const PRO_MXN = 'price_pro_mxn';
+
+  function buildService(overrides: {
+    /** Estado del contrato anterior en Stripe. */
+    estadoContrato?: string;
+    /** Plan que el documento de Firestore todavía refleja. */
+    planEnFirestore?: string;
+    cancelError?: unknown;
+  }) {
+    const userDoc: Record<string, unknown> = {
+      id: 'uid-1',
+      email: 'cliente@example.com',
+      plan: overrides.planEnFirestore ?? 'pro',
+      country: 'MX',
+      stripeCustomerId: 'cus_123',
+      stripeSubscriptionId: 'sub_vieja',
+    };
+
+    const subscriptionRetrieve = jest.fn().mockResolvedValue({
+      id: 'sub_vieja',
+      status: overrides.estadoContrato ?? 'past_due',
+      latest_invoice: 'in_vieja',
+      items: { data: [{ id: 'si_1', price: { id: PRO_MXN } }] },
+    });
+    const cancel = overrides.cancelError
+      ? jest.fn().mockRejectedValue(overrides.cancelError)
+      : jest.fn().mockResolvedValue({ status: 'canceled' });
+    const voidInvoice = jest.fn().mockResolvedValue({ status: 'void' });
+    const sessionsCreate = jest
+      .fn()
+      .mockResolvedValue({ url: 'https://checkout', id: 'cs_1' });
+
+    const updateUserSubscriptionState = jest
+      .fn()
+      .mockImplementation(async (_id: string, data: object) => {
+        Object.assign(userDoc, data);
+        return true;
+      });
+
+    const service: any = Object.create(PaymentsService.prototype);
+    service.stripe = {
+      subscriptions: {
+        retrieve: subscriptionRetrieve,
+        cancel,
+        list: jest.fn().mockResolvedValue({ data: [] }),
+      },
+      invoices: {
+        retrieve: jest
+          .fn()
+          .mockResolvedValue({ id: 'in_vieja', status: 'open' }),
+        voidInvoice,
+      },
+      customers: { retrieve: jest.fn().mockResolvedValue({ id: 'cus_123' }) },
+      checkout: { sessions: { create: sessionsCreate } },
+    };
+    service.firestoreService = {
+      getUserById: jest.fn().mockImplementation(async () => ({ ...userDoc })),
+      updateUser: jest.fn().mockResolvedValue(undefined),
+      updateUserSubscriptionState,
+      acquireSubscriptionSyncLock: jest.fn().mockResolvedValue('tok-1'),
+      releaseSubscriptionSyncLock: jest.fn().mockResolvedValue(undefined),
+    };
+    service.billingService = {
+      syncTaxProfileToStripe: jest.fn().mockResolvedValue(undefined),
+    };
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    service.MAX_RETRIES = 3;
+    service.proPriceIdMxn = PRO_MXN;
+    service.proPriceId = 'price_pro_usd';
+
+    return {
+      service,
+      cancel,
+      voidInvoice,
+      sessionsCreate,
+      updateUserSubscriptionState,
+    };
+  }
+
+  it('liquida el contrato impagado y deja continuar el alta', async () => {
+    const { service, cancel, voidInvoice, sessionsCreate } = buildService({});
+
+    const res = await service.createCheckoutSession(
+      'uid-1',
+      'cliente@example.com',
+      'https://ok',
+      'https://ko',
+      'MX',
+      'pro',
+    );
+
+    expect(voidInvoice).toHaveBeenCalledWith('in_vieja');
+    expect(cancel).toHaveBeenCalledWith('sub_vieja');
+    expect(sessionsCreate).toHaveBeenCalled();
+    expect(res.checkoutUrl).toBe('https://checkout');
+  });
+
+  it('deja recontratar EL MISMO plan que quedó impagado', async () => {
+    // El documento sigue diciendo `pro` porque el webhook de degradación aún no
+    // ha llegado. Comprobando el plan antes que Stripe, este cliente salía
+    // rechazado por «ya estás suscrito» y no tenía forma de volver a pagar.
+    const { service, sessionsCreate } = buildService({
+      planEnFirestore: 'pro',
+    });
+
+    await service.createCheckoutSession(
+      'uid-1',
+      'cliente@example.com',
+      'https://ok',
+      'https://ko',
+      'MX',
+      'pro',
+    );
+
+    expect(sessionsCreate).toHaveBeenCalled();
+  });
+
+  it('bloquea el alta si no consigue cerrar el contrato impagado', async () => {
+    const { service, sessionsCreate } = buildService({
+      cancelError: new Error('Stripe caído'),
+    });
+
+    // Seguir adelante dejaría al cliente con dos suscripciones vivas: es peor
+    // que pedirle que reintente.
+    await expect(
+      service.createCheckoutSession(
+        'uid-1',
+        'cliente@example.com',
+        'https://ok',
+        'https://ko',
+        'MX',
+        'pro',
+      ),
+    ).rejects.toBeInstanceOf(ServiceUnavailableException);
+    expect(sessionsCreate).not.toHaveBeenCalled();
+  });
+
+  it('sigue bloqueando el alta duplicada sobre un contrato vivo', async () => {
+    const { service, cancel, sessionsCreate } = buildService({
+      estadoContrato: 'active',
+    });
+
+    await expect(
+      service.createCheckoutSession(
+        'uid-1',
+        'cliente@example.com',
+        'https://ok',
+        'https://ko',
+        'MX',
+        'pro',
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(cancel).not.toHaveBeenCalled();
+    expect(sessionsCreate).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -1565,6 +1565,7 @@ describe('PaymentsService — handleSubscriptionUpdated', () => {
       { plan: 'free', stripeSubscriptionId: null },
       expect.any(Date),
       'tok-1',
+      expect.objectContaining({ eventType: 'churned' }),
     );
   });
 
@@ -2114,6 +2115,8 @@ describe('PaymentsService — alta y baja bajo el mutex', () => {
       expect.objectContaining({ plan: 'free' }),
       expect.any(Date),
       'tok-1',
+      // La baja se contabiliza en la misma transacción que la escribe.
+      expect.objectContaining({ eventType: 'canceled' }),
     );
     // Sin sello ni token, podía pisar un upgrade recién confirmado.
     expect(
@@ -2259,11 +2262,14 @@ describe('PaymentsService — handlePaymentFailed', () => {
 
     expect(voidInvoice).toHaveBeenCalledWith('in_123');
     expect(cancel).toHaveBeenCalledWith('sub_123');
+    // La baja y su registro viajan en la MISMA transacción: el evento es el
+    // quinto argumento, no una escritura posterior que pudiera perderse.
     expect(updateUserSubscriptionState).toHaveBeenCalledWith(
       'uid-1',
       { plan: 'free', stripeSubscriptionId: null },
       expect.any(Date),
       'tok-1',
+      expect.objectContaining({ eventType: 'churned', plan: 'pro' }),
     );
     expect(queueSubscriptionDowngradedEmail).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'uid-1' }),
@@ -2807,7 +2813,7 @@ describe('PaymentsService — la baja se aplica, avisa y cuenta una sola vez', (
   };
 
   it('contabiliza la baja por impago, que antes no registraba ningún camino', async () => {
-    const { service, saveSubscriptionEvent } = buildService(conPlan);
+    const { service, updateUserSubscriptionState } = buildService(conPlan);
 
     await service.handlePaymentFailed({
       id: 'in_123',
@@ -2816,7 +2822,14 @@ describe('PaymentsService — la baja se aplica, avisa y cuenta una sola vez', (
       parent: { subscription_details: { subscription: 'sub_123' } },
     });
 
-    expect(saveSubscriptionEvent).toHaveBeenCalledWith(
+    // El evento viaja DENTRO de la transacción que degrada, no en una escritura
+    // posterior: si esta fallaba, la reentrega veía al usuario ya en Free, lo
+    // tomaba por trabajo hecho y la baja no se contabilizaba nunca.
+    expect(updateUserSubscriptionState).toHaveBeenCalledWith(
+      'uid-1',
+      { plan: 'free', stripeSubscriptionId: null },
+      expect.any(Date),
+      'tok-1',
       expect.objectContaining({
         eventType: 'churned',
         // El plan sale del documento: con el valor por defecto se nombraba PRO
@@ -2841,14 +2854,20 @@ describe('PaymentsService — la baja se aplica, avisa y cuenta una sola vez', (
   });
 
   it('si el updated llega primero, es él quien contabiliza la baja', async () => {
-    const { service, saveSubscriptionEvent, queueSubscriptionDowngradedEmail } =
-      buildService(conPlan);
+    const {
+      service,
+      updateUserSubscriptionState,
+      queueSubscriptionDowngradedEmail,
+    } = buildService(conPlan);
 
     await service.handleSubscriptionUpdated(eventoPastDue);
 
     // El orden de los webhooks no lo decide nadie: gane quien gane, la baja
     // tiene que quedar contada exactamente una vez.
-    expect(saveSubscriptionEvent).toHaveBeenCalledTimes(1);
+    expect(updateUserSubscriptionState).toHaveBeenCalledTimes(1);
+    expect(updateUserSubscriptionState.mock.calls[0][4]).toEqual(
+      expect.objectContaining({ eventType: 'churned' }),
+    );
     expect(queueSubscriptionDowngradedEmail).toHaveBeenCalledTimes(1);
   });
 
@@ -2860,7 +2879,8 @@ describe('PaymentsService — la baja se aplica, avisa y cuenta una sola vez', (
     await service.handleSubscriptionUpdated(eventoPastDue);
 
     // Sin baja escrita no hay baja que contar: registrarla inflaría el churn con
-    // clientes que siguen pagando.
+    // clientes que siguen pagando. Lo garantiza la transacción — el evento entra
+    // en ella, así que un fencing que descarte la escritura lo descarta también.
     expect(saveSubscriptionEvent).not.toHaveBeenCalled();
   });
 });
@@ -2907,6 +2927,113 @@ describe('PaymentsService — reconciliación de un upgrade en trialing', () => 
       { plan: 'promax' },
       expect.any(Date),
       'tok-1',
+    );
+  });
+});
+
+/**
+ * Tercera ronda del review del PR #84.
+ */
+describe('PaymentsService — el webhook repara también trialing', () => {
+  const PROMAX_MXN = 'price_promax_mxn';
+
+  it('escribe el plan cuando Stripe tiene la suscripción en trialing', async () => {
+    const usuario = {
+      id: 'uid-1',
+      email: 'cliente@example.com',
+      plan: 'pro',
+      country: 'MX',
+      stripeSubscriptionId: 'sub_123',
+    };
+    const updateUserSubscriptionState = jest.fn().mockResolvedValue(true);
+    const enTrial = {
+      id: 'sub_123',
+      status: 'trialing',
+      customer: 'cus_123',
+      items: { data: [{ id: 'si_1', price: { id: PROMAX_MXN } }] },
+    };
+
+    const service: any = Object.create(PaymentsService.prototype);
+    service.stripe = {
+      subscriptions: { retrieve: jest.fn().mockResolvedValue(enTrial) },
+    };
+    service.firestoreService = {
+      getUserByStripeCustomerId: jest.fn().mockResolvedValue(usuario),
+      getUserById: jest.fn().mockResolvedValue(usuario),
+      updateUserSubscriptionState,
+      acquireSubscriptionSyncLock: jest.fn().mockResolvedValue('tok-1'),
+      releaseSubscriptionSyncLock: jest.fn().mockResolvedValue(undefined),
+    };
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    service.MAX_RETRIES = 3;
+    service.promaxPriceIdMxn = PROMAX_MXN;
+
+    await service.handleSubscriptionUpdated(enTrial);
+
+    // Este webhook es el que repara un upgrade que Stripe aplicó pero Firestore
+    // no llegó a guardar. Comparando contra `active` a secas, `trialing` no
+    // entraba en ninguna rama —ni escribía plan ni degradaba— y el fallo del
+    // camino principal quedaba sin nada que lo corrigiera después.
+    expect(updateUserSubscriptionState).toHaveBeenCalledWith(
+      'uid-1',
+      expect.objectContaining({ plan: 'promax' }),
+      expect.any(Date),
+      'tok-1',
+    );
+  });
+});
+
+describe('PaymentsService — subscription.deleted usa el mismo punto único', () => {
+  const PRO_MXN = 'price_pro_mxn';
+
+  it('registra la baja con los datos del usuario, no con valores de relleno', async () => {
+    const usuario = {
+      id: 'uid-1',
+      email: 'cliente@example.com',
+      plan: 'lite',
+      country: 'MX',
+      stripeSubscriptionId: 'sub_123',
+    };
+    const updateUserSubscriptionState = jest.fn().mockResolvedValue(true);
+
+    const service: any = Object.create(PaymentsService.prototype);
+    service.stripe = { subscriptions: { retrieve: jest.fn() } };
+    service.firestoreService = {
+      getUserByStripeCustomerId: jest.fn().mockResolvedValue(usuario),
+      getUserById: jest.fn().mockResolvedValue(usuario),
+      updateUserSubscriptionState,
+      saveSubscriptionEvent: jest.fn().mockResolvedValue(undefined),
+      acquireSubscriptionSyncLock: jest.fn().mockResolvedValue('tok-1'),
+      releaseSubscriptionSyncLock: jest.fn().mockResolvedValue(undefined),
+    };
+    service.emailService = {
+      queueSubscriptionDowngradedEmail: jest.fn().mockResolvedValue(undefined),
+    };
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    service.MAX_RETRIES = 3;
+
+    await service.handleSubscriptionDeleted({
+      id: 'sub_123',
+      customer: 'cus_1',
+      cancellation_details: { reason: 'cancellation_requested' },
+      items: { data: [{ price: { id: PRO_MXN } }] },
+    });
+
+    // Este camino tenía su propia copia de degradar-avisar-registrar, con sus
+    // propios valores por defecto: moneda `usd` fija y plan de relleno. Ahora
+    // entra por el mismo helper, así que la moneda sale del país y el plan del
+    // documento, y la razón de Stripe se conserva.
+    expect(updateUserSubscriptionState).toHaveBeenCalledWith(
+      'uid-1',
+      { plan: 'free', stripeSubscriptionId: null },
+      expect.any(Date),
+      'tok-1',
+      expect.objectContaining({
+        eventType: 'canceled',
+        plan: 'lite',
+        currency: 'mxn',
+        cancellationReason: 'cancellation_requested',
+      }),
     );
   });
 });

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -2181,6 +2181,8 @@ describe('PaymentsService — handlePaymentFailed', () => {
       customer: 'cus_123',
       billing_reason: 'subscription_cycle',
       attempt_count: 1,
+      amount_due: 19900,
+      currency: 'mxn',
       parent: { subscription_details: { subscription: 'sub_123' } },
       ...overrides,
     };
@@ -2269,7 +2271,13 @@ describe('PaymentsService — handlePaymentFailed', () => {
       { plan: 'free', stripeSubscriptionId: null },
       expect.any(Date),
       'tok-1',
-      expect.objectContaining({ eventType: 'churned', plan: 'pro' }),
+      expect.objectContaining({
+        eventType: 'churned',
+        plan: 'pro',
+        currency: 'mxn',
+        mrr: 199,
+        mrrMxn: 199,
+      }),
     );
     expect(queueSubscriptionDowngradedEmail).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'uid-1' }),
@@ -2405,7 +2413,14 @@ describe('PaymentsService — createCheckoutSession con contrato impagado', () =
       id: 'sub_vieja',
       status: overrides.estadoContrato ?? 'past_due',
       latest_invoice: 'in_vieja',
-      items: { data: [{ id: 'si_1', price: { id: PRO_MXN } }] },
+      items: {
+        data: [
+          {
+            id: 'si_1',
+            price: { id: PRO_MXN, currency: 'mxn', unit_amount: 19900 },
+          },
+        ],
+      },
     });
     const cancel = overrides.cancelError
       ? jest.fn().mockRejectedValue(overrides.cancelError)
@@ -2414,6 +2429,9 @@ describe('PaymentsService — createCheckoutSession con contrato impagado', () =
     const sessionsCreate = jest
       .fn()
       .mockResolvedValue({ url: 'https://checkout', id: 'cs_1' });
+    const queueSubscriptionDowngradedEmail = jest
+      .fn()
+      .mockResolvedValue(undefined);
 
     const updateUserSubscriptionState = jest
       .fn()
@@ -2448,6 +2466,7 @@ describe('PaymentsService — createCheckoutSession con contrato impagado', () =
     service.billingService = {
       syncTaxProfileToStripe: jest.fn().mockResolvedValue(undefined),
     };
+    service.emailService = { queueSubscriptionDowngradedEmail };
     service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
     service.MAX_RETRIES = 3;
     service.proPriceIdMxn = PRO_MXN;
@@ -2459,11 +2478,19 @@ describe('PaymentsService — createCheckoutSession con contrato impagado', () =
       voidInvoice,
       sessionsCreate,
       updateUserSubscriptionState,
+      queueSubscriptionDowngradedEmail,
     };
   }
 
   it('liquida el contrato impagado y deja continuar el alta', async () => {
-    const { service, cancel, voidInvoice, sessionsCreate } = buildService({});
+    const {
+      service,
+      cancel,
+      voidInvoice,
+      sessionsCreate,
+      updateUserSubscriptionState,
+      queueSubscriptionDowngradedEmail,
+    } = buildService({});
 
     const res = await service.createCheckoutSession(
       'uid-1',
@@ -2476,6 +2503,18 @@ describe('PaymentsService — createCheckoutSession con contrato impagado', () =
 
     expect(voidInvoice).toHaveBeenCalledWith('in_vieja');
     expect(cancel).toHaveBeenCalledWith('sub_vieja');
+    expect(updateUserSubscriptionState).toHaveBeenCalledWith(
+      'uid-1',
+      { plan: 'free', stripeSubscriptionId: null },
+      expect.any(Date),
+      'tok-1',
+      expect.objectContaining({
+        eventType: 'churned',
+        mrr: 199,
+        mrrMxn: 199,
+      }),
+    );
+    expect(queueSubscriptionDowngradedEmail).toHaveBeenCalledTimes(1);
     expect(sessionsCreate).toHaveBeenCalled();
     expect(res.checkoutUrl).toBe('https://checkout');
   });
@@ -2517,6 +2556,25 @@ describe('PaymentsService — createCheckoutSession con contrato impagado', () =
         'pro',
       ),
     ).rejects.toBeInstanceOf(ServiceUnavailableException);
+    expect(sessionsCreate).not.toHaveBeenCalled();
+  });
+
+  it('detiene el alta si el fencing rechaza registrar la baja', async () => {
+    const { service, sessionsCreate, updateUserSubscriptionState } =
+      buildService({});
+    updateUserSubscriptionState.mockResolvedValue(false);
+
+    await expect(
+      service.createCheckoutSession(
+        'uid-1',
+        'cliente@example.com',
+        'https://ok',
+        'https://ko',
+        'MX',
+        'pro',
+      ),
+    ).rejects.toBeInstanceOf(ServiceUnavailableException);
+
     expect(sessionsCreate).not.toHaveBeenCalled();
   });
 
@@ -2758,7 +2816,14 @@ describe('PaymentsService — la baja se aplica, avisa y cuenta una sola vez', (
           status: 'past_due',
           customer: 'cus_123',
           latest_invoice: 'in_123',
-          items: { data: [{ id: 'si_1', price: { id: PRO_MXN } }] },
+          items: {
+            data: [
+              {
+                id: 'si_1',
+                price: { id: PRO_MXN, currency: 'mxn', unit_amount: 14900 },
+              },
+            ],
+          },
         }),
         cancel: jest.fn().mockResolvedValue({ status: 'canceled' }),
       },
@@ -2809,7 +2874,14 @@ describe('PaymentsService — la baja se aplica, avisa y cuenta una sola vez', (
     status: 'past_due',
     customer: 'cus_123',
     latest_invoice: 'in_123',
-    items: { data: [{ id: 'si_1', price: { id: PRO_MXN } }] },
+    items: {
+      data: [
+        {
+          id: 'si_1',
+          price: { id: PRO_MXN, currency: 'mxn', unit_amount: 14900 },
+        },
+      ],
+    },
   };
 
   it('contabiliza la baja por impago, que antes no registraba ningún camino', async () => {
@@ -2819,6 +2891,8 @@ describe('PaymentsService — la baja se aplica, avisa y cuenta una sola vez', (
       id: 'in_123',
       customer: 'cus_123',
       billing_reason: 'subscription_cycle',
+      amount_due: 14900,
+      currency: 'mxn',
       parent: { subscription_details: { subscription: 'sub_123' } },
     });
 
@@ -2837,6 +2911,8 @@ describe('PaymentsService — la baja se aplica, avisa y cuenta una sola vez', (
         plan: 'lite',
         cancellationReason: 'payment_failed',
         currency: 'mxn',
+        mrr: 149,
+        mrrMxn: 149,
       }),
     );
   });
@@ -2866,9 +2942,44 @@ describe('PaymentsService — la baja se aplica, avisa y cuenta una sola vez', (
     // tiene que quedar contada exactamente una vez.
     expect(updateUserSubscriptionState).toHaveBeenCalledTimes(1);
     expect(updateUserSubscriptionState.mock.calls[0][4]).toEqual(
-      expect.objectContaining({ eventType: 'churned' }),
+      expect.objectContaining({
+        eventType: 'churned',
+        mrr: 149,
+        mrrMxn: 149,
+      }),
     );
     expect(queueSubscriptionDowngradedEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('conserva payment_failed si el updated retrasado relee una cancelación por impago', async () => {
+    const {
+      service,
+      updateUserSubscriptionState,
+      queueSubscriptionDowngradedEmail,
+    } = buildService(conPlan);
+    service.stripe.subscriptions.retrieve.mockResolvedValue({
+      id: 'sub_123',
+      status: 'canceled',
+      customer: 'cus_123',
+      cancellation_details: { reason: 'payment_failed' },
+      items: eventoPastDue.items,
+    });
+
+    await service.handleSubscriptionUpdated(eventoPastDue);
+
+    expect(updateUserSubscriptionState.mock.calls[0][4]).toEqual(
+      expect.objectContaining({
+        eventType: 'churned',
+        cancellationReason: 'payment_failed',
+        mrr: 149,
+        mrrMxn: 149,
+      }),
+    );
+    expect(queueSubscriptionDowngradedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'uid-1' }),
+      'lite',
+      'payment_failed',
+    );
   });
 
   it('no cuenta la baja si el fencing descarta la escritura', async () => {
@@ -2986,7 +3097,7 @@ describe('PaymentsService — el webhook repara también trialing', () => {
 describe('PaymentsService — subscription.deleted usa el mismo punto único', () => {
   const PRO_MXN = 'price_pro_mxn';
 
-  it('registra la baja con los datos del usuario, no con valores de relleno', async () => {
+  it('registra la baja con los datos reales y conserva si fue por impago', async () => {
     const usuario = {
       id: 'uid-1',
       email: 'cliente@example.com',
@@ -3016,7 +3127,13 @@ describe('PaymentsService — subscription.deleted usa el mismo punto único', (
       id: 'sub_123',
       customer: 'cus_1',
       cancellation_details: { reason: 'cancellation_requested' },
-      items: { data: [{ price: { id: PRO_MXN } }] },
+      items: {
+        data: [
+          {
+            price: { id: PRO_MXN, currency: 'mxn', unit_amount: 19900 },
+          },
+        ],
+      },
     });
 
     // Este camino tenía su propia copia de degradar-avisar-registrar, con sus
@@ -3032,8 +3149,40 @@ describe('PaymentsService — subscription.deleted usa el mismo punto único', (
         eventType: 'canceled',
         plan: 'lite',
         currency: 'mxn',
+        mrr: 199,
+        mrrMxn: 199,
         cancellationReason: 'cancellation_requested',
       }),
+    );
+
+    updateUserSubscriptionState.mockClear();
+    service.emailService.queueSubscriptionDowngradedEmail.mockClear();
+
+    await service.handleSubscriptionDeleted({
+      id: 'sub_123',
+      customer: 'cus_1',
+      cancellation_details: { reason: 'payment_failed' },
+      items: {
+        data: [
+          {
+            price: { id: PRO_MXN, currency: 'mxn', unit_amount: 19900 },
+          },
+        ],
+      },
+    });
+
+    expect(updateUserSubscriptionState.mock.calls[0][4]).toEqual(
+      expect.objectContaining({
+        eventType: 'churned',
+        cancellationReason: 'payment_failed',
+      }),
+    );
+    expect(
+      service.emailService.queueSubscriptionDowngradedEmail,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'uid-1' }),
+      'lite',
+      'payment_failed',
     );
   });
 });

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -864,8 +864,15 @@ export class PaymentsService {
       this.throwPendingPaymentError(current, context);
     }
 
+    // Mismo criterio que autorizó el cambio y que lo confirma en el camino
+    // principal: si `trialing` basta para aplicar el upgrade, tiene que bastar
+    // para reconocerlo aplicado. Comparando contra `active` a secas, un upgrade
+    // hecho durante una prueba se daría por no aplicado justo aquí —en el camino
+    // que existe para reparar el desenlace indeterminado— y el cliente quedaría
+    // con el precio nuevo en Stripe y el plan viejo en el producto, sin nada que
+    // lo corrigiera después.
     const applied =
-      current.status === 'active' &&
+      PaymentsService.ESTADOS_MODIFICABLES.includes(current.status) &&
       current.items.data.some((item) => item.price?.id === expectedPriceId);
 
     if (!applied) {
@@ -2065,8 +2072,6 @@ export class PaymentsService {
       // Liquidando aquí también, los dos caminos convergen y el orden deja de
       // importar de verdad. La liquidación es reanudable e idempotente, así que
       // que ambos la ejecuten no duplica nada.
-      const previousPlan = user.plan || 'pro';
-
       if (PaymentsService.ESTADOS_IMPAGADOS.includes(current.status)) {
         const invoiceId =
           typeof current.latest_invoice === 'string'
@@ -2099,50 +2104,19 @@ export class PaymentsService {
         }
       }
 
-      const applied = await this.withRetry(
-        () =>
-          this.firestoreService.updateUserSubscriptionState(
-            user.id,
-            {
-              plan: 'free',
-              stripeSubscriptionId: null,
-            },
-            readAt,
-            lockToken,
-          ),
-        `handleSubscriptionUpdated(${user.id})`,
+      // Por el punto único: si el cobro fallido ya aplicó esta misma baja, aquí
+      // no se reescribe, no se manda un segundo correo y no se cuenta otra vez.
+      // Y si este camino llega primero, es este el que la contabiliza — antes no
+      // lo hacía ninguno de los dos y la baja podía no aparecer en el panel.
+      await this.registrarBajaDefinitiva(
+        user,
+        current.id,
+        PaymentsService.ESTADOS_IMPAGADOS.includes(current.status)
+          ? 'payment_failed'
+          : 'canceled',
+        readAt,
+        lockToken,
       );
-
-      // El email va atado a la escritura: avisar de una degradación que se
-      // descartó por obsoleta alarmaría a un cliente que sigue de pago.
-      if (!applied) {
-        this.logger.log(
-          `Downgrade descartado para user ${user.id}: el documento ya refleja una lectura posterior`,
-        );
-        return;
-      }
-
-      this.logger.log(
-        `Subscription updated for user ${user.id}: ${current.status}`,
-      );
-
-      // Send downgrade notification email
-      this.emailService
-        .queueSubscriptionDowngradedEmail(
-          {
-            id: user.id,
-            email: user.email,
-            displayName: user.displayName,
-            language: this.detectLanguageFromCountry(user.country),
-          },
-          previousPlan,
-          current.status,
-        )
-        .catch((err) =>
-          this.logger.error(
-            `Failed to queue subscription downgraded email: ${err.message}`,
-          ),
-        );
     }
   }
 
@@ -2322,6 +2296,114 @@ export class PaymentsService {
 
     await this.firestoreService.saveSubscriptionEvent(subscriptionEvent);
     this.logger.log(`Saved subscription event: canceled for user ${user.id}`);
+  }
+
+  /**
+   * Aplica una baja definitiva: degrada a Free, avisa al cliente y la contabiliza.
+   *
+   * Existe porque tres caminos distintos observan la MISMA baja —el cobro
+   * fallido, el `subscription.updated` que lo refleja y el `subscription.deleted`
+   * que provoca nuestra propia cancelación— y cada uno traía su mezcla de
+   * escritura, aviso y registro. De ahí salían los dos defectos que el review
+   * destapó: el cliente recibía un correo por cada camino, y la baja podía no
+   * contabilizarse en ninguno.
+   *
+   * Los tres pasos van juntos y una sola vez: **el primero que llega la aplica**
+   * y los demás la ven aplicada. El corte no es una marca aparte que mantener,
+   * sino el propio estado resultante —Free y sin contrato—, que ningún otro
+   * camino puede confundir con una baja pendiente.
+   *
+   * El aviso y el registro van atados a que la escritura se aplique de verdad:
+   * si el fencing la descarta por obsoleta, no hay baja que contar ni de la que
+   * avisar.
+   *
+   * @returns `true` si esta llamada fue la que aplicó la baja.
+   */
+  private async registrarBajaDefinitiva(
+    user: User,
+    subscriptionId: string,
+    motivo: 'payment_failed' | 'canceled',
+    readAt: Date,
+    lockToken: string,
+  ): Promise<boolean> {
+    if (user.plan === 'free' && !user.stripeSubscriptionId) {
+      this.logger.log(
+        `Baja de ${user.id} (${motivo}) ya aplicada por otro camino; no se ` +
+          `reescribe, ni se avisa, ni se cuenta dos veces.`,
+      );
+      return false;
+    }
+
+    // El plan que se pierde sale del documento, no del evento: es el que el
+    // cliente tenía reconocido y el que hay que nombrarle en el aviso.
+    const planPerdido: PaidPlanType =
+      user.plan === 'lite' ||
+      user.plan === 'pro' ||
+      user.plan === 'promax' ||
+      user.plan === 'enterprise'
+        ? user.plan
+        : 'pro';
+
+    const aplicado = await this.withRetry(
+      () =>
+        this.firestoreService.updateUserSubscriptionState(
+          user.id,
+          { plan: 'free', stripeSubscriptionId: null },
+          readAt,
+          lockToken,
+        ),
+      `registrarBajaDefinitiva(${user.id})`,
+    );
+
+    if (!aplicado) {
+      this.logger.log(
+        `Baja de ${user.id} (${motivo}) descartada: el documento ya refleja ` +
+          `una lectura posterior.`,
+      );
+      return false;
+    }
+
+    this.logger.warn(
+      `Baja aplicada para ${user.id}: ${planPerdido.toUpperCase()} → free (${motivo}).`,
+    );
+
+    this.emailService
+      .queueSubscriptionDowngradedEmail(
+        {
+          id: user.id,
+          email: user.email,
+          displayName: user.displayName,
+          language: this.detectLanguageFromCountry(user.country),
+        },
+        planPerdido,
+        motivo,
+      )
+      .catch((err) =>
+        this.logger.error(
+          `Failed to queue subscription downgraded email: ${err.message}`,
+        ),
+      );
+
+    // `churned` distingue la baja involuntaria de la que el cliente decide, y
+    // las métricas ya lo cuentan junto a `canceled` (`finance.service.ts`), así
+    // que separar no esconde ninguna baja del panel.
+    await this.firestoreService.saveSubscriptionEvent({
+      id: this.generateSubscriptionEventId(),
+      userId: user.id,
+      userEmail: user.email,
+      eventType: motivo === 'payment_failed' ? 'churned' : 'canceled',
+      plan: planPerdido,
+      previousPlan: planPerdido,
+      currency: user.country === 'MX' ? 'mxn' : 'usd',
+      mrr: 0,
+      mrrMxn: 0,
+      stripeSubscriptionId: subscriptionId,
+      cancellationReason: motivo,
+      country: user.country,
+      createdAt: new Date(),
+    });
+
+    return true;
   }
 
   /**
@@ -2599,57 +2681,22 @@ export class PaymentsService {
           return false;
         }
 
-        // El sello se toma tras liquidar en Stripe: es el instante que esta
-        // escritura describe, y dentro del lease no hay otro ciclo con el que
-        // competir.
-        const aplicado = await this.withRetry(
-          () =>
-            this.firestoreService.updateUserSubscriptionState(
-              fresh.id,
-              { plan: 'free', stripeSubscriptionId: null },
-              new Date(),
-              lockToken,
-            ),
-          `handlePaymentFailed(${fresh.id})`,
+        // Degradar, avisar y contabilizar van juntos y una sola vez. El sello se
+        // toma tras liquidar en Stripe: es el instante que esta escritura
+        // describe, y dentro del lease no hay otro ciclo con el que competir.
+        return this.registrarBajaDefinitiva(
+          fresh,
+          subscriptionId,
+          'payment_failed',
+          new Date(),
+          lockToken,
         );
-
-        if (!aplicado) {
-          this.logger.log(
-            `Degradación descartada: el documento ya refleja una lectura ` +
-              `posterior — ${contexto}.`,
-          );
-          return false;
-        }
-
-        this.logger.warn(
-          `Plan degradado a Free por renovación impagada — ${contexto}.`,
-        );
-        return true;
       },
     );
 
     if (!degradado) {
-      return;
+      this.logger.log(`Sin baja que aplicar en este ciclo — ${contexto}.`);
     }
-
-    // El aviso va atado a la escritura y fuera del lease: contar una degradación
-    // que no llegó a aplicarse alarmaría a un cliente que sigue de pago.
-    this.emailService
-      .queueSubscriptionDowngradedEmail(
-        {
-          id: user.id,
-          email: user.email,
-          displayName: user.displayName,
-          language: this.detectLanguageFromCountry(user.country),
-        },
-        user.plan || 'pro',
-        'payment_failed',
-      )
-      .catch((err) =>
-        this.logger.error(
-          `Failed to queue subscription downgraded email: ${err.message}`,
-        ),
-      );
   }
 
   /**

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -228,27 +228,41 @@ export class PaymentsService {
     }
 
     // Get or create Stripe customer
-    const user = await this.firestoreService.getUserById(userId);
+    let user = await this.firestoreService.getUserById(userId);
 
-    // VALIDATION: Prevent duplicate subscriptions
-    // Check if user already has the same plan
-    if (user?.plan === plan) {
-      throw new BadRequestException(
-        `You are already subscribed to the ${plan.toUpperCase()} plan. Manage your subscription from your account settings.`,
-      );
-    }
-
-    // Check if user has an active subscription in Stripe (defense in depth)
+    // El contraste con Stripe va ANTES de mirar el plan del documento, y el orden
+    // importa desde #65. El documento puede decir todavía `pro` mientras el
+    // contrato está impagado —el webhook que lo degrada tarda en llegar, o se
+    // perdió—, y comprobando primero el plan, el cliente al que acaban de cortarle
+    // el PRO por impago no podría recontratar PRO: saldría rechazado por «ya estás
+    // suscrito» sin que nadie llegase a liquidar el contrato muerto. Otro callejón
+    // de la misma familia que el issue.
     if (user?.stripeSubscriptionId) {
       try {
         const existingSubscription = await this.stripe.subscriptions.retrieve(
           user.stripeSubscriptionId,
         );
 
+        // Un contrato impagado ya no reserva el sitio: se liquida aquí mismo y
+        // el checkout continúa. Es la salida que le faltaba al cliente de #65
+        // —antes esta rama lo remitía al endpoint de upgrade, que lo rechazaba
+        // por no estar `active`— y de paso evita el duplicado que se produciría
+        // dejándolo pasar sin cancelar el anterior.
         if (
-          ['active', 'trialing', 'past_due'].includes(
+          PaymentsService.ESTADOS_IMPAGADOS.includes(
             existingSubscription.status,
           )
+        ) {
+          await this.liquidarContratoImpagadoAntesDelAlta(
+            user,
+            existingSubscription,
+          );
+          // La liquidación dejó el documento en Free; sin releer, la comprobación
+          // de plan de más abajo seguiría viendo el plan muerto y rechazaría el
+          // alta que acabamos de habilitar.
+          user = (await this.firestoreService.getUserById(userId)) ?? user;
+        } else if (
+          PaymentsService.ESTADOS_VIVOS.includes(existingSubscription.status)
         ) {
           // Get the current plan from the subscription
           const currentPriceId = existingSubscription.items.data[0]?.price?.id;
@@ -283,11 +297,25 @@ export class PaymentsService {
         }
       } catch (error) {
         if (error instanceof BadRequestException) throw error;
+        // También sale el fallo de la liquidación. Este `catch` existe para
+        // tolerar que la suscripción no exista en Stripe (típico al cambiar de
+        // modo test/live), no para tragarse un contrato impagado que no se pudo
+        // cerrar: tragándolo dejaría continuar el alta y el cliente acabaría con
+        // dos suscripciones vivas, que es lo que la liquidación venía a impedir.
+        if (error instanceof ServiceUnavailableException) throw error;
         // Subscription doesn't exist in Stripe (maybe switched test/live mode)
         this.logger.warn(
           `Could not verify subscription ${user.stripeSubscriptionId}: ${error.message}`,
         );
       }
+    }
+
+    // VALIDATION: Prevent duplicate subscriptions
+    // Check if user already has the same plan
+    if (user?.plan === plan) {
+      throw new BadRequestException(
+        `You are already subscribed to the ${plan.toUpperCase()} plan. Manage your subscription from your account settings.`,
+      );
     }
 
     // VALIDATION: Check for any active subscription by customer ID (defense in depth)
@@ -527,22 +555,25 @@ export class PaymentsService {
   /**
    * Mensaje para un upgrade bloqueado por el estado de la suscripción.
    *
-   * La acción que resuelve el bloqueo depende del estado: cambiar la tarjeta solo
-   * sirve en los estados de cobro (`past_due`, `unpaid`); si la suscripción ya
-   * terminó hay que contratarla de nuevo, y en el resto de estados no hay nada que
-   * el cliente pueda arreglar por su cuenta.
+   * La acción que resuelve el bloqueo depende del estado. En los de cobro
+   * (`past_due`, `unpaid`) la salida ya no es cambiar la tarjeta: desde #65 el
+   * contrato impagado se cancela, así que no queda suscripción que rescatar y lo
+   * que corresponde es contratar de nuevo —el propio checkout liquida los restos—.
+   * Si la suscripción ya terminó, igual; en el resto de estados no hay nada que el
+   * cliente pueda arreglar por su cuenta.
+   *
+   * Este mensaje cierra el callejón de #65 por el otro extremo: el checkout ya no
+   * remite aquí a nadie en `past_due`, y quien llegue igualmente sale hacia el
+   * checkout en vez de quedarse sin instrucción que seguir.
    */
   private inactiveSubscriptionMessage(status: string): string {
     const base = `Your subscription is not active (status: ${status}).`;
 
-    if (status === 'past_due' || status === 'unpaid') {
-      return (
-        `${base} Please update your payment method from your account settings ` +
-        `before upgrading.`
-      );
-    }
-
-    if (status === 'canceled' || status === 'incomplete_expired') {
+    if (
+      PaymentsService.ESTADOS_IMPAGADOS.includes(status) ||
+      status === 'canceled' ||
+      status === 'incomplete_expired'
+    ) {
       return `${base} Please subscribe again to get the plan you need.`;
     }
 
@@ -951,7 +982,7 @@ export class PaymentsService {
       this.throwPendingPaymentError(subscription, upgradeContext);
     }
 
-    if (subscription.status !== 'active') {
+    if (!PaymentsService.ESTADOS_MODIFICABLES.includes(subscription.status)) {
       this.logger.warn(
         `Upgrade bloqueado: la suscripción está en estado '${subscription.status}' — ${upgradeContext}`,
       );
@@ -1063,7 +1094,7 @@ export class PaymentsService {
           this.throwPendingPaymentError(vigente, upgradeContext);
         }
 
-        if (vigente.status !== 'active') {
+        if (!PaymentsService.ESTADOS_MODIFICABLES.includes(vigente.status)) {
           this.logger.warn(
             `Upgrade bloqueado: la suscripción pasó a '${vigente.status}' ` +
               `mientras se preparaba — ${upgradeContext}`,
@@ -1378,8 +1409,41 @@ export class PaymentsService {
     };
   }
 
-  /** Estados en los que una suscripción sigue dando derecho al plan. */
-  private static readonly ESTADOS_VIVOS = ['active', 'trialing', 'past_due'];
+  /**
+   * Estados en los que una suscripción sigue dando derecho al plan.
+   *
+   * Es la ÚNICA fuente de verdad: `createCheckoutSession`, `upgradeSubscription`
+   * y la adopción del checkout la consultan en lugar de mantener su propia lista.
+   * Que hubiera dos fue justo lo que encerró al cliente de #65: checkout tenía a
+   * `past_due` por viva y remitía al upgrade, y el upgrade la rechazaba por no
+   * estar `active`. No quedaba ningún camino.
+   *
+   * `past_due` NO está, y esa es la política de cobro decidida en #65: el primer
+   * cobro fallido de una renovación cancela la suscripción y devuelve al cliente
+   * a Free (`handlePaymentFailed`). Deja de ser una espera con plan concedido y
+   * pasa a ser un tránsito de segundos hacia la cancelación.
+   */
+  private static readonly ESTADOS_VIVOS = ['active', 'trialing'];
+
+  /**
+   * Estados desde los que se puede modificar el plan de una suscripción viva.
+   *
+   * Coincide hoy con `ESTADOS_VIVOS` y se declara aparte porque responde a otra
+   * pregunta: aquella dice si el cliente tiene derecho al plan, esta si Stripe
+   * admite un `subscriptions.update` con proración sobre ese contrato. `trialing`
+   * entra porque Stripe permite el cambio de precio durante la prueba y no cobra
+   * hasta que termina —hoy es teórico, el proyecto no configura `trial_period_days`.
+   */
+  private static readonly ESTADOS_MODIFICABLES = ['active', 'trialing'];
+
+  /**
+   * Estados de cobro fallido: la suscripción existe en Stripe pero ya no da
+   * derecho al plan. Con la política de #65 no deberían durar más que el viaje
+   * del webhook, pero se comprueban igual porque un webhook puede perderse y
+   * porque `unpaid` es el destino de las cuentas cuyo dunning quedó configurado
+   * de otra forma en el Dashboard.
+   */
+  private static readonly ESTADOS_IMPAGADOS = ['past_due', 'unpaid'];
 
   /**
    * Decide si el alta del checkout debe fijar el plan del usuario.
@@ -1946,8 +2010,14 @@ export class PaymentsService {
           ? `Subscription updated for user ${user.id}: active (${plan})`
           : `Subscription updated descartado para user ${user.id}: el documento ya refleja una lectura posterior`,
       );
-    } else if (['canceled', 'unpaid'].includes(current.status)) {
-      // Subscription terminated - downgrade to free and clear subscription ID
+    } else if (['canceled', 'unpaid', 'past_due'].includes(current.status)) {
+      // `past_due` entra aquí desde #65. Antes tenía su propia rama que conservaba
+      // el plan "para dar tiempo a pagar", y era incompatible con la política
+      // nueva por partida doble: concedía plan sin cobro, y al llegar después de
+      // que `handlePaymentFailed` degradara, restauraba el `stripeSubscriptionId`
+      // que aquel acababa de limpiar —el sello por `readAt` no lo frenaba, porque
+      // es una lectura genuinamente posterior—. Dejando que degrade, el orden de
+      // llegada de los dos eventos deja de importar: ambos escriben lo mismo.
       const previousPlan = user.plan || 'pro';
 
       const applied = await this.withRetry(
@@ -1994,25 +2064,6 @@ export class PaymentsService {
             `Failed to queue subscription downgraded email: ${err.message}`,
           ),
         );
-    } else if (current.status === 'past_due') {
-      // Payment pending - keep subscriptionId to allow status queries
-      // Don't downgrade immediately, give user time to pay
-      // The handlePaymentFailed method already sends notification emails
-      await this.withRetry(
-        () =>
-          this.firestoreService.updateUserSubscriptionState(
-            user.id,
-            {
-              stripeSubscriptionId: current.id,
-            },
-            readAt,
-            lockToken,
-          ),
-        `handleSubscriptionUpdated(${user.id})`,
-      );
-      this.logger.log(
-        `Subscription past_due for user ${user.id} - keeping subscription active for recovery`,
-      );
     }
   }
 
@@ -2177,6 +2228,161 @@ export class PaymentsService {
     this.logger.log(`Saved subscription event: canceled for user ${user.id}`);
   }
 
+  /**
+   * Liquida en Stripe una suscripción cuyo cobro no prosperó: anula la factura
+   * pendiente y cancela el contrato.
+   *
+   * Implementa la mitad "en Stripe" de la política de #65 —que no quede plan
+   * concedido sin pagar, ni factura impagada arrastrándose—. La otra mitad, el
+   * plan del usuario, la escribe quien llama, dentro del mutex de sincronización.
+   *
+   * **Relee la factura antes de tocar nada.** El payload del webhook describe el
+   * instante del fallo, no el de ahora, y entre ambos caben minutos: reentregas
+   * de Stripe, un reintento que sí cobró, o el cliente pagando a mano desde el
+   * portal. Cancelar sobre ese payload le quitaría el plan a alguien que acaba de
+   * pagarlo. Si la factura ya no está `open`, no hay nada que liquidar.
+   *
+   * **Anula antes de cancelar**, y no al revés, porque los dos fallos posibles no
+   * cuestan lo mismo. Si la anulación funciona y la cancelación no, queda un
+   * contrato sin deuda que el siguiente ciclo o el propio Stripe vuelven a poner
+   * en evidencia. Al revés quedaría el cliente sin plan Y con una factura viva
+   * persiguiéndole, que es exactamente lo que esta política venía a evitar.
+   *
+   * Es idempotente por construcción: la relectura absorbe las reentregas, y una
+   * suscripción ya cancelada se detecta antes de llamar.
+   *
+   * @returns `true` si la suscripción quedó liquidada y procede degradar el plan;
+   *          `false` si la factura ya no estaba pendiente y no hay que tocar nada.
+   */
+  private async liquidarSuscripcionImpagada(
+    invoiceId: string,
+    subscriptionId: string,
+    contexto: string,
+  ): Promise<boolean> {
+    const seguiaPendiente = await this.anularFacturaPendiente(
+      invoiceId,
+      contexto,
+    );
+
+    if (!seguiaPendiente) {
+      return false;
+    }
+
+    await this.cancelarSuscripcion(subscriptionId, contexto);
+
+    return true;
+  }
+
+  /**
+   * Anula una factura si sigue pendiente de cobro.
+   *
+   * Se anula en vez de marcarse incobrable porque no hay nada devengado que
+   * reclamar: el corte de servicio es inmediato, y el CFDI cuelga de
+   * `invoice.payment_succeeded` (`webhooks.service.ts`), así que una factura que
+   * nunca se cobró tampoco llegó a timbrarse — no hay comprobante que corregir.
+   *
+   * @returns `true` si estaba `open` y se anuló; `false` si ya no estaba
+   *          pendiente, sea porque se cobró o porque ya se había anulado.
+   */
+  private async anularFacturaPendiente(
+    invoiceId: string,
+    contexto: string,
+  ): Promise<boolean> {
+    const vigente = await this.stripe.invoices.retrieve(invoiceId);
+
+    if (vigente.status !== 'open') {
+      this.logger.log(
+        `Factura ${invoiceId} en '${vigente.status}', no pendiente de cobro; ` +
+          `no se anula nada — ${contexto}.`,
+      );
+      return false;
+    }
+
+    await this.stripe.invoices.voidInvoice(invoiceId);
+    this.logger.log(`Factura ${invoiceId} anulada — ${contexto}.`);
+
+    return true;
+  }
+
+  /** Cancela la suscripción salvo que Stripe ya la tenga cancelada. */
+  private async cancelarSuscripcion(
+    subscriptionId: string,
+    contexto: string,
+  ): Promise<void> {
+    const suscripcion =
+      await this.stripe.subscriptions.retrieve(subscriptionId);
+
+    if (suscripcion.status === 'canceled') {
+      this.logger.log(
+        `La suscripción ${subscriptionId} ya estaba cancelada — ${contexto}.`,
+      );
+      return;
+    }
+
+    await this.stripe.subscriptions.cancel(subscriptionId);
+    this.logger.log(`Suscripción ${subscriptionId} cancelada — ${contexto}.`);
+  }
+
+  /**
+   * Liquida el contrato impagado que un cliente arrastra al pedir un alta nueva.
+   *
+   * Con `past_due` fuera de los estados vivos, el checkout ya no puede limitarse
+   * a bloquear —eso era el callejón de #65—, pero tampoco puede dejar pasar sin
+   * más: la suscripción anterior seguiría viva en Stripe y el cliente acabaría
+   * con dos. Así que se cierra la vieja antes de abrir la nueva.
+   *
+   * Normalmente esto no llega a ejecutarse: `handlePaymentFailed` liquida el
+   * contrato en cuanto falla el cobro. Queda para la ventana en la que el webhook
+   * aún no ha llegado, se perdió, o el dunning del Dashboard dejó la suscripción
+   * en `unpaid` en vez de cancelarla.
+   *
+   * Si la liquidación falla se bloquea el alta: crear la segunda suscripción
+   * sabiendo que la primera sigue viva dejaría al cliente pagando dos veces.
+   */
+  private async liquidarContratoImpagadoAntesDelAlta(
+    user: User,
+    impagada: Stripe.Subscription,
+  ): Promise<void> {
+    const contexto = `user ${user.id} (alta nueva sobre contrato ${impagada.status} ${impagada.id})`;
+    const invoiceId =
+      typeof impagada.latest_invoice === 'string'
+        ? impagada.latest_invoice
+        : (impagada.latest_invoice?.id ?? null);
+
+    try {
+      await this.withSubscriptionSyncLock(user.id, async (lockToken) => {
+        if (invoiceId) {
+          await this.anularFacturaPendiente(invoiceId, contexto);
+        }
+
+        await this.cancelarSuscripcion(impagada.id, contexto);
+
+        await this.withRetry(
+          () =>
+            this.firestoreService.updateUserSubscriptionState(
+              user.id,
+              { plan: 'free', stripeSubscriptionId: null },
+              new Date(),
+              lockToken,
+            ),
+          `liquidarContratoImpagadoAntesDelAlta(${user.id})`,
+        );
+      });
+
+      this.logger.warn(
+        `Contrato impagado liquidado para permitir el alta — ${contexto}.`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `No se pudo liquidar el contrato impagado — ${contexto}: ${(error as Error).message}`,
+      );
+      throw new ServiceUnavailableException(
+        'We could not close your previous unpaid subscription. Please try again ' +
+          'in a few minutes or contact support@zplpdf.com.',
+      );
+    }
+  }
+
   async handlePaymentFailed(invoice: Stripe.Invoice): Promise<void> {
     const customerId = invoice.customer as string;
     const user =
@@ -2189,37 +2395,162 @@ export class PaymentsService {
       return;
     }
 
-    // Log the failed payment
-    this.logger.warn(
-      `Payment failed for user ${user.id}, invoice: ${invoice.id}`,
-    );
-
-    // If this is not the first attempt, send payment failed notification
-    const attemptCount = invoice.attempt_count || 1;
-    if (attemptCount >= 2) {
-      this.logger.warn(
-        `Multiple payment failures (${attemptCount}) for user ${user.id}`,
-      );
-      // Send payment failed notification email
-      this.emailService
-        .queuePaymentFailedEmail(
-          {
-            id: user.id,
-            email: user.email,
-            displayName: user.displayName,
-            language: this.detectLanguageFromCountry(user.country),
-          },
-          attemptCount,
-        )
-        .catch((err) =>
-          this.logger.error(
-            `Failed to queue payment failed email: ${err.message}`,
-          ),
-        );
+    // La política de "no paga → Free" (#65) se aplica SOLO a la renovación, que
+    // es lo que significa literalmente no pagar la suscripción. Los otros dos
+    // motivos que traen aquí un `payment_failed` no son eso:
+    //
+    // - `subscription_create`: el alta que no llegó a cobrarse. No hay plan que
+    //   quitar —nunca se concedió— y Stripe expira sola la suscripción
+    //   `incomplete` a las 23 h.
+    // - `subscription_update`: la proración de un upgrade. El cliente TIENE su
+    //   plan al corriente y lo que falló fue la mejora. Cancelar aquí le quitaría
+    //   lo que sí pagó por no poder pagar lo que pidió de más; además el upgrade
+    //   usa `pending_if_incomplete` justamente para que este fallo no toque la
+    //   suscripción vigente (#73), y esto lo desharía.
+    //
+    // Para ambos se mantiene el comportamiento anterior: registrar y avisar.
+    if (invoice.billing_reason !== 'subscription_cycle') {
+      this.notificarCobroFallido(user, invoice);
+      return;
     }
 
-    // Note: Don't immediately downgrade - Stripe will retry and send subscription.updated
-    // if the final retry fails. This handler is for logging and notifications only.
+    const invoiceId = invoice.id;
+    const subscriptionId = getSubscriptionIdFromInvoice(invoice);
+
+    if (!invoiceId || !subscriptionId) {
+      this.logger.error(
+        `Cobro fallido de ${user.id} sin factura (${invoiceId ?? 'null'}) o sin ` +
+          `suscripción (${subscriptionId ?? 'null'}) que liquidar. Solo se avisa.`,
+      );
+      this.notificarCobroFallido(user, invoice);
+      return;
+    }
+
+    const contexto = `user ${user.id} (renovación impagada, sub ${subscriptionId}, factura ${invoiceId})`;
+
+    // Mismo mutex que los webhooks de suscripción y el upgrade: esto lee el
+    // estado en Stripe y escribe el plan, así que compite con ellos por el mismo
+    // documento (#77). Sin el lease, la cancelación podría pisar un alta recién
+    // confirmada.
+    const degradado = await this.withSubscriptionSyncLock(
+      user.id,
+      async (lockToken) => {
+        // Revalidación dentro del lease: entre el evento y este punto el cliente
+        // pudo contratar de nuevo. Una factura del contrato ANTERIOR no debe
+        // llevarse por delante el que ya está pagando.
+        const fresh =
+          (await this.firestoreService.getUserById(user.id)) ?? user;
+
+        if (
+          fresh.stripeSubscriptionId &&
+          fresh.stripeSubscriptionId !== subscriptionId
+        ) {
+          this.logger.warn(
+            `Cobro fallido ignorado: el usuario ya tiene otra suscripción ` +
+              `(${fresh.stripeSubscriptionId}) — ${contexto}.`,
+          );
+          return false;
+        }
+
+        const liquidada = await this.liquidarSuscripcionImpagada(
+          invoiceId,
+          subscriptionId,
+          contexto,
+        );
+
+        if (!liquidada) {
+          return false;
+        }
+
+        // El sello se toma tras liquidar en Stripe: es el instante que esta
+        // escritura describe, y dentro del lease no hay otro ciclo con el que
+        // competir.
+        const aplicado = await this.withRetry(
+          () =>
+            this.firestoreService.updateUserSubscriptionState(
+              fresh.id,
+              { plan: 'free', stripeSubscriptionId: null },
+              new Date(),
+              lockToken,
+            ),
+          `handlePaymentFailed(${fresh.id})`,
+        );
+
+        if (!aplicado) {
+          this.logger.log(
+            `Degradación descartada: el documento ya refleja una lectura ` +
+              `posterior — ${contexto}.`,
+          );
+          return false;
+        }
+
+        this.logger.warn(
+          `Plan degradado a Free por renovación impagada — ${contexto}.`,
+        );
+        return true;
+      },
+    );
+
+    if (!degradado) {
+      return;
+    }
+
+    // El aviso va atado a la escritura y fuera del lease: contar una degradación
+    // que no llegó a aplicarse alarmaría a un cliente que sigue de pago.
+    this.emailService
+      .queueSubscriptionDowngradedEmail(
+        {
+          id: user.id,
+          email: user.email,
+          displayName: user.displayName,
+          language: this.detectLanguageFromCountry(user.country),
+        },
+        user.plan || 'pro',
+        'payment_failed',
+      )
+      .catch((err) =>
+        this.logger.error(
+          `Failed to queue subscription downgraded email: ${err.message}`,
+        ),
+      );
+  }
+
+  /**
+   * Aviso de cobro fallido sin degradación: los motivos que no son una
+   * renovación (alta o proración de upgrade) conservan el comportamiento
+   * anterior — registrar, y avisar a partir del segundo intento.
+   */
+  private notificarCobroFallido(user: User, invoice: Stripe.Invoice): void {
+    this.logger.warn(
+      `Payment failed for user ${user.id}, invoice: ${invoice.id} ` +
+        `(billing_reason: ${invoice.billing_reason})`,
+    );
+
+    const attemptCount = invoice.attempt_count || 1;
+
+    if (attemptCount < 2) {
+      return;
+    }
+
+    this.logger.warn(
+      `Multiple payment failures (${attemptCount}) for user ${user.id}`,
+    );
+
+    this.emailService
+      .queuePaymentFailedEmail(
+        {
+          id: user.id,
+          email: user.email,
+          displayName: user.displayName,
+          language: this.detectLanguageFromCountry(user.country),
+        },
+        attemptCount,
+      )
+      .catch((err) =>
+        this.logger.error(
+          `Failed to queue payment failed email: ${err.message}`,
+        ),
+      );
   }
 
   async handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -208,6 +208,50 @@ export class PaymentsService {
     return isMexico ? this.proPriceIdMxn : this.proPriceId;
   }
 
+  /**
+   * Rechaza el alta cuando ya hay un contrato vivo, con el motivo que toque.
+   *
+   * Siempre lanza. Está extraído porque lo necesitan dos caminos: el contrato que
+   * ya estaba vivo al empezar, y el que se recuperó a mitad de la liquidación
+   * —el cliente pagó desde el portal justo entonces—. Ese segundo camino es el
+   * que faltaba: sin él se cancelaba una suscripción recién pagada y se le abría
+   * un segundo cobro al cliente el mismo día.
+   */
+  private bloquearAltaSobreContratoVivo(
+    viva: Stripe.Subscription,
+    plan: SellablePlan,
+  ): never {
+    const currentPriceId = viva.items.data[0]?.price?.id;
+    const currentPlan = currentPriceId
+      ? this.getPlanFromPriceId(currentPriceId)
+      : null;
+
+    // If trying to buy the same plan, reject
+    if (currentPlan === plan) {
+      throw new BadRequestException(
+        `You already have an active ${plan.toUpperCase()} subscription. Manage it from your account settings.`,
+      );
+    }
+
+    // If moving UP between paid plans (lite→pro, lite→promax, pro→promax),
+    // redirect to the upgrade endpoint to modify the existing subscription
+    // with proration instead of creating a duplicate subscription.
+    if (currentPlan && PLAN_ORDER[plan] > PLAN_ORDER[currentPlan]) {
+      throw new BadRequestException(
+        `Use the upgrade endpoint to upgrade from ${currentPlan.toUpperCase()} to ${plan.toUpperCase()}.`,
+      );
+    }
+
+    // Any other case with an active subscription (downgrade, lateral move, or
+    // an unrecognized current plan) must NOT create a second checkout, or Stripe
+    // would create a duplicate subscription and the webhook would orphan the old
+    // one. Block and direct the user to the customer portal to change/cancel first.
+    throw new BadRequestException(
+      `You already have an active subscription${currentPlan ? ` (${currentPlan.toUpperCase()})` : ''}. ` +
+        `To downgrade or change your plan, manage it from your account settings (customer portal).`,
+    );
+  }
+
   async createCheckoutSession(
     userId: string,
     email: string,
@@ -253,47 +297,30 @@ export class PaymentsService {
             existingSubscription.status,
           )
         ) {
-          await this.liquidarContratoImpagadoAntesDelAlta(
+          const liquidado = await this.liquidarContratoImpagadoAntesDelAlta(
             user,
             existingSubscription,
           );
-          // La liquidación dejó el documento en Free; sin releer, la comprobación
-          // de plan de más abajo seguiría viendo el plan muerto y rechazaría el
-          // alta que acabamos de habilitar.
-          user = (await this.firestoreService.getUserById(userId)) ?? user;
+
+          if (liquidado) {
+            // La liquidación dejó el documento en Free; sin releer, la
+            // comprobación de plan de más abajo seguiría viendo el plan muerto y
+            // rechazaría el alta que acabamos de habilitar.
+            user = (await this.firestoreService.getUserById(userId)) ?? user;
+          } else {
+            // El cliente pagó entre la lectura de arriba y la liquidación —desde
+            // el portal, o con un reintento que entró—. El contrato ha vuelto a
+            // la vida, así que se trata como tal: dejarlo pasar abriría un
+            // segundo cobro sobre una renovación que acaba de saldar.
+            this.bloquearAltaSobreContratoVivo(
+              await this.stripe.subscriptions.retrieve(existingSubscription.id),
+              plan,
+            );
+          }
         } else if (
           PaymentsService.ESTADOS_VIVOS.includes(existingSubscription.status)
         ) {
-          // Get the current plan from the subscription
-          const currentPriceId = existingSubscription.items.data[0]?.price?.id;
-          const currentPlan = currentPriceId
-            ? this.getPlanFromPriceId(currentPriceId)
-            : null;
-
-          // If trying to buy the same plan, reject
-          if (currentPlan === plan) {
-            throw new BadRequestException(
-              `You already have an active ${plan.toUpperCase()} subscription. Manage it from your account settings.`,
-            );
-          }
-
-          // If moving UP between paid plans (lite→pro, lite→promax, pro→promax),
-          // redirect to the upgrade endpoint to modify the existing subscription
-          // with proration instead of creating a duplicate subscription.
-          if (currentPlan && PLAN_ORDER[plan] > PLAN_ORDER[currentPlan]) {
-            throw new BadRequestException(
-              `Use the upgrade endpoint to upgrade from ${currentPlan.toUpperCase()} to ${plan.toUpperCase()}.`,
-            );
-          }
-
-          // Any other case with an active subscription (downgrade, lateral move, or
-          // an unrecognized current plan) must NOT create a second checkout, or Stripe
-          // would create a duplicate subscription and the webhook would orphan the old
-          // one. Block and direct the user to the customer portal to change/cancel first.
-          throw new BadRequestException(
-            `You already have an active subscription${currentPlan ? ` (${currentPlan.toUpperCase()})` : ''}. ` +
-              `To downgrade or change your plan, manage it from your account settings (customer portal).`,
-          );
+          this.bloquearAltaSobreContratoVivo(existingSubscription, plan);
         }
       } catch (error) {
         if (error instanceof BadRequestException) throw error;
@@ -1343,8 +1370,19 @@ export class PaymentsService {
     }
 
     // Defensa en profundidad: el plan solo se marca cuando la suscripción queda
-    // confirmada como activa.
-    if (updatedSubscription.status !== 'active') {
+    // confirmada en un estado que da derecho a él.
+    //
+    // Se compara contra la misma lista que autorizó el cambio, no contra `active`
+    // a secas. Exigir `active` aquí después de haber admitido `trialing` arriba
+    // aplicaría el precio nuevo en Stripe y luego devolvería error sin escribir
+    // el plan: contrato y entitlements desincronizados, y el cliente leyendo que
+    // no se cambió nada mientras se le facturará el plan superior al acabar la
+    // prueba. La salida no es prohibir `trialing` en el upgrade —eso reabriría el
+    // callejón de #65 con otro estado, porque el checkout lo tiene por vivo y
+    // remite aquí—, sino aceptar el estado en que Stripe deja el contrato.
+    if (
+      !PaymentsService.ESTADOS_MODIFICABLES.includes(updatedSubscription.status)
+    ) {
       this.logger.error(
         `Upgrade no confirmado: la suscripción quedó en '${updatedSubscription.status}' ` +
           `tras el cambio de precio — ${upgradeContext}. No se actualiza el plan en Firestore.`,
@@ -2011,14 +2049,55 @@ export class PaymentsService {
           : `Subscription updated descartado para user ${user.id}: el documento ya refleja una lectura posterior`,
       );
     } else if (['canceled', 'unpaid', 'past_due'].includes(current.status)) {
-      // `past_due` entra aquí desde #65. Antes tenía su propia rama que conservaba
-      // el plan "para dar tiempo a pagar", y era incompatible con la política
-      // nueva por partida doble: concedía plan sin cobro, y al llegar después de
-      // que `handlePaymentFailed` degradara, restauraba el `stripeSubscriptionId`
-      // que aquel acababa de limpiar —el sello por `readAt` no lo frenaba, porque
-      // es una lectura genuinamente posterior—. Dejando que degrade, el orden de
-      // llegada de los dos eventos deja de importar: ambos escriben lo mismo.
+      // `past_due` entra aquí desde #65: antes tenía una rama propia que
+      // conservaba el plan "para dar tiempo a pagar", y eso concedía plan sin
+      // cobro.
+      //
+      // Pero degradar no basta, y suponer que sí fue un error: limpiar el
+      // `stripeSubscriptionId` sin cancelar en Stripe deja el contrato vivo y sin
+      // dueño. Si este evento se adelanta a `invoice.payment_failed` —Stripe no
+      // garantiza el orden—, el usuario se queda sin ID, contrata de nuevo (la
+      // defensa por customer solo lista `active`, así que no ve la impagada), y
+      // el `payment_failed` que llega después descarta el evento por apuntar a
+      // otro contrato. El viejo sobrevive, y con la tarjeta ya al día Stripe
+      // puede cobrarlo: dos suscripciones cobrables sobre el mismo cliente.
+      //
+      // Liquidando aquí también, los dos caminos convergen y el orden deja de
+      // importar de verdad. La liquidación es reanudable e idempotente, así que
+      // que ambos la ejecuten no duplica nada.
       const previousPlan = user.plan || 'pro';
+
+      if (PaymentsService.ESTADOS_IMPAGADOS.includes(current.status)) {
+        const invoiceId =
+          typeof current.latest_invoice === 'string'
+            ? current.latest_invoice
+            : (current.latest_invoice?.id ?? null);
+        const contexto = `user ${user.id} (subscription.updated en '${current.status}', sub ${current.id})`;
+
+        // Sin factura que consultar no hay cobro que comprobar: se cancela y
+        // punto. Es un caso de borde —una suscripción impagada siempre trae su
+        // `latest_invoice`—, pero dejarlo sin cancelar reabriría el agujero.
+        let liquidado = true;
+
+        if (invoiceId) {
+          liquidado = await this.liquidarSuscripcionImpagada(
+            invoiceId,
+            current.id,
+            contexto,
+          );
+        } else {
+          await this.cancelarSuscripcion(current.id, contexto);
+        }
+
+        // La factura se saldó entre que Stripe emitió el evento y ahora: el
+        // contrato está al corriente y degradar castigaría a quien acaba de pagar.
+        if (!liquidado) {
+          this.logger.log(
+            `Degradación abortada: la factura se cobró — ${contexto}.`,
+          );
+          return;
+        }
+      }
 
       const applied = await this.withRetry(
         () =>
@@ -2144,6 +2223,23 @@ export class PaymentsService {
           return { aplicado: false as const };
         }
 
+        // Eco de una baja ya aplicada. Desde #65 lo provoca el flujo normal: la
+        // cancelación por impago la lanza este mismo servicio, y Stripe devuelve
+        // el `deleted` cuando el usuario ya está en Free y sin contrato. Sin este
+        // corte se reescribe lo mismo, se manda un segundo correo de degradación
+        // —a veces un tercero, contando el de `subscription.updated`— y se guarda
+        // otro evento de baja, con lo que el churn queda contado por duplicado.
+        // Peor aún: con el plan ya en `free`, el cálculo de abajo cae al
+        // `'pro'` por defecto, así que a un cliente de LITE se le nombraría un
+        // plan que nunca tuvo.
+        if (fresh.plan === 'free' && !fresh.stripeSubscriptionId) {
+          this.logger.log(
+            `subscription.deleted de ${subscription.id} es eco de una baja ya ` +
+              `aplicada para ${user.id}; no se reescribe ni se vuelve a avisar.`,
+          );
+          return { aplicado: false as const };
+        }
+
         // El plan cancelado sale de la lectura de DENTRO del lease: si un
         // `subscription.updated` pendiente escribió PROMAX entre la lectura
         // inicial y esta, la baja se aplicaría bien pero se registraría y se
@@ -2248,23 +2344,22 @@ export class PaymentsService {
    * en evidencia. Al revés quedaría el cliente sin plan Y con una factura viva
    * persiguiéndole, que es exactamente lo que esta política venía a evitar.
    *
-   * Es idempotente por construcción: la relectura absorbe las reentregas, y una
-   * suscripción ya cancelada se detecta antes de llamar.
+   * Es reanudable: si un ciclo anterior anuló la factura pero murió antes de
+   * cancelar, la reentrega de Stripe encuentra la factura ya anulada y termina el
+   * trabajo. Distinguir eso de una factura cobrada es justo lo que decide entre
+   * rematar la liquidación y no tocar nada.
    *
    * @returns `true` si la suscripción quedó liquidada y procede degradar el plan;
-   *          `false` si la factura ya no estaba pendiente y no hay que tocar nada.
+   *          `false` si el cliente pagó y no hay que tocar nada.
    */
   private async liquidarSuscripcionImpagada(
     invoiceId: string,
     subscriptionId: string,
     contexto: string,
   ): Promise<boolean> {
-    const seguiaPendiente = await this.anularFacturaPendiente(
-      invoiceId,
-      contexto,
-    );
+    const factura = await this.anularFacturaPendiente(invoiceId, contexto);
 
-    if (!seguiaPendiente) {
+    if (factura === 'cobrada') {
       return false;
     }
 
@@ -2274,34 +2369,51 @@ export class PaymentsService {
   }
 
   /**
-   * Anula una factura si sigue pendiente de cobro.
+   * Anula la factura si sigue pendiente, y dice si procede seguir liquidando.
+   *
+   * La distinción que devuelve NO es "estaba abierta o no", sino "hay deuda o el
+   * cliente pagó", y son cosas distintas: una factura `void` significa que un
+   * ciclo anterior ya hizo esta mitad del trabajo y murió antes de cancelar, así
+   * que hay que REMATAR, no abortar. Conflar ambos casos dejaba contratos vivos
+   * sin cobro cada vez que la cancelación fallaba y Stripe reentregaba el evento.
+   *
+   * `uncollectible` cuenta igual que `void`: es deuda dada por perdida, no cobro.
+   * `draft` no se puede anular —no está finalizada— y tampoco acredita pago, así
+   * que se deja pasar sin tocarla; la cancelación del contrato se la lleva.
    *
    * Se anula en vez de marcarse incobrable porque no hay nada devengado que
    * reclamar: el corte de servicio es inmediato, y el CFDI cuelga de
    * `invoice.payment_succeeded` (`webhooks.service.ts`), así que una factura que
    * nunca se cobró tampoco llegó a timbrarse — no hay comprobante que corregir.
    *
-   * @returns `true` si estaba `open` y se anuló; `false` si ya no estaba
-   *          pendiente, sea porque se cobró o porque ya se había anulado.
+   * @returns `'liquidable'` si procede cancelar el contrato; `'cobrada'` si el
+   *          cliente pagó y no hay que tocar nada.
    */
   private async anularFacturaPendiente(
     invoiceId: string,
     contexto: string,
-  ): Promise<boolean> {
+  ): Promise<'liquidable' | 'cobrada'> {
     const vigente = await this.stripe.invoices.retrieve(invoiceId);
+
+    if (vigente.status === 'paid') {
+      this.logger.log(
+        `Factura ${invoiceId} cobrada; no se liquida nada — ${contexto}.`,
+      );
+      return 'cobrada';
+    }
 
     if (vigente.status !== 'open') {
       this.logger.log(
-        `Factura ${invoiceId} en '${vigente.status}', no pendiente de cobro; ` +
-          `no se anula nada — ${contexto}.`,
+        `Factura ${invoiceId} en '${vigente.status}': sin cobro y sin nada que ` +
+          `anular, se sigue con la cancelación — ${contexto}.`,
       );
-      return false;
+      return 'liquidable';
     }
 
     await this.stripe.invoices.voidInvoice(invoiceId);
     this.logger.log(`Factura ${invoiceId} anulada — ${contexto}.`);
 
-    return true;
+    return 'liquidable';
   }
 
   /** Cancela la suscripción salvo que Stripe ya la tenga cancelada. */
@@ -2338,39 +2450,56 @@ export class PaymentsService {
    *
    * Si la liquidación falla se bloquea el alta: crear la segunda suscripción
    * sabiendo que la primera sigue viva dejaría al cliente pagando dos veces.
+   *
+   * @returns `true` si el contrato quedó liquidado y el alta puede continuar;
+   *          `false` si el cliente pagó entre medias y el contrato revivió.
    */
   private async liquidarContratoImpagadoAntesDelAlta(
     user: User,
     impagada: Stripe.Subscription,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const contexto = `user ${user.id} (alta nueva sobre contrato ${impagada.status} ${impagada.id})`;
     const invoiceId =
       typeof impagada.latest_invoice === 'string'
         ? impagada.latest_invoice
         : (impagada.latest_invoice?.id ?? null);
 
+    let liquidado: boolean;
+
     try {
-      await this.withSubscriptionSyncLock(user.id, async (lockToken) => {
-        if (invoiceId) {
-          await this.anularFacturaPendiente(invoiceId, contexto);
-        }
+      liquidado = await this.withSubscriptionSyncLock(
+        user.id,
+        async (lockToken) => {
+          // El resultado MANDA. La lectura que trajo aquí es de antes del lease,
+          // y en ese hueco cabe el cliente pagando desde el portal: cancelar
+          // ignorando que la factura se saldó le quitaría el contrato que acaba
+          // de poner al día, y el alta que sigue le cobraría por segunda vez.
+          if (invoiceId) {
+            const factura = await this.anularFacturaPendiente(
+              invoiceId,
+              contexto,
+            );
 
-        await this.cancelarSuscripcion(impagada.id, contexto);
+            if (factura === 'cobrada') {
+              return false;
+            }
+          }
 
-        await this.withRetry(
-          () =>
-            this.firestoreService.updateUserSubscriptionState(
-              user.id,
-              { plan: 'free', stripeSubscriptionId: null },
-              new Date(),
-              lockToken,
-            ),
-          `liquidarContratoImpagadoAntesDelAlta(${user.id})`,
-        );
-      });
+          await this.cancelarSuscripcion(impagada.id, contexto);
 
-      this.logger.warn(
-        `Contrato impagado liquidado para permitir el alta — ${contexto}.`,
+          await this.withRetry(
+            () =>
+              this.firestoreService.updateUserSubscriptionState(
+                user.id,
+                { plan: 'free', stripeSubscriptionId: null },
+                new Date(),
+                lockToken,
+              ),
+            `liquidarContratoImpagadoAntesDelAlta(${user.id})`,
+          );
+
+          return true;
+        },
       );
     } catch (error) {
       this.logger.error(
@@ -2381,6 +2510,14 @@ export class PaymentsService {
           'in a few minutes or contact support@zplpdf.com.',
       );
     }
+
+    this.logger.warn(
+      liquidado
+        ? `Contrato impagado liquidado para permitir el alta — ${contexto}.`
+        : `Alta detenida: el contrato se puso al corriente mientras se liquidaba — ${contexto}.`,
+    );
+
+    return liquidado;
   }
 
   async handlePaymentFailed(invoice: Stripe.Invoice): Promise<void> {

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -35,6 +35,10 @@ import { randomUUID } from 'node:crypto';
 type PaidPlanType = 'lite' | 'pro' | 'promax' | 'enterprise';
 /** Planes de pago vendibles por checkout/upgrade (excluye enterprise, que es manual). */
 type SellablePlan = 'lite' | 'pro' | 'promax';
+type FuenteMrrBaja =
+  | { subscription: Stripe.Subscription }
+  | { invoice: Stripe.Invoice };
+type MrrPerdido = Pick<SubscriptionEvent, 'currency' | 'mrr' | 'mrrMxn'>;
 
 @Injectable()
 export class PaymentsService {
@@ -2114,14 +2118,19 @@ export class PaymentsService {
       // no se reescribe, no se manda un segundo correo y no se cuenta otra vez.
       // Y si este camino llega primero, es este el que la contabiliza — antes no
       // lo hacía ninguno de los dos y la baja podía no aparecer en el panel.
+      const razonDeStripe = current.cancellation_details?.reason ?? undefined;
+      const bajaPorImpago =
+        PaymentsService.ESTADOS_IMPAGADOS.includes(current.status) ||
+        razonDeStripe === 'payment_failed';
+
       await this.registrarBajaDefinitiva(
         user,
         current.id,
-        PaymentsService.ESTADOS_IMPAGADOS.includes(current.status)
-          ? 'payment_failed'
-          : 'canceled',
+        bajaPorImpago ? 'payment_failed' : 'canceled',
         readAt,
         lockToken,
+        { subscription: current },
+        razonDeStripe,
       );
     }
   }
@@ -2213,13 +2222,17 @@ export class PaymentsService {
         // inicial y esta, la baja se aplicaría bien pero se registraría y se
         // notificaría como PRO. El helper también absorbe el eco de la
         // cancelación que lanza este mismo servicio al liquidar un impago.
+        const razonDeStripe =
+          subscription.cancellation_details?.reason ?? undefined;
+
         return this.registrarBajaDefinitiva(
           fresh,
           subscription.id,
-          'canceled',
+          razonDeStripe === 'payment_failed' ? 'payment_failed' : 'canceled',
           new Date(),
           lockToken,
-          subscription.cancellation_details?.reason || undefined,
+          { subscription },
+          razonDeStripe,
         );
       },
       'la baja de la suscripción',
@@ -2261,12 +2274,72 @@ export class PaymentsService {
    *
    * @returns `true` si esta llamada fue la que aplicó la baja.
    */
+  private async calcularMrrPerdido(
+    fuente: FuenteMrrBaja,
+    country?: string,
+  ): Promise<MrrPerdido> {
+    let amountMinor = 0;
+    let sourceCurrency: string | undefined;
+
+    if ('subscription' in fuente) {
+      const items = fuente.subscription.items.data;
+      sourceCurrency = items[0]?.price?.currency;
+      amountMinor = items.reduce((total, item) => {
+        const decimal = item.price?.unit_amount_decimal;
+        const unitAmount =
+          item.price?.unit_amount ?? (decimal ? Number(decimal) : 0);
+        return total + unitAmount * (item.quantity ?? 1);
+      }, 0);
+    } else {
+      sourceCurrency = fuente.invoice.currency;
+      amountMinor = fuente.invoice.amount_due ?? 0;
+    }
+
+    const currency: 'usd' | 'mxn' =
+      sourceCurrency?.toLowerCase() === 'mxn' ||
+      (!sourceCurrency && country === 'MX')
+        ? 'mxn'
+        : 'usd';
+    const mrr = Math.max(0, amountMinor) / 100;
+
+    if (mrr === 0) {
+      this.logger.warn(
+        `No se pudo determinar el MRR perdido desde ${
+          'subscription' in fuente ? fuente.subscription.id : fuente.invoice.id
+        }; el evento de baja conservará importe cero.`,
+      );
+      return { currency, mrr, mrrMxn: 0 };
+    }
+
+    if (currency === 'mxn') {
+      return { currency, mrr, mrrMxn: mrr };
+    }
+
+    try {
+      const conversion = await this.exchangeRateService.convertUsdToMxn(
+        mrr,
+        this.firestoreService,
+      );
+      return { currency, mrr, mrrMxn: conversion.amountMxn };
+    } catch (error) {
+      // La baja no debe perderse porque el proveedor de tipo de cambio esté
+      // caído. Es el mismo fallback que ya usan altas y renovaciones.
+      const fallbackRate = 20;
+      this.logger.warn(
+        `No se pudo convertir el MRR churneado a MXN: ${(error as Error).message}. ` +
+          `Se usa la tasa de respaldo ${fallbackRate}.`,
+      );
+      return { currency, mrr, mrrMxn: mrr * fallbackRate };
+    }
+  }
+
   private async registrarBajaDefinitiva(
     user: User,
     subscriptionId: string,
     motivo: 'payment_failed' | 'canceled',
     readAt: Date,
     lockToken: string,
+    fuenteMrr: FuenteMrrBaja,
     /** Motivo que da Stripe, cuando la baja viene de un evento suyo. */
     razonDeStripe?: string,
   ): Promise<boolean> {
@@ -2287,6 +2360,7 @@ export class PaymentsService {
       user.plan === 'enterprise'
         ? user.plan
         : 'pro';
+    const mrrPerdido = await this.calcularMrrPerdido(fuenteMrr, user.country);
 
     // `churned` distingue la baja involuntaria de la que el cliente decide, y
     // las métricas cuentan ambos tipos, así que separar no esconde nada del panel.
@@ -2297,9 +2371,9 @@ export class PaymentsService {
       eventType: motivo === 'payment_failed' ? 'churned' : 'canceled',
       plan: planPerdido,
       previousPlan: planPerdido,
-      currency: user.country === 'MX' ? 'mxn' : 'usd',
-      mrr: 0,
-      mrrMxn: 0,
+      currency: mrrPerdido.currency,
+      mrr: mrrPerdido.mrr,
+      mrrMxn: mrrPerdido.mrrMxn,
       stripeSubscriptionId: subscriptionId,
       cancellationReason: razonDeStripe ?? motivo,
       country: user.country,
@@ -2498,6 +2572,18 @@ export class PaymentsService {
       liquidado = await this.withSubscriptionSyncLock(
         user.id,
         async (lockToken) => {
+          const fresh =
+            (await this.firestoreService.getUserById(user.id)) ?? user;
+
+          if (
+            fresh.stripeSubscriptionId &&
+            fresh.stripeSubscriptionId !== impagada.id
+          ) {
+            throw new Error(
+              `el usuario ya apunta a otra suscripción (${fresh.stripeSubscriptionId})`,
+            );
+          }
+
           // El resultado MANDA. La lectura que trajo aquí es de antes del lease,
           // y en ese hueco cabe el cliente pagando desde el portal: cancelar
           // ignorando que la factura se saldó le quitaría el contrato que acaba
@@ -2515,16 +2601,30 @@ export class PaymentsService {
 
           await this.cancelarSuscripcion(impagada.id, contexto);
 
-          await this.withRetry(
-            () =>
-              this.firestoreService.updateUserSubscriptionState(
-                user.id,
-                { plan: 'free', stripeSubscriptionId: null },
-                new Date(),
-                lockToken,
-              ),
-            `liquidarContratoImpagadoAntesDelAlta(${user.id})`,
+          // La liquidación observada desde checkout es la misma baja que ven los
+          // webhooks. Debe pasar por el punto único para escribir también el
+          // churn y encolar exactamente una notificación.
+          const aplicado = await this.registrarBajaDefinitiva(
+            fresh,
+            impagada.id,
+            'payment_failed',
+            new Date(),
+            lockToken,
+            { subscription: impagada },
+            'payment_failed',
           );
+
+          // `false` tras una lectura que todavía conserva el contrato significa
+          // que el fencing rechazó la escritura. Continuar abriría el checkout
+          // con Firestore apuntando al estado viejo.
+          if (
+            !aplicado &&
+            !(fresh.plan === 'free' && !fresh.stripeSubscriptionId)
+          ) {
+            throw new Error(
+              'la escritura de la baja fue rechazada por el fencing de sincronización',
+            );
+          }
 
           return true;
         },
@@ -2636,6 +2736,7 @@ export class PaymentsService {
           'payment_failed',
           new Date(),
           lockToken,
+          { invoice },
         );
       },
     );

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -2015,9 +2015,9 @@ export class PaymentsService {
     const priceId = current.items.data[0]?.price?.id;
     const plan = priceId ? this.getPlanFromPriceId(priceId) : null;
 
-    // Si la suscripción está activa pero no podemos resolver el plan, no tocamos
+    // Si la suscripción está viva pero no podemos resolver el plan, no tocamos
     // el plan del usuario (evita asignar uno incorrecto por mala configuración).
-    if (current.status === 'active' && !plan) {
+    if (PaymentsService.ESTADOS_VIVOS.includes(current.status) && !plan) {
       this.logger.error(
         `CRITICAL: No se pudo determinar el plan para subscription.updated de user ${user.id} ` +
           `(sub ${current.id}). Plan NO actualizado. Revisar STRIPE_*_PRICE_ID.`,
@@ -2028,7 +2028,13 @@ export class PaymentsService {
     // Check subscription status with retry
     const period = this.resolveBillingPeriod(current);
 
-    if (current.status === 'active') {
+    // `trialing` entra aquí junto a `active`: son los dos estados que dan derecho
+    // al plan. Comparar contra `active` a secas dejaba a `trialing` sin ninguna
+    // rama —ni escribe plan ni degrada—, y este webhook es precisamente el que
+    // repara un upgrade que Stripe aplicó pero Firestore no llegó a guardar. Sin
+    // esto, un upgrade durante una prueba se quedaba sin nada que lo arreglase
+    // después: el fallo del camino principal era definitivo.
+    if (PaymentsService.ESTADOS_VIVOS.includes(current.status)) {
       // IMPORTANT: Only include period fields if they have values - Firestore rejects undefined
       const activeUpdateData: Record<string, unknown> = {
         plan,
@@ -2194,108 +2200,37 @@ export class PaymentsService {
               `lease: el usuario ${user.id} ya tiene activa ` +
               `${fresh.stripeSubscriptionId}.`,
           );
-          return { aplicado: false as const };
+          return false;
         }
 
-        // Eco de una baja ya aplicada. Desde #65 lo provoca el flujo normal: la
-        // cancelación por impago la lanza este mismo servicio, y Stripe devuelve
-        // el `deleted` cuando el usuario ya está en Free y sin contrato. Sin este
-        // corte se reescribe lo mismo, se manda un segundo correo de degradación
-        // —a veces un tercero, contando el de `subscription.updated`— y se guarda
-        // otro evento de baja, con lo que el churn queda contado por duplicado.
-        // Peor aún: con el plan ya en `free`, el cálculo de abajo cae al
-        // `'pro'` por defecto, así que a un cliente de LITE se le nombraría un
-        // plan que nunca tuvo.
-        if (fresh.plan === 'free' && !fresh.stripeSubscriptionId) {
-          this.logger.log(
-            `subscription.deleted de ${subscription.id} es eco de una baja ya ` +
-              `aplicada para ${user.id}; no se reescribe ni se vuelve a avisar.`,
-          );
-          return { aplicado: false as const };
-        }
-
-        // El plan cancelado sale de la lectura de DENTRO del lease: si un
+        // Mismo punto único que los otros dos caminos. Este camino tenía su
+        // propia copia de degradar-avisar-registrar, con sus propios valores por
+        // defecto —`'usd'` fijo, plan `'pro'` de relleno—, y era la segunda
+        // implementación de una decisión que solo debería estar escrita una vez.
+        //
+        // El plan sale de la lectura de DENTRO del lease: si un
         // `subscription.updated` pendiente escribió PROMAX entre la lectura
         // inicial y esta, la baja se aplicaría bien pero se registraría y se
-        // notificaría como PRO.
-        const canceladoAhora =
-          fresh.plan === 'lite' ||
-          fresh.plan === 'pro' ||
-          fresh.plan === 'promax'
-            ? fresh.plan
-            : 'pro';
-
-        const escrito = await this.withRetry(
-          () =>
-            this.firestoreService.updateUserSubscriptionState(
-              user.id,
-              {
-                plan: 'free',
-                stripeSubscriptionId: null,
-              },
-              new Date(),
-              lockToken,
-            ),
-          `handleSubscriptionDeleted(${user.id})`,
+        // notificaría como PRO. El helper también absorbe el eco de la
+        // cancelación que lanza este mismo servicio al liquidar un impago.
+        return this.registrarBajaDefinitiva(
+          fresh,
+          subscription.id,
+          'canceled',
+          new Date(),
+          lockToken,
+          subscription.cancellation_details?.reason || undefined,
         );
-
-        return { aplicado: escrito, canceledPlan: canceladoAhora };
       },
       'la baja de la suscripción',
     );
 
-    const canceledPlan = resultado.canceledPlan ?? 'pro';
-
-    if (!resultado.aplicado) {
-      this.logger.warn(
-        `Baja de ${user.id} no escrita: el documento ya refleja una lectura ` +
-          `posterior o el lease cambió de manos.`,
+    if (!resultado) {
+      this.logger.log(
+        `Baja de ${user.id} no escrita en este ciclo: ya aplicada, descartada ` +
+          `por obsoleta, o de un contrato que no es el vigente.`,
       );
-      return;
     }
-
-    this.logger.log(
-      `User ${user.id} downgraded to Free plan (was ${canceledPlan})`,
-    );
-
-    // Send downgrade notification email
-    this.emailService
-      .queueSubscriptionDowngradedEmail(
-        {
-          id: user.id,
-          email: user.email,
-          displayName: user.displayName,
-          language: this.detectLanguageFromCountry(user.country),
-        },
-        canceledPlan,
-        'canceled',
-      )
-      .catch((err) =>
-        this.logger.error(
-          `Failed to queue subscription downgraded email: ${err.message}`,
-        ),
-      );
-
-    // Save subscription event for churn tracking
-    const subscriptionEvent: SubscriptionEvent = {
-      id: this.generateSubscriptionEventId(),
-      userId: user.id,
-      userEmail: user.email,
-      eventType: 'canceled',
-      plan: canceledPlan,
-      previousPlan: canceledPlan,
-      currency: 'usd', // Default, actual currency not available in deleted event
-      mrr: 0,
-      mrrMxn: 0,
-      stripeSubscriptionId: subscription.id,
-      cancellationReason:
-        subscription.cancellation_details?.reason || undefined,
-      country: user.country,
-      createdAt: new Date(),
-    };
-
-    await this.firestoreService.saveSubscriptionEvent(subscriptionEvent);
-    this.logger.log(`Saved subscription event: canceled for user ${user.id}`);
   }
 
   /**
@@ -2313,9 +2248,16 @@ export class PaymentsService {
    * sino el propio estado resultante —Free y sin contrato—, que ningún otro
    * camino puede confundir con una baja pendiente.
    *
-   * El aviso y el registro van atados a que la escritura se aplique de verdad:
-   * si el fencing la descarta por obsoleta, no hay baja que contar ni de la que
-   * avisar.
+   * **La degradación y el registro del churn van en la MISMA transacción.**
+   * Escribir el evento después no servía: si esa segunda escritura fallaba, la
+   * reentrega del webhook encontraba al usuario ya en Free, lo tomaba por trabajo
+   * hecho y la baja no se contabilizaba nunca. Y al revés —registrar primero—
+   * un fencing que descartase la degradación habría contado un churn que no
+   * ocurrió. Dentro de la transacción constan las dos cosas o ninguna.
+   *
+   * El aviso queda fuera a propósito: es el único de los tres que no es dato, y
+   * el servicio de correo se traga sus propios errores. Un correo perdido es
+   * recuperable a mano; una baja sin contabilizar, no.
    *
    * @returns `true` si esta llamada fue la que aplicó la baja.
    */
@@ -2325,6 +2267,8 @@ export class PaymentsService {
     motivo: 'payment_failed' | 'canceled',
     readAt: Date,
     lockToken: string,
+    /** Motivo que da Stripe, cuando la baja viene de un evento suyo. */
+    razonDeStripe?: string,
   ): Promise<boolean> {
     if (user.plan === 'free' && !user.stripeSubscriptionId) {
       this.logger.log(
@@ -2344,6 +2288,24 @@ export class PaymentsService {
         ? user.plan
         : 'pro';
 
+    // `churned` distingue la baja involuntaria de la que el cliente decide, y
+    // las métricas cuentan ambos tipos, así que separar no esconde nada del panel.
+    const evento: SubscriptionEvent = {
+      id: this.generateSubscriptionEventId(),
+      userId: user.id,
+      userEmail: user.email,
+      eventType: motivo === 'payment_failed' ? 'churned' : 'canceled',
+      plan: planPerdido,
+      previousPlan: planPerdido,
+      currency: user.country === 'MX' ? 'mxn' : 'usd',
+      mrr: 0,
+      mrrMxn: 0,
+      stripeSubscriptionId: subscriptionId,
+      cancellationReason: razonDeStripe ?? motivo,
+      country: user.country,
+      createdAt: new Date(),
+    };
+
     const aplicado = await this.withRetry(
       () =>
         this.firestoreService.updateUserSubscriptionState(
@@ -2351,6 +2313,8 @@ export class PaymentsService {
           { plan: 'free', stripeSubscriptionId: null },
           readAt,
           lockToken,
+          // En la misma transacción: o consta la baja y su registro, o ninguno.
+          evento,
         ),
       `registrarBajaDefinitiva(${user.id})`,
     );
@@ -2364,7 +2328,8 @@ export class PaymentsService {
     }
 
     this.logger.warn(
-      `Baja aplicada para ${user.id}: ${planPerdido.toUpperCase()} → free (${motivo}).`,
+      `Baja aplicada para ${user.id}: ${planPerdido.toUpperCase()} → free ` +
+        `(${motivo}), evento ${evento.id}.`,
     );
 
     this.emailService
@@ -2383,25 +2348,6 @@ export class PaymentsService {
           `Failed to queue subscription downgraded email: ${err.message}`,
         ),
       );
-
-    // `churned` distingue la baja involuntaria de la que el cliente decide, y
-    // las métricas ya lo cuentan junto a `canceled` (`finance.service.ts`), así
-    // que separar no esconde ninguna baja del panel.
-    await this.firestoreService.saveSubscriptionEvent({
-      id: this.generateSubscriptionEventId(),
-      userId: user.id,
-      userEmail: user.email,
-      eventType: motivo === 'payment_failed' ? 'churned' : 'canceled',
-      plan: planPerdido,
-      previousPlan: planPerdido,
-      currency: user.country === 'MX' ? 'mxn' : 'usd',
-      mrr: 0,
-      mrrMxn: 0,
-      stripeSubscriptionId: subscriptionId,
-      cancellationReason: motivo,
-      country: user.country,
-      createdAt: new Date(),
-    });
 
     return true;
   }


### PR DESCRIPTION
Cierra #65.

## El callejón

Los dos endpoints de cambio de plan discrepaban sobre qué suscripción está viva:

| | estados que consideraba vivos |
|---|---|
| `createCheckoutSession` | `active`, `trialing`, `past_due` |
| `upgradeSubscription` | solo `active` |

Un cliente en `past_due` quedaba encerrado: checkout lo remitía al endpoint de upgrade para no crear una suscripción duplicada, y upgrade lo rechazaba por no estar `active`. No había camino ni para subir de plan ni para volver a pagar. Lo tocó un caso real (`sistemas@prodisab2b.com`, 2026-08-04).

## La política

El issue dejaba abierto qué hacer con `past_due`. La decisión: **quien no paga vuelve a Free y no arrastra factura impagada**. Con eso `past_due` deja de conceder plan, y el estado intermedio que encerraba al cliente deja de existir.

`ESTADOS_VIVOS` pasa a ser la única fuente de verdad —la consultan checkout, upgrade y la adopción del checkout—. Mantener dos listas fue exactamente la causa de que divergieran.

## Dónde NO se aplica

`invoice.payment_failed` llega por tres motivos y solo uno es "no pagar la suscripción":

| `billing_reason` | qué se hace | por qué |
|---|---|---|
| `subscription_cycle` | anular factura, cancelar, degradar a Free | es la renovación impagada |
| `subscription_create` | solo avisar | el alta nunca concedió plan; Stripe expira sola la `incomplete` |
| `subscription_update` | solo avisar | **el cliente tiene su plan al corriente**; lo que falló fue la mejora |

El tercero es el que puede hacer daño: cancelar ahí le quitaría al cliente lo que sí pagó por no poder pagar lo que pidió de más, y desharía el `pending_if_incomplete` con el que #73 protegió justamente ese caso.

## Los frenos

- **Se relee la factura en Stripe antes de tocar nada.** El payload describe el instante del fallo, no el de ahora: entre medias caben una reentrega, un reintento que sí cobró, o el cliente pagando a mano desde el portal. Sin releer, se le quitaría el plan a quien acaba de pagarlo.
- **Se anula antes de cancelar.** Si falla la cancelación queda un contrato sin deuda, recuperable. Al revés quedaría el cliente sin plan y con una factura viva persiguiéndole — lo contrario de lo que busca la política.
- **Se ignora la factura de un contrato ya sustituido**, revalidando dentro del lease de sincronización (#77).

## Efectos colaterales que había que cerrar

- **El checkout liquida y deja pasar**, en vez de bloquear. Si no consigue cerrar el contrato, aborta el alta: dejar pasar crearía la segunda suscripción viva que la liquidación venía a impedir.
- **El contraste con Stripe va ahora ANTES de mirar el plan del documento.** Al revés, el cliente al que acaban de cortarle el PRO por impago no podía recontratar PRO mientras el webhook de degradación no hubiera llegado: salía rechazado por «ya estás suscrito».
- **`past_due` en `subscription.updated` degrada** en lugar de conservar el plan. Su rama anterior restauraba el `stripeSubscriptionId` que la degradación acababa de limpiar, y el sello por `readAt` no lo frenaba porque es una lectura genuinamente posterior. Ahora el orden de llegada de los dos eventos deja de importar: ambos escriben lo mismo.
- El mensaje de upgrade bloqueado en `past_due`/`unpaid` pasa de «actualiza tu método de pago» a «vuelve a contratar»: ya no queda suscripción que rescatar con una tarjeta nueva.

## Verificación

`npm run build` sin issues, `eslint` limpio, **310 tests pasan** (12 nuevos). Los nuevos cubren sobre todo los frenos, porque cancelar de más le quita a alguien algo que pagó.

## ⚠️ Requiere acción en el Dashboard de Stripe

El código cancela al primer fallo, pero conviene alinear el dunning para que Stripe no siga reintentando un contrato ya cancelado: **Billing → Subscriptions and emails → Manage failed payments**. Sin ese ajuste el comportamiento es correcto igualmente —la cancelación es nuestra—, pero los reintentos de Stripe quedan huérfanos.

No se ha podido verificar desde aquí qué política tiene configurada la cuenta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)