### PR TITLE
chore: sanear tsc --noEmit y añadirlo como gate del CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,13 @@ jobs:
       # runner que se destruye a continuación.
       - run: npm run lint:ci
 
-      # `nest build` corre TSC además de compilar, así que esto también cubre el
-      # chequeo de tipos del código de producción. Los specs quedan fuera: `tsc
-      # --noEmit` todavía falla por imports sin extensión `.js` (#79), y añadirlo
-      # como gate antes de sanearlos dejaría el CI en rojo desde el primer día.
+      # Cubre lo que `build` no ve. `nest build` corre TSC, pero solo sobre el
+      # código que compila a `dist/`: los specs quedaban sin comprobar, y ahí es
+      # donde vivían los 11 imports sin extensión `.js` de #79. Con el proyecto
+      # en ESM, TypeScript los exige aunque el fuente sea `.ts`, y jest no lo
+      # delataba porque su `moduleNameMapper` reescribe esas rutas.
+      - run: npm run typecheck
+
       - run: npm run build
 
       - run: npm test

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "start:prod": "node --experimental-specifier-resolution=node dist/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "lint:ci": "eslint \"{src,apps,libs,test}/**/*.ts\" --max-warnings=0",
+    "typecheck": "tsc --noEmit",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
+import { AppController } from './app.controller.js';
+import { AppService } from './app.service.js';
 
 describe('AppController', () => {
   let appController: AppController;

--- a/src/common/services/period-calculator.util.spec.ts
+++ b/src/common/services/period-calculator.util.spec.ts
@@ -3,7 +3,7 @@ import {
   calculateFreePeriod,
   generatePeriodId,
   UserForPeriod,
-} from './period-calculator.util';
+} from './period-calculator.util.js';
 
 describe('period-calculator.util', () => {
   describe('calculateFreePeriod (usuario Free registrado a mitad de mes)', () => {

--- a/src/modules/admin/admin.service.spec.ts
+++ b/src/modules/admin/admin.service.spec.ts
@@ -4,7 +4,7 @@ jest.mock('@google-cloud/storage', () => ({
 }));
 jest.mock('stripe', () => jest.fn());
 
-import { AdminService } from './admin.service';
+import { AdminService } from './admin.service.js';
 
 /**
  * Los eventos de cuota/acceso anteriores al fix del conversion-gate se

--- a/src/modules/email/email.service.spec.ts
+++ b/src/modules/email/email.service.spec.ts
@@ -1,10 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { Logger } from '@nestjs/common';
-import { EmailService } from './email.service';
-import { FirestoreService } from '../cache/firestore.service';
-import { PeriodCalculatorService } from '../../common/services/period-calculator.service';
-import { User, PlanType } from '../../common/interfaces/user.interface';
+import { EmailService } from './email.service.js';
+import { FirestoreService } from '../cache/firestore.service.js';
+import { PeriodCalculatorService } from '../../common/services/period-calculator.service.js';
+import { User, PlanType } from '../../common/interfaces/user.interface.js';
 
 describe('EmailService.triggerBlockedEmail', () => {
   let service: EmailService;

--- a/src/modules/zpl/zpl.service.spec.ts
+++ b/src/modules/zpl/zpl.service.spec.ts
@@ -18,7 +18,7 @@ jest.mock('@google-cloud/storage', () => ({
   })),
 }));
 
-import { ZplService, LabelSize } from './zpl.service';
+import { ZplService, LabelSize } from './zpl.service.js';
 
 /**
  * Regresión: una etiqueta de envío real (Amazon Logistics) que empieza con un

--- a/src/utils/timezone.util.spec.ts
+++ b/src/utils/timezone.util.spec.ts
@@ -1,7 +1,7 @@
 import {
   getStartOfDateInTimezone,
   getEndOfDateInTimezone,
-} from './timezone.util';
+} from './timezone.util.js';
 
 /**
  * El dashboard opera en GMT-6 (Mérida). Estos helpers convierten un string de

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
-import { AppModule } from './../src/app.module';
+import { AppModule } from './../src/app.module.js';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;


### PR DESCRIPTION
Cierra #79.

## El problema

Once imports relativos de siete specs omitían la extensión `.js`. El proyecto es ESM (`"type": "module"`), y ahí TypeScript la exige aunque el fuente sea `.ts`, así que `npx tsc --noEmit` fallaba con once `TS2307`.

Comprobado antes de tocar nada: **los once módulos referenciados existen**. Era solo la extensión, no imports rotos.

## Por qué no lo delataba nada

| | ¿ve los specs? |
|---|---|
| `nest build` | No — TSC corre, pero solo sobre lo que compila a `dist/` |
| `jest` | No — su `moduleNameMapper` reescribe `^(\.{1,2}/.*)\.js$` → `$1`, así que resuelve con extensión o sin ella |
| `tsc --noEmit` | Sí — y estaba inutilizable |

## El gate

Con el chequeo limpio, `typecheck` entra en el workflow, que era el objetivo de fondo del issue: el CI pasa a cubrir los specs y no solo el código de producción.

Pasos del job: `npm ci` → `lint:ci` → **`typecheck`** → `build` → `test`.

## Verificado que el gate detecta, no solo que pasa

Devolví un import a su forma anterior a propósito:

```
npm run typecheck  → exit 2   (error TS2307)
npx jest           → exit 0   ← no lo detecta
```

Es la prueba de que el paso añade cobertura real en vez de ser decorativo.

## Verificación

Sobre Node 22.17.0, la del runner: `npm ci` en limpio exit 0, `lint:ci` 0, `typecheck` 0, `build` con TSC en 0 issues, **331/331 pruebas**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)