### PR TITLE
chore(ci): verificar build, lint y pruebas en cada PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [development, main]
   push:
-    branches: [development, main, chore/ci-verificacion-en-prs]
+    branches: [development, main]
 
 # Un PR que recibe varios push seguidos no necesita terminar las ejecuciones
 # viejas: solo importa el estado del último commit.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+# Hasta ahora build, lint y pruebas dependían de que alguien los corriera a mano
+# antes de aprobar un PR, y no quedaba constancia de si se habían corrido (#79).
+on:
+  pull_request:
+    branches: [development, main]
+  push:
+    branches: [development, main]
+
+# Un PR que recibe varios push seguidos no necesita terminar las ejecuciones
+# viejas: solo importa el estado del último commit.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: build · lint · tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          # La misma que corre en producción (`FROM node:18-slim` en el
+          # Dockerfile). Verificar sobre otra versión dejaría pasar justo lo que
+          # solo falla en la desplegada.
+          node-version: '18'
+          cache: npm
+
+      # `ci` y no `install`: instala exactamente lo del lockfile y falla si se
+      # ha desincronizado de package.json, en vez de resolverlo por su cuenta.
+      - run: npm ci
+
+      # Sin `--fix`, a diferencia de `npm run lint`: aquí hay que detectar, no
+      # arreglar. Con auto-fix el job pasaría en verde dejando los arreglos en un
+      # runner que se destruye a continuación.
+      - run: npm run lint:ci
+
+      # `nest build` corre TSC además de compilar, así que esto también cubre el
+      # chequeo de tipos del código de producción. Los specs quedan fuera: `tsc
+      # --noEmit` todavía falla por imports sin extensión `.js` (#79), y añadirlo
+      # como gate antes de sanearlos dejaría el CI en rojo desde el primer día.
+      - run: npm run build
+
+      - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [development, main]
   push:
-    branches: [development, main]
+    branches: [development, main, chore/ci-verificacion-en-prs]
 
 # Un PR que recibe varios push seguidos no necesita terminar las ejecuciones
 # viejas: solo importa el estado del último commit.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start:debug": "NODE_OPTIONS='--experimental-specifier-resolution=node' nest start --debug --watch",
     "start:prod": "node --experimental-specifier-resolution=node dist/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "lint:ci": "eslint \"{src,apps,libs,test}/**/*.ts\" --max-warnings=0",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",


### PR DESCRIPTION
Aporta el check que el review del PR #84 no pudo mirar: este repositorio no tenía `.github/workflows/`, ningún PR registraba ejecuciones y `gh pr checks` devolvía `no checks reported`. Build, lint y pruebas dependían de que alguien los corriera a mano, sin que quedara constancia de si se habían corrido.

Es la parte de CI que dejó apuntada #79.

## Decisiones

| | por qué |
|---|---|
| **Node 18** | La misma que corre en producción (`FROM node:18-slim`). Verificar sobre otra versión dejaría pasar justo lo que solo falla en la desplegada. |
| **`npm ci`** | Instala exactamente lo del lockfile y falla si se ha desincronizado de package.json, en vez de resolverlo por su cuenta. |
| **`lint:ci` nuevo** | `npm run lint` lleva `--fix`. Con auto-fix el job pasaría en verde dejando los arreglos en un runner que se destruye a continuación: detectaría cero problemas siempre. |
| **`concurrency`** | Un PR con varios push seguidos solo necesita el estado del último commit. |

## Lo que NO entra todavía

`tsc --noEmit` sigue fuera. Falla por los imports sin extensión `.js` de los specs (#79, aún abierto), y ponerlo de gate antes de sanearlos dejaría el CI en rojo desde el primer día. El chequeo de tipos del código de producción sí queda cubierto, porque `nest build` corre TSC.

Cuando se cierre #79, añadir el paso es una línea.

## Verificación

Los tres pasos corridos sobre esta rama: `lint:ci` limpio, `build` sin issues, 297/297 tests.

⚠️ **En local con Node 24, no 18** — no puedo ejercitar aquí la versión que usará el runner. Si el primer run sale rojo por incompatibilidad del tooling con Node 18, es un hallazgo en sí mismo: significaría que las herramientas ya no soportan la versión que estamos desplegando (Node 18 está en EOL desde abril de 2025), y tocaría subir la base del Dockerfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)