### PR TITLE
fix(users): paginación real, filtros y orden en GET /api/users/history

### DIFF
--- a/src/common/interfaces/conversion-history.interface.ts
+++ b/src/common/interfaces/conversion-history.interface.ts
@@ -8,3 +8,11 @@ export interface ConversionHistory {
   fileUrl?: string;
   createdAt: Date;
 }
+
+/**
+ * Registro de historial tal y como vive en Firestore: incluye el id del
+ * documento, necesario para las acciones por fila del frontend.
+ */
+export interface ConversionHistoryRecord extends ConversionHistory {
+  id: string;
+}

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -20,7 +20,10 @@ import type {
   Cfdi,
   CfdiClaim,
 } from '../../common/interfaces/cfdi.interface.js';
-import type { ConversionHistory } from '../../common/interfaces/conversion-history.interface.js';
+import type {
+  ConversionHistory,
+  ConversionHistoryRecord,
+} from '../../common/interfaces/conversion-history.interface.js';
 import type { BatchJob } from '../zpl/interfaces/batch.interface.js';
 import type { HourlyLabelaryStats } from '../zpl/interfaces/labelary-analytics.interface.js';
 import { getDateStringInTimezone } from '../../utils/timezone.util.js';
@@ -1322,6 +1325,39 @@ export class FirestoreService {
       });
     } catch (error) {
       this.logger.error(`Error al obtener historial: ${error.message}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Lee hasta `maxScan` conversiones del usuario (las más recientes primero)
+   * incluyendo el id del documento, para filtrar, ordenar y paginar en memoria.
+   *
+   * Usa el mismo índice que `getUserConversionHistory` (`userId` + `createdAt desc`),
+   * así que no requiere índices compuestos nuevos por cada combinación de filtros.
+   */
+  async scanUserConversionHistory(
+    userId: string,
+    maxScan: number,
+  ): Promise<ConversionHistoryRecord[]> {
+    try {
+      const snapshot = await this.firestore
+        .collection(this.historyCollection)
+        .where('userId', '==', userId)
+        .orderBy('createdAt', 'desc')
+        .limit(maxScan)
+        .get();
+
+      return snapshot.docs.map((doc) => {
+        const data = doc.data();
+        return {
+          ...data,
+          id: doc.id,
+          createdAt: data.createdAt?.toDate?.() || data.createdAt,
+        } as ConversionHistoryRecord;
+      });
+    } catch (error) {
+      this.logger.error(`Error al escanear historial: ${error.message}`);
       throw error;
     }
   }

--- a/src/modules/users/dto/conversion-history.dto.ts
+++ b/src/modules/users/dto/conversion-history.dto.ts
@@ -1,0 +1,92 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { LabelSize } from '../../zpl/enums/label-size.enum.js';
+import { OutputFormat } from '../../zpl/enums/output-format.enum.js';
+import { HistoryStatus } from './get-history-query.dto.js';
+
+export class ConversionHistoryItemDto {
+  @ApiProperty({ description: 'Firestore document id' })
+  id: string;
+
+  @ApiProperty({ description: 'Conversion job id' })
+  jobId: string;
+
+  @ApiProperty({ description: 'Number of labels in the conversion' })
+  labelCount: number;
+
+  @ApiProperty({ description: 'Label size', enum: LabelSize })
+  labelSize: string;
+
+  @ApiProperty({ description: 'Conversion status', enum: HistoryStatus })
+  status: 'completed' | 'failed';
+
+  @ApiProperty({ description: 'Output format', enum: OutputFormat })
+  outputFormat: 'pdf' | 'png' | 'jpeg';
+
+  @ApiPropertyOptional({
+    description: 'Fresh signed download URL (completed conversions only)',
+  })
+  fileUrl?: string;
+
+  @ApiProperty({ description: 'Conversion date (ISO 8601)', nullable: true })
+  createdAt: string | null;
+}
+
+export class ConversionHistoryPaginationDto {
+  @ApiProperty({ description: 'Current page' })
+  page: number;
+
+  @ApiProperty({ description: 'Items per page' })
+  limit: number;
+
+  @ApiProperty({ description: 'Total items after applying filters' })
+  total: number;
+
+  @ApiProperty({ description: 'Total pages after applying filters' })
+  totalPages: number;
+
+  @ApiPropertyOptional({
+    description:
+      'True when the user has more conversions than the scan cap, so filters ' +
+      'and totals only cover the most recent ones',
+  })
+  truncated?: boolean;
+}
+
+export class ConversionHistoryFacetsDto {
+  @ApiProperty({
+    description: 'Label sizes present in the scanned history',
+    type: [String],
+  })
+  labelSizes: string[];
+
+  @ApiProperty({
+    description: 'Output formats present in the scanned history',
+    type: [String],
+  })
+  outputFormats: string[];
+
+  @ApiProperty({
+    description: 'Statuses present in the scanned history',
+    type: [String],
+  })
+  statuses: string[];
+}
+
+export class ConversionHistoryResponseDto {
+  @ApiProperty({ default: true })
+  success: true;
+
+  @ApiProperty({ type: [ConversionHistoryItemDto] })
+  data: ConversionHistoryItemDto[];
+
+  @ApiProperty({ type: ConversionHistoryPaginationDto })
+  pagination: ConversionHistoryPaginationDto;
+
+  @ApiProperty({
+    description:
+      'Values actually present in the scanned history, so the frontend can ' +
+      'populate the filter selects without hardcoding them',
+    type: ConversionHistoryFacetsDto,
+  })
+  facets: ConversionHistoryFacetsDto;
+}

--- a/src/modules/users/dto/conversion-history.dto.ts
+++ b/src/modules/users/dto/conversion-history.dto.ts
@@ -13,7 +13,9 @@ export class ConversionHistoryItemDto {
   @ApiProperty({ description: 'Number of labels in the conversion' })
   labelCount: number;
 
-  @ApiProperty({ description: 'Label size', enum: LabelSize })
+  @ApiProperty({
+    description: `Label size, e.g. ${Object.values(LabelSize).join(', ')}. Acepta cualquiera de los valores listados en facets.labelSizes`,
+  })
   labelSize: string;
 
   @ApiProperty({ description: 'Conversion status', enum: HistoryStatus })

--- a/src/modules/users/dto/get-history-query.dto.ts
+++ b/src/modules/users/dto/get-history-query.dto.ts
@@ -1,0 +1,107 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsOptional,
+  IsString,
+  IsNumber,
+  IsEnum,
+  IsDateString,
+  Min,
+  Max,
+  MaxLength,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { LabelSize } from '../../zpl/enums/label-size.enum.js';
+import { OutputFormat } from '../../zpl/enums/output-format.enum.js';
+
+export enum HistoryStatus {
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+}
+
+export enum HistorySortBy {
+  CREATED_AT = 'createdAt',
+  LABEL_COUNT = 'labelCount',
+}
+
+export enum HistorySortOrder {
+  ASC = 'asc',
+  DESC = 'desc',
+}
+
+export class GetHistoryQueryDto {
+  @ApiPropertyOptional({ default: 1, minimum: 1, description: 'Page number' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    default: 25,
+    minimum: 1,
+    maximum: 100,
+    description: 'Items per page',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  limit?: number = 25;
+
+  @ApiPropertyOptional({
+    description: 'Free text over jobId (prefix match, case-insensitive)',
+    maxLength: 100,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  search?: string;
+
+  @ApiPropertyOptional({ enum: HistoryStatus })
+  @IsOptional()
+  @IsEnum(HistoryStatus)
+  status?: HistoryStatus;
+
+  @ApiPropertyOptional({ enum: OutputFormat })
+  @IsOptional()
+  @IsEnum(OutputFormat)
+  outputFormat?: OutputFormat;
+
+  @ApiPropertyOptional({ enum: LabelSize })
+  @IsOptional()
+  @IsEnum(LabelSize)
+  labelSize?: LabelSize;
+
+  @ApiPropertyOptional({
+    description: 'Filter by conversion date from (ISO 8601, inclusive)',
+  })
+  @IsOptional()
+  @IsDateString()
+  dateFrom?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Filter by conversion date to (ISO 8601, inclusive). A date without time ' +
+      '(YYYY-MM-DD) covers the whole day',
+  })
+  @IsOptional()
+  @IsDateString()
+  dateTo?: string;
+
+  @ApiPropertyOptional({
+    enum: HistorySortBy,
+    default: HistorySortBy.CREATED_AT,
+  })
+  @IsOptional()
+  @IsEnum(HistorySortBy)
+  sortBy?: HistorySortBy = HistorySortBy.CREATED_AT;
+
+  @ApiPropertyOptional({
+    enum: HistorySortOrder,
+    default: HistorySortOrder.DESC,
+  })
+  @IsOptional()
+  @IsEnum(HistorySortOrder)
+  sortOrder?: HistorySortOrder = HistorySortOrder.DESC;
+}

--- a/src/modules/users/dto/get-history-query.dto.ts
+++ b/src/modules/users/dto/get-history-query.dto.ts
@@ -2,7 +2,7 @@ import { ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsOptional,
   IsString,
-  IsNumber,
+  IsInt,
   IsEnum,
   IsDateString,
   Min,
@@ -32,7 +32,7 @@ export class GetHistoryQueryDto {
   @ApiPropertyOptional({ default: 1, minimum: 1, description: 'Page number' })
   @IsOptional()
   @Type(() => Number)
-  @IsNumber()
+  @IsInt()
   @Min(1)
   page?: number = 1;
 
@@ -44,7 +44,7 @@ export class GetHistoryQueryDto {
   })
   @IsOptional()
   @Type(() => Number)
-  @IsNumber()
+  @IsInt()
   @Min(1)
   @Max(100)
   limit?: number = 25;
@@ -68,10 +68,22 @@ export class GetHistoryQueryDto {
   @IsEnum(OutputFormat)
   outputFormat?: OutputFormat;
 
-  @ApiPropertyOptional({ enum: LabelSize })
+  /**
+   * No se valida contra `LabelSize`: las conversiones batch guardan el tamaño
+   * tal cual llega (`BatchConvertDto.labelSize` es un string libre), así que el
+   * historial contiene valores fuera del enum (`small`, `large`, `4x4`…). Como
+   * `facets.labelSizes` los expone para poblar el select del frontend, un enum
+   * estricto rechazaría con 400 el propio valor que el endpoint acaba de
+   * ofrecer. Un tamaño inexistente simplemente no devuelve resultados.
+   */
+  @ApiPropertyOptional({
+    description: `Label size, e.g. ${Object.values(LabelSize).join(', ')}. Acepta cualquiera de los valores listados en facets.labelSizes`,
+    maxLength: 50,
+  })
   @IsOptional()
-  @IsEnum(LabelSize)
-  labelSize?: LabelSize;
+  @IsString()
+  @MaxLength(50)
+  labelSize?: string;
 
   @ApiPropertyOptional({
     description: 'Filter by conversion date from (ISO 8601, inclusive)',

--- a/src/modules/users/dto/get-history-query.dto.ts
+++ b/src/modules/users/dto/get-history-query.dto.ts
@@ -5,6 +5,7 @@ import {
   IsInt,
   IsEnum,
   IsDateString,
+  Matches,
   Min,
   Max,
   MaxLength,
@@ -12,6 +13,27 @@ import {
 import { Type } from 'class-transformer';
 import { LabelSize } from '../../zpl/enums/label-size.enum.js';
 import { OutputFormat } from '../../zpl/enums/output-format.enum.js';
+
+/**
+ * Formato extendido de ISO 8601: `YYYY-MM-DD` con hora y offset opcionales.
+ *
+ * `@IsDateString()` por sí solo es demasiado laxo para un filtro de rango: acepta
+ * el separador espacio (`2026-01-20 12:00:00`), que `Date.parse` resuelve en la
+ * zona local del proceso —el mismo filtro significaría cosas distintas en Cloud
+ * Run y en Mérida—, y también el formato básico sin guiones (`20260120T120000Z`),
+ * que `Date.parse` no entiende y devuelve `NaN`, dejando el límite ignorado en
+ * silencio. Restringiendo aquí, lo que pasa la validación siempre parsea y
+ * siempre significa lo mismo; el resto recibe un 400 explícito.
+ */
+export const ISO_DATE_PATTERN =
+  /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d{1,3})?)?(Z|[+-]\d{2}:\d{2})?)?$/;
+
+const ISO_DATE_MESSAGE =
+  '$property must be YYYY-MM-DD or YYYY-MM-DDTHH:mm[:ss[.SSS]] with an optional Z or ±HH:MM offset';
+
+const ISO_DATE_DESCRIPTION =
+  'Formato YYYY-MM-DD o YYYY-MM-DDTHH:mm[:ss[.SSS]] con Z u offset ±HH:MM opcional. ' +
+  'Sin zona horaria se interpreta como UTC.';
 
 export enum HistoryStatus {
   COMPLETED = 'completed',
@@ -86,19 +108,23 @@ export class GetHistoryQueryDto {
   labelSize?: string;
 
   @ApiPropertyOptional({
-    description: 'Filter by conversion date from (ISO 8601, inclusive)',
+    description: `Filter by conversion date from (inclusive). ${ISO_DATE_DESCRIPTION}`,
+    example: '2026-01-01',
   })
   @IsOptional()
   @IsDateString()
+  @Matches(ISO_DATE_PATTERN, { message: ISO_DATE_MESSAGE })
   dateFrom?: string;
 
   @ApiPropertyOptional({
     description:
-      'Filter by conversion date to (ISO 8601, inclusive). A date without time ' +
-      '(YYYY-MM-DD) covers the whole day',
+      `Filter by conversion date to (inclusive). ${ISO_DATE_DESCRIPTION} ` +
+      'A date without time (YYYY-MM-DD) covers the whole day',
+    example: '2026-01-31T23:59:59.999Z',
   })
   @IsOptional()
   @IsDateString()
+  @Matches(ISO_DATE_PATTERN, { message: ISO_DATE_MESSAGE })
   dateTo?: string;
 
   @ApiPropertyOptional({

--- a/src/modules/users/dto/get-history-query.dto.ts
+++ b/src/modules/users/dto/get-history-query.dto.ts
@@ -112,7 +112,7 @@ export class GetHistoryQueryDto {
     example: '2026-01-01',
   })
   @IsOptional()
-  @IsDateString()
+  @IsDateString({ strict: true })
   @Matches(ISO_DATE_PATTERN, { message: ISO_DATE_MESSAGE })
   dateFrom?: string;
 
@@ -123,7 +123,7 @@ export class GetHistoryQueryDto {
     example: '2026-01-31T23:59:59.999Z',
   })
   @IsOptional()
-  @IsDateString()
+  @IsDateString({ strict: true })
   @Matches(ISO_DATE_PATTERN, { message: ISO_DATE_MESSAGE })
   dateTo?: string;
 

--- a/src/modules/users/dto/index.ts
+++ b/src/modules/users/dto/index.ts
@@ -1,2 +1,4 @@
 export * from './user-profile.dto.js';
 export * from './user-limits.dto.js';
+export * from './get-history-query.dto.js';
+export * from './conversion-history.dto.js';

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -16,13 +16,26 @@ import {
   ApiBearerAuth,
   ApiQuery,
 } from '@nestjs/swagger';
-import { UsersService } from './users.service.js';
+import {
+  UsersService,
+  DEFAULT_HISTORY_LIMIT,
+  MAX_HISTORY_SCAN,
+} from './users.service.js';
 import { FirebaseAuthGuard } from '../../common/guards/firebase-auth.guard.js';
 import { CurrentUser } from '../../common/decorators/current-user.decorator.js';
 import type { FirebaseUser } from '../../common/decorators/current-user.decorator.js';
 import { UserProfileDto } from './dto/user-profile.dto.js';
 import { UserLimitsDto } from './dto/user-limits.dto.js';
 import { VerificationStatusDto } from './dto/verification-status.dto.js';
+import {
+  GetHistoryQueryDto,
+  HistorySortBy,
+  HistorySortOrder,
+  HistoryStatus,
+} from './dto/get-history-query.dto.js';
+import { ConversionHistoryResponseDto } from './dto/conversion-history.dto.js';
+import { LabelSize } from '../zpl/enums/label-size.enum.js';
+import { OutputFormat } from '../zpl/enums/output-format.enum.js';
 
 @ApiTags('users')
 @ApiBearerAuth()
@@ -139,36 +152,95 @@ export class UsersController {
   }
 
   @Get('history')
-  @ApiOperation({ summary: 'Get conversion history (Pro/Enterprise only)' })
+  @ApiOperation({
+    summary: 'Get conversion history (Pro/Pro Max/Enterprise only)',
+    description:
+      'Devuelve el historial de conversiones con filtros, orden y paginación real. ' +
+      `Los filtros y el orden se aplican sobre las ${MAX_HISTORY_SCAN} conversiones más ` +
+      'recientes del usuario; si tiene más, la respuesta incluye `pagination.truncated: true`. ' +
+      '`facets` lista los valores presentes en ese bloque, para poblar los selects del frontend.',
+  })
   @ApiQuery({
     name: 'page',
     required: false,
     type: Number,
-    description: 'Page number (default: 1)',
+    description: 'Page number, min 1 (default: 1)',
   })
   @ApiQuery({
     name: 'limit',
     required: false,
     type: Number,
-    description: 'Items per page (default: 50)',
+    description: `Items per page, min 1 max 100 (default: ${DEFAULT_HISTORY_LIMIT})`,
+  })
+  @ApiQuery({
+    name: 'search',
+    required: false,
+    type: String,
+    description:
+      'Filtra por jobId (coincidencia por prefijo, case-insensitive)',
+  })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    enum: HistoryStatus,
+    description: 'Filtra por estado de la conversión',
+  })
+  @ApiQuery({
+    name: 'outputFormat',
+    required: false,
+    enum: OutputFormat,
+    description: 'Filtra por formato de salida',
+  })
+  @ApiQuery({
+    name: 'labelSize',
+    required: false,
+    enum: LabelSize,
+    description: 'Filtra por tamaño de etiqueta',
+  })
+  @ApiQuery({
+    name: 'dateFrom',
+    required: false,
+    type: String,
+    description: 'createdAt >= dateFrom (ISO 8601)',
+  })
+  @ApiQuery({
+    name: 'dateTo',
+    required: false,
+    type: String,
+    description:
+      'createdAt <= dateTo (ISO 8601). Una fecha sin hora (YYYY-MM-DD) incluye ' +
+      'el día completo',
+  })
+  @ApiQuery({
+    name: 'sortBy',
+    required: false,
+    enum: HistorySortBy,
+    description: 'Campo de orden (default: createdAt)',
+  })
+  @ApiQuery({
+    name: 'sortOrder',
+    required: false,
+    enum: HistorySortOrder,
+    description: 'Dirección del orden (default: desc)',
   })
   @ApiResponse({
     status: 200,
     description: 'Conversion history',
+    type: ConversionHistoryResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Query parameters inválidos',
   })
   @ApiResponse({
     status: 403,
-    description: 'History is only available for Pro and Enterprise plans',
+    description:
+      'History is only available for Pro, Pro Max and Enterprise plans',
   })
   async getHistory(
     @CurrentUser() user: FirebaseUser,
-    @Query('page') page?: number,
-    @Query('limit') limit?: number,
-  ) {
-    return this.usersService.getUserHistory(
-      user.uid,
-      page ? Number(page) : 1,
-      limit ? Number(limit) : 50,
-    );
+    @Query() query: GetHistoryQueryDto,
+  ): Promise<ConversionHistoryResponseDto> {
+    return this.usersService.getUserHistory(user.uid, query);
   }
 }

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -194,8 +194,11 @@ export class UsersController {
   @ApiQuery({
     name: 'labelSize',
     required: false,
-    enum: LabelSize,
-    description: 'Filtra por tamaño de etiqueta',
+    type: String,
+    description:
+      `Filtra por tamaño de etiqueta. No es un enum cerrado: las conversiones batch ` +
+      `guardan el tamaño sin normalizar, así que además de ${Object.values(LabelSize).join(', ')} ` +
+      'acepta cualquier valor de facets.labelSizes',
   })
   @ApiQuery({
     name: 'dateFrom',

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -1,0 +1,490 @@
+// Evitar la conexión real a Google Cloud Storage / Stripe al cargar el módulo.
+jest.mock('@google-cloud/storage', () => ({
+  Storage: jest.fn().mockImplementation(() => ({ bucket: jest.fn() })),
+}));
+jest.mock('stripe', () => jest.fn());
+
+import { UsersService, MAX_HISTORY_SCAN } from './users.service.js';
+import {
+  HistorySortBy,
+  HistorySortOrder,
+  HistoryStatus,
+} from './dto/get-history-query.dto.js';
+import { LabelSize } from '../zpl/enums/label-size.enum.js';
+import { OutputFormat } from '../zpl/enums/output-format.enum.js';
+import type { ConversionHistoryRecord } from '../../common/interfaces/conversion-history.interface.js';
+
+/**
+ * `getUserHistory` devolvía un array plano sin metadatos, así que el frontend
+ * calculaba `totalPages` con `Math.ceil(data.length / limit)` y siempre le daba
+ * 1: un usuario con 300 conversiones solo veía las 10 más recientes (issue #89).
+ */
+describe('UsersService — getUserHistory', () => {
+  /** URL firmada con el formato real, para que `extractStorageInfo` la parsee. */
+  function signedUrl(file: string): string {
+    return `https://storage.googleapis.com/bucket-zpl/${file}?X-Goog-Algorithm=GOOG4-RSA-SHA256`;
+  }
+
+  function record(
+    overrides: Partial<ConversionHistoryRecord> & { id: string },
+  ): ConversionHistoryRecord {
+    return {
+      userId: 'uid-1',
+      jobId: `job-${overrides.id}`,
+      labelCount: 10,
+      labelSize: LabelSize.FOUR_BY_SIX,
+      status: 'completed',
+      outputFormat: OutputFormat.PDF,
+      fileUrl: signedUrl(`${overrides.id}.pdf`),
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      ...overrides,
+    };
+  }
+
+  /**
+   * UsersService tiene un constructor con muchas dependencias que estos tests no
+   * ejercitan. Instanciamos por prototipo e inyectamos solo lo necesario.
+   */
+  function buildService(
+    records: ConversionHistoryRecord[],
+    user: Record<string, unknown> = { id: 'uid-1', plan: 'pro' },
+  ) {
+    const scanUserConversionHistory = jest.fn().mockResolvedValue(records);
+    const generateSignedUrlForPath = jest
+      .fn()
+      .mockImplementation(async (path: string) => `signed://${path}`);
+
+    const service: any = Object.create(UsersService.prototype);
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    service.historyScanCache = new Map();
+    service.firestoreService = {
+      getUserById: jest.fn().mockResolvedValue(user),
+      scanUserConversionHistory,
+    };
+    service.storageService = { generateSignedUrlForPath };
+
+    return { service, scanUserConversionHistory, generateSignedUrlForPath };
+  }
+
+  describe('paginación', () => {
+    const many = Array.from({ length: 30 }, (_, i) =>
+      record({
+        id: `r${String(i).padStart(2, '0')}`,
+        createdAt: new Date(Date.UTC(2026, 0, 1, 0, 0, i)),
+      }),
+    );
+
+    it('devuelve totales reales aunque la página venga llena', async () => {
+      const { service } = buildService(many);
+
+      const result = await service.getUserHistory('uid-1', {
+        page: 1,
+        limit: 10,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toHaveLength(10);
+      expect(result.pagination).toMatchObject({
+        page: 1,
+        limit: 10,
+        total: 30,
+        totalPages: 3,
+      });
+    });
+
+    it('page=2 devuelve registros distintos a page=1', async () => {
+      const { service } = buildService(many);
+
+      const first = await service.getUserHistory('uid-1', {
+        page: 1,
+        limit: 10,
+      });
+      const second = await service.getUserHistory('uid-1', {
+        page: 2,
+        limit: 10,
+      });
+
+      const firstIds = first.data.map((r: { id: string }) => r.id);
+      const secondIds = second.data.map((r: { id: string }) => r.id);
+
+      expect(secondIds).toHaveLength(10);
+      expect(firstIds).not.toEqual(secondIds);
+      expect(firstIds.some((id: string) => secondIds.includes(id))).toBe(false);
+    });
+
+    it('totalPages es 1 cuando no hay resultados, no 0', async () => {
+      const { service } = buildService([]);
+
+      const result = await service.getUserHistory('uid-1', {});
+
+      expect(result.pagination.total).toBe(0);
+      expect(result.pagination.totalPages).toBe(1);
+      expect(result.data).toEqual([]);
+    });
+
+    it('marca truncated cuando el usuario supera el tope de escaneo', async () => {
+      const atCap = Array.from({ length: MAX_HISTORY_SCAN }, (_, i) =>
+        record({ id: `t${i}` }),
+      );
+      const { service } = buildService(atCap);
+
+      const result = await service.getUserHistory('uid-1', { limit: 10 });
+
+      expect(result.pagination.truncated).toBe(true);
+    });
+
+    it('no marca truncated por debajo del tope', async () => {
+      const { service } = buildService(many);
+
+      const result = await service.getUserHistory('uid-1', {});
+
+      expect(result.pagination.truncated).toBeUndefined();
+    });
+  });
+
+  describe('orden', () => {
+    it('sin parámetros devuelve las conversiones más recientes primero', async () => {
+      const { service } = buildService([
+        record({ id: 'a', createdAt: new Date('2026-01-03T00:00:00.000Z') }),
+        record({ id: 'b', createdAt: new Date('2026-01-01T00:00:00.000Z') }),
+        record({ id: 'c', createdAt: new Date('2026-01-02T00:00:00.000Z') }),
+      ]);
+
+      const result = await service.getUserHistory('uid-1', {});
+
+      expect(result.data.map((r: { id: string }) => r.id)).toEqual([
+        'a',
+        'c',
+        'b',
+      ]);
+    });
+
+    it('ordena por labelCount ascendente', async () => {
+      const { service } = buildService([
+        record({ id: 'a', labelCount: 50 }),
+        record({ id: 'b', labelCount: 5 }),
+        record({ id: 'c', labelCount: 20 }),
+      ]);
+
+      const result = await service.getUserHistory('uid-1', {
+        sortBy: HistorySortBy.LABEL_COUNT,
+        sortOrder: HistorySortOrder.ASC,
+      });
+
+      expect(result.data.map((r: { id: string }) => r.id)).toEqual([
+        'b',
+        'c',
+        'a',
+      ]);
+    });
+
+    it('combina orden por labelCount con un filtro', async () => {
+      const { service } = buildService([
+        record({ id: 'a', labelCount: 50, status: 'failed' }),
+        record({ id: 'b', labelCount: 5 }),
+        record({ id: 'c', labelCount: 20 }),
+      ]);
+
+      const result = await service.getUserHistory('uid-1', {
+        status: HistoryStatus.COMPLETED,
+        sortBy: HistorySortBy.LABEL_COUNT,
+        sortOrder: HistorySortOrder.DESC,
+      });
+
+      expect(result.data.map((r: { id: string }) => r.id)).toEqual(['c', 'b']);
+    });
+
+    it('desempata por fecha descendente con el mismo labelCount', async () => {
+      const { service } = buildService([
+        record({
+          id: 'viejo',
+          labelCount: 7,
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+        record({
+          id: 'nuevo',
+          labelCount: 7,
+          createdAt: new Date('2026-01-05T00:00:00.000Z'),
+        }),
+      ]);
+
+      const result = await service.getUserHistory('uid-1', {
+        sortBy: HistorySortBy.LABEL_COUNT,
+      });
+
+      expect(result.data.map((r: { id: string }) => r.id)).toEqual([
+        'nuevo',
+        'viejo',
+      ]);
+    });
+  });
+
+  describe('filtros', () => {
+    const mixed = [
+      record({
+        id: 'a',
+        status: 'completed',
+        outputFormat: OutputFormat.PDF,
+        labelSize: LabelSize.FOUR_BY_SIX,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      }),
+      record({
+        id: 'b',
+        status: 'failed',
+        outputFormat: OutputFormat.PNG,
+        labelSize: LabelSize.TWO_BY_ONE,
+        createdAt: new Date('2026-01-10T00:00:00.000Z'),
+      }),
+      record({
+        id: 'c',
+        status: 'completed',
+        outputFormat: OutputFormat.PNG,
+        labelSize: LabelSize.FOUR_BY_SIX,
+        createdAt: new Date('2026-01-20T00:00:00.000Z'),
+      }),
+    ];
+
+    it('filtra por status', async () => {
+      const { service } = buildService(mixed);
+
+      const result = await service.getUserHistory('uid-1', {
+        status: HistoryStatus.FAILED,
+      });
+
+      expect(result.data.map((r: { id: string }) => r.id)).toEqual(['b']);
+      expect(result.pagination.total).toBe(1);
+    });
+
+    it('combina outputFormat y labelSize', async () => {
+      const { service } = buildService(mixed);
+
+      const result = await service.getUserHistory('uid-1', {
+        outputFormat: OutputFormat.PNG,
+        labelSize: LabelSize.FOUR_BY_SIX,
+      });
+
+      expect(result.data.map((r: { id: string }) => r.id)).toEqual(['c']);
+    });
+
+    it('filtra por rango de fechas inclusivo en ambos extremos', async () => {
+      const { service } = buildService(mixed);
+
+      const result = await service.getUserHistory('uid-1', {
+        dateFrom: '2026-01-10T00:00:00.000Z',
+        dateTo: '2026-01-20T00:00:00.000Z',
+      });
+
+      expect(result.data.map((r: { id: string }) => r.id)).toEqual(['c', 'b']);
+    });
+
+    it('un dateTo sin hora incluye las conversiones de ese mismo día', async () => {
+      const { service } = buildService([
+        record({ id: 'a', createdAt: new Date('2026-01-20T18:30:00.000Z') }),
+        record({ id: 'b', createdAt: new Date('2026-01-21T00:00:01.000Z') }),
+      ]);
+
+      const result = await service.getUserHistory('uid-1', {
+        dateTo: '2026-01-20',
+      });
+
+      expect(result.data.map((r: { id: string }) => r.id)).toEqual(['a']);
+    });
+
+    it('un dateTo con hora se respeta al instante exacto', async () => {
+      const { service } = buildService([
+        record({ id: 'a', createdAt: new Date('2026-01-20T10:00:00.000Z') }),
+        record({ id: 'b', createdAt: new Date('2026-01-20T18:30:00.000Z') }),
+      ]);
+
+      const result = await service.getUserHistory('uid-1', {
+        dateTo: '2026-01-20T12:00:00.000Z',
+      });
+
+      expect(result.data.map((r: { id: string }) => r.id)).toEqual(['a']);
+    });
+
+    it('busca por prefijo de jobId sin distinguir mayúsculas', async () => {
+      const { service } = buildService([
+        record({ id: 'a', jobId: 'ABC-123' }),
+        record({ id: 'b', jobId: 'abd-999' }),
+        record({ id: 'c', jobId: 'zzz-abc' }),
+      ]);
+
+      const result = await service.getUserHistory('uid-1', { search: 'abc' });
+
+      expect(result.data.map((r: { id: string }) => r.id)).toEqual(['a']);
+    });
+
+    it('total refleja los filtros, no el total absoluto', async () => {
+      const { service } = buildService(mixed);
+
+      const result = await service.getUserHistory('uid-1', {
+        status: HistoryStatus.COMPLETED,
+        limit: 1,
+      });
+
+      expect(result.pagination.total).toBe(2);
+      expect(result.pagination.totalPages).toBe(2);
+      expect(result.data).toHaveLength(1);
+    });
+  });
+
+  describe('respuesta', () => {
+    it('incluye el id del documento de Firestore en cada ítem', async () => {
+      const { service } = buildService([record({ id: 'doc-abc' })]);
+
+      const result = await service.getUserHistory('uid-1', {});
+
+      expect(result.data[0].id).toBe('doc-abc');
+      expect(result.data[0].jobId).toBe('job-doc-abc');
+    });
+
+    it('serializa createdAt como ISO 8601', async () => {
+      const { service } = buildService([
+        record({ id: 'a', createdAt: new Date('2026-01-02T03:04:05.000Z') }),
+      ]);
+
+      const result = await service.getUserHistory('uid-1', {});
+
+      expect(result.data[0].createdAt).toBe('2026-01-02T03:04:05.000Z');
+    });
+
+    it('expone los valores presentes en el historial como facets', async () => {
+      const { service } = buildService([
+        record({
+          id: 'a',
+          labelSize: LabelSize.FOUR_BY_SIX,
+          outputFormat: OutputFormat.PDF,
+          status: 'completed',
+        }),
+        record({
+          id: 'b',
+          labelSize: LabelSize.TWO_BY_ONE,
+          outputFormat: OutputFormat.PDF,
+          status: 'failed',
+        }),
+      ]);
+
+      const result = await service.getUserHistory('uid-1', {});
+
+      expect(result.facets).toEqual({
+        labelSizes: ['2x1', '4x6'],
+        outputFormats: ['pdf'],
+        statuses: ['completed', 'failed'],
+      });
+    });
+
+    it('los facets describen todo el historial, no la página filtrada', async () => {
+      const { service } = buildService([
+        record({ id: 'a', status: 'completed' }),
+        record({ id: 'b', status: 'failed' }),
+      ]);
+
+      const result = await service.getUserHistory('uid-1', {
+        status: HistoryStatus.COMPLETED,
+      });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.facets.statuses).toEqual(['completed', 'failed']);
+    });
+  });
+
+  describe('firma de URLs', () => {
+    it('solo firma los registros de la página devuelta', async () => {
+      const records = Array.from({ length: 30 }, (_, i) =>
+        record({ id: `r${i}` }),
+      );
+      const { service, generateSignedUrlForPath } = buildService(records);
+
+      const result = await service.getUserHistory('uid-1', { limit: 5 });
+
+      expect(result.data).toHaveLength(5);
+      expect(generateSignedUrlForPath).toHaveBeenCalledTimes(5);
+    });
+
+    it('no firma las conversiones fallidas', async () => {
+      const { service, generateSignedUrlForPath } = buildService([
+        record({ id: 'a', status: 'failed', fileUrl: null }),
+        record({ id: 'b', status: 'completed' }),
+      ]);
+
+      await service.getUserHistory('uid-1', {});
+
+      expect(generateSignedUrlForPath).toHaveBeenCalledTimes(1);
+    });
+
+    it('conserva la URL original si la firma falla', async () => {
+      const { service, generateSignedUrlForPath } = buildService([
+        record({ id: 'a' }),
+      ]);
+      generateSignedUrlForPath.mockRejectedValue(new Error('storage caído'));
+
+      const result = await service.getUserHistory('uid-1', {});
+
+      expect(result.data[0].fileUrl).toBe(signedUrl('a.pdf'));
+    });
+  });
+
+  describe('control de acceso', () => {
+    it('rechaza a los planes sin historial', async () => {
+      const { service } = buildService([], { id: 'uid-1', plan: 'lite' });
+
+      await expect(service.getUserHistory('uid-1', {})).rejects.toThrow(
+        'History is only available for Pro, Pro Max and Enterprise plans',
+      );
+    });
+
+    it('permite a un admin sin simulación aunque su plan sea free', async () => {
+      const { service } = buildService([record({ id: 'a' })], {
+        id: 'uid-1',
+        plan: 'free',
+        role: 'admin',
+      });
+
+      const result = await service.getUserHistory('uid-1', {});
+
+      expect(result.data).toHaveLength(1);
+    });
+  });
+
+  describe('caché del escaneo', () => {
+    it('reutiliza el escaneo entre requests consecutivas del mismo usuario', async () => {
+      const { service, scanUserConversionHistory } = buildService([
+        record({ id: 'a' }),
+      ]);
+
+      await service.getUserHistory('uid-1', { page: 1 });
+      await service.getUserHistory('uid-1', { page: 1, search: 'job' });
+
+      expect(scanUserConversionHistory).toHaveBeenCalledTimes(1);
+      expect(scanUserConversionHistory).toHaveBeenCalledWith(
+        'uid-1',
+        MAX_HISTORY_SCAN,
+      );
+    });
+
+    it('vuelve a leer cuando la entrada ha caducado', async () => {
+      const { service, scanUserConversionHistory } = buildService([
+        record({ id: 'a' }),
+      ]);
+
+      await service.getUserHistory('uid-1', {});
+      service.historyScanCache.get('uid-1').expiresAt = Date.now() - 1;
+      await service.getUserHistory('uid-1', {});
+
+      expect(scanUserConversionHistory).toHaveBeenCalledTimes(2);
+    });
+
+    it('se invalida al registrar una conversión nueva', async () => {
+      const { service, scanUserConversionHistory } = buildService([
+        record({ id: 'a' }),
+      ]);
+
+      await service.getUserHistory('uid-1', {});
+      service.invalidateHistoryScanCache('uid-1');
+      await service.getUserHistory('uid-1', {});
+
+      expect(scanUserConversionHistory).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -4,8 +4,11 @@ jest.mock('@google-cloud/storage', () => ({
 }));
 jest.mock('stripe', () => jest.fn());
 
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
 import { UsersService, MAX_HISTORY_SCAN } from './users.service.js';
 import {
+  GetHistoryQueryDto,
   HistorySortBy,
   HistorySortOrder,
   HistoryStatus,
@@ -123,6 +126,20 @@ describe('UsersService — getUserHistory', () => {
     });
 
     it('marca truncated cuando el usuario supera el tope de escaneo', async () => {
+      // El servicio pide un documento de más; devolverlo significa que sobran.
+      const overCap = Array.from({ length: MAX_HISTORY_SCAN + 1 }, (_, i) =>
+        record({ id: `t${i}` }),
+      );
+      const { service } = buildService(overCap);
+
+      const result = await service.getUserHistory('uid-1', { limit: 10 });
+
+      expect(result.pagination.truncated).toBe(true);
+      // El registro sobrante es solo la señal: no debe contarse como resultado.
+      expect(result.pagination.total).toBe(MAX_HISTORY_SCAN);
+    });
+
+    it('no marca truncated con exactamente el tope de conversiones', async () => {
       const atCap = Array.from({ length: MAX_HISTORY_SCAN }, (_, i) =>
         record({ id: `t${i}` }),
       );
@@ -130,7 +147,8 @@ describe('UsersService — getUserHistory', () => {
 
       const result = await service.getUserHistory('uid-1', { limit: 10 });
 
-      expect(result.pagination.truncated).toBe(true);
+      expect(result.pagination.truncated).toBeUndefined();
+      expect(result.pagination.total).toBe(MAX_HISTORY_SCAN);
     });
 
     it('no marca truncated por debajo del tope', async () => {
@@ -139,6 +157,17 @@ describe('UsersService — getUserHistory', () => {
       const result = await service.getUserHistory('uid-1', {});
 
       expect(result.pagination.truncated).toBeUndefined();
+    });
+
+    it('pide un documento más que el tope, para detectar el corte', async () => {
+      const { service, scanUserConversionHistory } = buildService([]);
+
+      await service.getUserHistory('uid-1', {});
+
+      expect(scanUserConversionHistory).toHaveBeenCalledWith(
+        'uid-1',
+        MAX_HISTORY_SCAN + 1,
+      );
     });
   });
 
@@ -253,6 +282,22 @@ describe('UsersService — getUserHistory', () => {
 
       expect(result.data.map((r: { id: string }) => r.id)).toEqual(['b']);
       expect(result.pagination.total).toBe(1);
+    });
+
+    it('filtra por un labelSize fuera del enum, como los que guarda el batch', async () => {
+      // `BatchConvertDto.labelSize` es un string libre: el historial contiene
+      // valores como `large` que los facets exponen y el filtro debe aceptar.
+      const { service } = buildService([
+        record({ id: 'a', labelSize: 'large' }),
+        record({ id: 'b', labelSize: LabelSize.FOUR_BY_SIX }),
+      ]);
+
+      const result = await service.getUserHistory('uid-1', {
+        labelSize: 'large',
+      });
+
+      expect(result.data.map((r: { id: string }) => r.id)).toEqual(['a']);
+      expect(result.facets.labelSizes).toEqual(['4x6', 'large']);
     });
 
     it('combina outputFormat y labelSize', async () => {
@@ -457,10 +502,6 @@ describe('UsersService — getUserHistory', () => {
       await service.getUserHistory('uid-1', { page: 1, search: 'job' });
 
       expect(scanUserConversionHistory).toHaveBeenCalledTimes(1);
-      expect(scanUserConversionHistory).toHaveBeenCalledWith(
-        'uid-1',
-        MAX_HISTORY_SCAN,
-      );
     });
 
     it('vuelve a leer cuando la entrada ha caducado', async () => {
@@ -486,5 +527,100 @@ describe('UsersService — getUserHistory', () => {
 
       expect(scanUserConversionHistory).toHaveBeenCalledTimes(2);
     });
+  });
+});
+
+/**
+ * La validación del query es lo que separa un 400 con mensaje claro de un 500 o,
+ * peor, de una respuesta con metadatos incoherentes.
+ */
+describe('GetHistoryQueryDto', () => {
+  /** Reproduce lo que hace el ValidationPipe global (`transform: true`). */
+  async function validateQuery(query: Record<string, string>) {
+    const dto = plainToInstance(GetHistoryQueryDto, query, {
+      enableImplicitConversion: false,
+    });
+    const errors = await validate(dto);
+    return {
+      dto,
+      failed: errors.map((e) => e.property),
+    };
+  }
+
+  it('acepta un query vacío y aplica los defaults', async () => {
+    const { dto, failed } = await validateQuery({});
+
+    expect(failed).toEqual([]);
+    expect(dto.page).toBe(1);
+    expect(dto.limit).toBe(25);
+    expect(dto.sortBy).toBe(HistorySortBy.CREATED_AT);
+    expect(dto.sortOrder).toBe(HistorySortOrder.DESC);
+  });
+
+  it('rechaza un limit fraccionario', async () => {
+    // `Array.slice` truncaría el índice mientras `totalPages` conservaría el
+    // divisor decimal: páginas de tamaño variable y metadatos incoherentes.
+    const { failed } = await validateQuery({ limit: '2.5' });
+
+    expect(failed).toContain('limit');
+  });
+
+  it('rechaza una page fraccionaria', async () => {
+    const { failed } = await validateQuery({ page: '1.5' });
+
+    expect(failed).toContain('page');
+  });
+
+  it('rechaza un limit por encima de 100', async () => {
+    const { failed } = await validateQuery({ limit: '101' });
+
+    expect(failed).toContain('limit');
+  });
+
+  it('rechaza page y limit por debajo de 1', async () => {
+    expect((await validateQuery({ page: '0' })).failed).toContain('page');
+    expect((await validateQuery({ limit: '0' })).failed).toContain('limit');
+  });
+
+  it('rechaza enums desconocidos', async () => {
+    expect((await validateQuery({ status: 'pending' })).failed).toContain(
+      'status',
+    );
+    expect((await validateQuery({ outputFormat: 'gif' })).failed).toContain(
+      'outputFormat',
+    );
+    expect((await validateQuery({ sortBy: 'fileUrl' })).failed).toContain(
+      'sortBy',
+    );
+  });
+
+  it('rechaza fechas que no son ISO 8601', async () => {
+    expect((await validateQuery({ dateFrom: '20-01-2026' })).failed).toContain(
+      'dateFrom',
+    );
+  });
+
+  it('acepta un labelSize fuera del enum', async () => {
+    // Lo contrario rechazaría con 400 el valor que `facets.labelSizes` ofrece.
+    const { failed } = await validateQuery({ labelSize: 'large' });
+
+    expect(failed).toEqual([]);
+  });
+
+  it('acepta un query completo y válido', async () => {
+    const { failed } = await validateQuery({
+      page: '2',
+      limit: '50',
+      search: 'job-abc',
+      status: 'completed',
+      outputFormat: 'pdf',
+      labelSize: '4x6',
+      dateFrom: '2026-01-01',
+      dateTo: '2026-01-31T23:59:59.999Z',
+      sortBy: 'labelCount',
+      sortOrder: 'asc',
+    });
+
+    expect(failed).toEqual([]);
   });
 });

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -60,6 +60,7 @@ describe('UsersService — getUserHistory', () => {
     const service: any = Object.create(UsersService.prototype);
     service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
     service.historyScanCache = new Map();
+    service.historyScanGeneration = new Map();
     service.firestoreService = {
       getUserById: jest.fn().mockResolvedValue(user),
       scanUserConversionHistory,
@@ -335,6 +336,35 @@ describe('UsersService — getUserHistory', () => {
       expect(result.data.map((r: { id: string }) => r.id)).toEqual(['a']);
     });
 
+    it('interpreta en UTC las fechas-hora sin offset', async () => {
+      // `@IsDateString()` acepta `2026-01-20T12:00:00`; sin forzar UTC el corte
+      // se movería con la zona del proceso (GMT-6 en local, UTC en Cloud Run).
+      const { service } = buildService([
+        record({ id: 'a', createdAt: new Date('2026-01-20T11:00:00.000Z') }),
+        record({ id: 'b', createdAt: new Date('2026-01-20T13:00:00.000Z') }),
+      ]);
+
+      const result = await service.getUserHistory('uid-1', {
+        dateTo: '2026-01-20T12:00:00',
+      });
+
+      expect(result.data.map((r: { id: string }) => r.id)).toEqual(['a']);
+    });
+
+    it('respeta un offset explícito distinto de UTC', async () => {
+      const { service } = buildService([
+        record({ id: 'a', createdAt: new Date('2026-01-20T17:00:00.000Z') }),
+        record({ id: 'b', createdAt: new Date('2026-01-20T19:00:00.000Z') }),
+      ]);
+
+      // 12:00 en GMT-6 son las 18:00 UTC.
+      const result = await service.getUserHistory('uid-1', {
+        dateTo: '2026-01-20T12:00:00-06:00',
+      });
+
+      expect(result.data.map((r: { id: string }) => r.id)).toEqual(['a']);
+    });
+
     it('un dateTo con hora se respeta al instante exacto', async () => {
       const { service } = buildService([
         record({ id: 'a', createdAt: new Date('2026-01-20T10:00:00.000Z') }),
@@ -525,6 +555,32 @@ describe('UsersService — getUserHistory', () => {
       service.invalidateHistoryScanCache('uid-1');
       await service.getUserHistory('uid-1', {});
 
+      expect(scanUserConversionHistory).toHaveBeenCalledTimes(2);
+    });
+
+    it('no cachea un escaneo invalidado mientras estaba en vuelo', async () => {
+      // Si `recordConversion` invalida durante el await, cachear el resultado
+      // ocultaría la conversión recién guardada durante todo el TTL.
+      const { service, scanUserConversionHistory } = buildService([
+        record({ id: 'viejo' }),
+      ]);
+      scanUserConversionHistory.mockImplementationOnce(async () => {
+        service.invalidateHistoryScanCache('uid-1');
+        return [record({ id: 'viejo' })];
+      });
+
+      await service.getUserHistory('uid-1', {});
+
+      expect(service.historyScanCache.has('uid-1')).toBe(false);
+
+      // La siguiente request vuelve a leer y ve la conversión nueva.
+      scanUserConversionHistory.mockResolvedValue([
+        record({ id: 'nuevo' }),
+        record({ id: 'viejo' }),
+      ]);
+      const result = await service.getUserHistory('uid-1', {});
+
+      expect(result.data.map((r: { id: string }) => r.id)).toContain('nuevo');
       expect(scanUserConversionHistory).toHaveBeenCalledTimes(2);
     });
   });

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -659,6 +659,15 @@ describe('GetHistoryQueryDto', () => {
     );
   });
 
+  it('rechaza fechas de calendario inexistentes', async () => {
+    expect((await validateQuery({ dateFrom: '2026-02-30' })).failed).toContain(
+      'dateFrom',
+    );
+    expect((await validateQuery({ dateTo: '2026-04-31' })).failed).toContain(
+      'dateTo',
+    );
+  });
+
   it('rechaza el separador espacio, que Date.parse resuelve en zona local', async () => {
     const { failed } = await validateQuery({ dateFrom: '2026-01-20 12:00:00' });
 

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -60,7 +60,7 @@ describe('UsersService — getUserHistory', () => {
     const service: any = Object.create(UsersService.prototype);
     service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
     service.historyScanCache = new Map();
-    service.historyScanGeneration = new Map();
+    service.historyCacheGeneration = 0;
     service.firestoreService = {
       getUserById: jest.fn().mockResolvedValue(user),
       scanUserConversionHistory,
@@ -654,6 +654,43 @@ describe('GetHistoryQueryDto', () => {
     expect((await validateQuery({ dateFrom: '20-01-2026' })).failed).toContain(
       'dateFrom',
     );
+    expect((await validateQuery({ dateFrom: '2026-13-45' })).failed).toContain(
+      'dateFrom',
+    );
+  });
+
+  it('rechaza el separador espacio, que Date.parse resuelve en zona local', async () => {
+    const { failed } = await validateQuery({ dateFrom: '2026-01-20 12:00:00' });
+
+    expect(failed).toContain('dateFrom');
+  });
+
+  it('rechaza el formato básico sin guiones, que Date.parse no entiende', async () => {
+    // `20260120T120000Z` pasaría `@IsDateString()` pero da NaN al parsear: el
+    // límite quedaría ignorado en silencio en vez de devolver un 400.
+    expect(Number.isNaN(Date.parse('20260120T120000Z'))).toBe(true);
+
+    const { failed } = await validateQuery({ dateTo: '20260120T120000Z' });
+
+    expect(failed).toContain('dateTo');
+  });
+
+  it('acepta las formas de fecha que el frontend puede enviar', async () => {
+    const validas = [
+      '2026-01-20',
+      '2026-01-20T12:00',
+      '2026-01-20T12:00:00',
+      '2026-01-20T12:00:00Z',
+      '2026-01-20T12:00:00.999Z',
+      '2026-01-20T12:00:00-06:00',
+    ];
+
+    for (const dateFrom of validas) {
+      const { failed } = await validateQuery({ dateFrom });
+      expect({ dateFrom, failed }).toEqual({ dateFrom, failed: [] });
+      // Nada que pase la validación puede quedar sin parsear.
+      expect(Number.isNaN(Date.parse(dateFrom))).toBe(false);
+    }
   });
 
   it('acepta un labelSize fuera del enum', async () => {

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -22,10 +22,20 @@ import type {
   PlanType,
   PlanLimits,
 } from '../../common/interfaces/user.interface.js';
-import type { ConversionHistory } from '../../common/interfaces/conversion-history.interface.js';
+import type { ConversionHistoryRecord } from '../../common/interfaces/conversion-history.interface.js';
 import { UserProfileDto } from './dto/user-profile.dto.js';
 import { UserLimitsDto } from './dto/user-limits.dto.js';
 import { VerificationStatusDto } from './dto/verification-status.dto.js';
+import {
+  GetHistoryQueryDto,
+  HistorySortBy,
+  HistorySortOrder,
+} from './dto/get-history-query.dto.js';
+import type {
+  ConversionHistoryFacetsDto,
+  ConversionHistoryItemDto,
+  ConversionHistoryResponseDto,
+} from './dto/conversion-history.dto.js';
 import type { FirebaseUser } from '../../common/decorators/current-user.decorator.js';
 import { BATCH_LIMITS } from '../zpl/interfaces/batch.interface.js';
 import { isBlockedEmailDomain } from '../../common/constants/blocked-email-domains.js';
@@ -47,10 +57,36 @@ export interface CheckCanConvertResult {
   userEmail?: string | null;
 }
 
+/** Límite por defecto de ítems por página del historial. */
+export const DEFAULT_HISTORY_LIMIT = 25;
+
+/**
+ * Tope de documentos que se leen de Firestore por request de historial. Los
+ * filtros, la búsqueda y el orden se aplican sobre este bloque (el más reciente),
+ * de modo que un usuario con más conversiones ve `pagination.truncated: true`.
+ */
+export const MAX_HISTORY_SCAN = 1000;
+
+/** TTL de la caché en memoria del escaneo de historial. */
+const HISTORY_SCAN_CACHE_TTL_MS = 60_000;
+
+/** Tope de usuarios distintos cacheados a la vez por instancia. */
+const MAX_HISTORY_CACHE_ENTRIES = 200;
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+interface HistoryScanCacheEntry {
+  records: ConversionHistoryRecord[];
+  expiresAt: number;
+}
+
 @Injectable()
 export class UsersService {
   private readonly logger = new Logger(UsersService.name);
   private stripe: Stripe | null = null;
+
+  /** Caché por instancia del escaneo de historial (ver `getScannedHistory`). */
+  private readonly historyScanCache = new Map<string, HistoryScanCacheEntry>();
 
   constructor(
     private readonly firestoreService: FirestoreService,
@@ -314,9 +350,8 @@ export class UsersService {
 
   async getUserHistory(
     userId: string,
-    page: number = 1,
-    limit: number = 50,
-  ): Promise<ConversionHistory[]> {
+    query: GetHistoryQueryDto = {},
+  ): Promise<ConversionHistoryResponseDto> {
     const user = await this.firestoreService.getUserById(userId);
 
     if (!user) {
@@ -337,37 +372,234 @@ export class UsersService {
       );
     }
 
+    const page = query.page ?? 1;
+    const limit = query.limit ?? DEFAULT_HISTORY_LIMIT;
+
+    // Se lee un bloque acotado del historial y se filtra/ordena/pagina en memoria:
+    // así `search`, `sortBy=labelCount` y las combinaciones de filtros no exigen
+    // un índice compuesto por cada permutación (ver issue #89).
+    const scanned = await this.getScannedHistory(userId);
+    const truncated = scanned.length >= MAX_HISTORY_SCAN;
+
+    // Los facets salen del escaneo completo, no de la página: describen lo que
+    // el usuario tiene, para que el frontend pueble los selects sin hardcodear.
+    const facets = this.buildHistoryFacets(scanned);
+
+    const filtered = this.filterHistory(scanned, query);
+    this.sortHistory(filtered, query);
+
+    const total = filtered.length;
     const offset = (page - 1) * limit;
-    const history = await this.firestoreService.getUserConversionHistory(
-      userId,
-      limit,
-      offset,
+    const pageRecords = filtered.slice(offset, offset + limit);
+
+    // Firmar solo los registros que se devuelven, ya filtrados y paginados
+    const data = await Promise.all(
+      pageRecords.map((record) => this.toHistoryItem(record)),
     );
 
-    // Regenerar URLs firmadas frescas para cada registro completado
-    return Promise.all(
-      history.map(async (record) => {
-        if (record.fileUrl && record.status === 'completed') {
-          const { storagePath, downloadFilename } = this.extractStorageInfo(
-            record.fileUrl,
-          );
-          if (storagePath) {
-            try {
-              record.fileUrl =
-                await this.storageService.generateSignedUrlForPath(
-                  storagePath,
-                  downloadFilename,
-                );
-            } catch (error) {
-              this.logger.warn(
-                `Failed to regenerate URL for ${record.jobId}: ${error.message}`,
-              );
-            }
-          }
-        }
-        return record;
-      }),
+    return {
+      success: true,
+      data,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.max(1, Math.ceil(total / limit)),
+        ...(truncated && { truncated: true }),
+      },
+      facets,
+    };
+  }
+
+  /**
+   * Escaneo del historial del usuario con caché corta en memoria.
+   *
+   * La caché absorbe el tecleo del buscador y los cambios de filtro/página, que
+   * de otro modo repetirían hasta `MAX_HISTORY_SCAN` lecturas de Firestore por
+   * pulsación. Es por instancia: en Cloud Run cada instancia mantiene la suya, y
+   * el TTL corto acota la ventana en la que una conversión nueva no aparece.
+   */
+  private async getScannedHistory(
+    userId: string,
+  ): Promise<ConversionHistoryRecord[]> {
+    const cached = this.historyScanCache.get(userId);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.records;
+    }
+
+    const records = await this.firestoreService.scanUserConversionHistory(
+      userId,
+      MAX_HISTORY_SCAN,
     );
+
+    // Evitar que la caché crezca sin límite en instancias longevas
+    if (this.historyScanCache.size >= MAX_HISTORY_CACHE_ENTRIES) {
+      this.pruneHistoryScanCache();
+    }
+
+    this.historyScanCache.set(userId, {
+      records,
+      expiresAt: Date.now() + HISTORY_SCAN_CACHE_TTL_MS,
+    });
+
+    return records;
+  }
+
+  /** Invalida la caché del historial de un usuario (tras registrar una conversión). */
+  private invalidateHistoryScanCache(userId: string): void {
+    this.historyScanCache.delete(userId);
+  }
+
+  /** Elimina las entradas caducadas; si todas siguen vivas, vacía la caché entera. */
+  private pruneHistoryScanCache(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.historyScanCache) {
+      if (entry.expiresAt <= now) {
+        this.historyScanCache.delete(key);
+      }
+    }
+    if (this.historyScanCache.size >= MAX_HISTORY_CACHE_ENTRIES) {
+      this.historyScanCache.clear();
+    }
+  }
+
+  private buildHistoryFacets(
+    records: ConversionHistoryRecord[],
+  ): ConversionHistoryFacetsDto {
+    const labelSizes = new Set<string>();
+    const outputFormats = new Set<string>();
+    const statuses = new Set<string>();
+
+    for (const record of records) {
+      if (record.labelSize) labelSizes.add(record.labelSize);
+      if (record.outputFormat) outputFormats.add(record.outputFormat);
+      if (record.status) statuses.add(record.status);
+    }
+
+    return {
+      labelSizes: [...labelSizes].sort(),
+      outputFormats: [...outputFormats].sort(),
+      statuses: [...statuses].sort(),
+    };
+  }
+
+  private filterHistory(
+    records: ConversionHistoryRecord[],
+    query: GetHistoryQueryDto,
+  ): ConversionHistoryRecord[] {
+    const search = query.search?.trim().toLowerCase();
+    const dateFrom = this.toTimestamp(query.dateFrom);
+    const dateTo = this.toRangeEndTimestamp(query.dateTo);
+
+    return records.filter((record) => {
+      if (query.status && record.status !== query.status) return false;
+      if (query.outputFormat && record.outputFormat !== query.outputFormat) {
+        return false;
+      }
+      if (query.labelSize && record.labelSize !== query.labelSize) return false;
+
+      if (search && !record.jobId?.toLowerCase().startsWith(search)) {
+        return false;
+      }
+
+      if (dateFrom !== null || dateTo !== null) {
+        const createdAt = this.toTimestamp(record.createdAt);
+        if (createdAt === null) return false;
+        if (dateFrom !== null && createdAt < dateFrom) return false;
+        if (dateTo !== null && createdAt > dateTo) return false;
+      }
+
+      return true;
+    });
+  }
+
+  private sortHistory(
+    records: ConversionHistoryRecord[],
+    query: GetHistoryQueryDto,
+  ): void {
+    const sortBy = query.sortBy ?? HistorySortBy.CREATED_AT;
+    const direction = query.sortOrder === HistorySortOrder.ASC ? 1 : -1;
+
+    records.sort((a, b) => {
+      const aVal =
+        sortBy === HistorySortBy.LABEL_COUNT
+          ? (a.labelCount ?? 0)
+          : (this.toTimestamp(a.createdAt) ?? 0);
+      const bVal =
+        sortBy === HistorySortBy.LABEL_COUNT
+          ? (b.labelCount ?? 0)
+          : (this.toTimestamp(b.createdAt) ?? 0);
+
+      if (aVal === bVal) {
+        // Desempate estable por fecha para que el paginado no baraje filas
+        // con el mismo labelCount entre requests.
+        const aTime = this.toTimestamp(a.createdAt) ?? 0;
+        const bTime = this.toTimestamp(b.createdAt) ?? 0;
+        if (aTime !== bTime) return bTime - aTime;
+        return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+      }
+
+      return (aVal - bVal) * direction;
+    });
+  }
+
+  private toTimestamp(value: Date | string | undefined): number | null {
+    if (!value) return null;
+    const time = value instanceof Date ? value.getTime() : Date.parse(value);
+    return Number.isNaN(time) ? null : time;
+  }
+
+  /**
+   * Extremo superior de un rango de fechas. Un `dateTo` sin hora (`YYYY-MM-DD`,
+   * lo que envía un date-picker) se interpreta como el final de ese día: con la
+   * medianoche que devuelve `Date.parse` el usuario perdería las conversiones
+   * del propio día que acaba de seleccionar.
+   */
+  private toRangeEndTimestamp(value: string | undefined): number | null {
+    const time = this.toTimestamp(value);
+    if (time === null) return null;
+    return /^\d{4}-\d{2}-\d{2}$/.test(value) ? time + DAY_IN_MS - 1 : time;
+  }
+
+  /**
+   * Convierte un registro de Firestore al ítem de respuesta, regenerando la URL
+   * firmada solo si la conversión se completó con archivo.
+   */
+  private async toHistoryItem(
+    record: ConversionHistoryRecord,
+  ): Promise<ConversionHistoryItemDto> {
+    const createdAt = this.toTimestamp(record.createdAt);
+
+    const item: ConversionHistoryItemDto = {
+      id: record.id,
+      jobId: record.jobId,
+      labelCount: record.labelCount,
+      labelSize: record.labelSize,
+      status: record.status,
+      outputFormat: record.outputFormat,
+      createdAt: createdAt !== null ? new Date(createdAt).toISOString() : null,
+    };
+
+    if (record.fileUrl && record.status === 'completed') {
+      item.fileUrl = record.fileUrl;
+      const { storagePath, downloadFilename } = this.extractStorageInfo(
+        record.fileUrl,
+      );
+      if (storagePath) {
+        try {
+          item.fileUrl = await this.storageService.generateSignedUrlForPath(
+            storagePath,
+            downloadFilename,
+          );
+        } catch (error) {
+          this.logger.warn(
+            `Failed to regenerate URL for ${record.jobId}: ${error.message}`,
+          );
+        }
+      }
+    }
+
+    return item;
   }
 
   /**
@@ -515,6 +747,9 @@ export class UsersService {
       fileUrl: fileUrl || null,
       createdAt: new Date(),
     });
+
+    // La conversión recién guardada debe aparecer en el historial al instante
+    this.invalidateHistoryScanCache(userId);
 
     // Update lastActivityAt and reset inactive notification flags
     this.firestoreService

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -91,10 +91,18 @@ export class UsersService {
   private readonly historyScanCache = new Map<string, HistoryScanCacheEntry>();
 
   /**
-   * Contador de invalidaciones por usuario. Permite detectar que una conversión
-   * se registró mientras un escaneo estaba en vuelo y descartar su resultado.
+   * Contador monótono de invalidaciones. Permite detectar que se registró una
+   * conversión mientras un escaneo estaba en vuelo y descartar su resultado.
+   *
+   * Es global en vez de por usuario a propósito: un mapa crecería sin límite con
+   * los usuarios que convierten sin mirar nunca el historial (Free y Lite ni
+   * siquiera tienen acceso), y podarlo podría devolver un contador a su valor
+   * inicial justo mientras hay una lectura en vuelo, que es el caso que esta
+   * guarda existe para evitar. El coste de un contador único es que la
+   * conversión de un usuario impide cachear el escaneo simultáneo de otro: se
+   * pierde una oportunidad de caché, nunca se sirven datos obsoletos.
    */
-  private readonly historyScanGeneration = new Map<string, number>();
+  private historyCacheGeneration = 0;
 
   constructor(
     private readonly firestoreService: FirestoreService,
@@ -435,11 +443,11 @@ export class UsersService {
       return { records: cached.records, truncated: cached.truncated };
     }
 
-    // Generación del usuario antes de leer: si `recordConversion` invalida
-    // mientras el escaneo está en vuelo, al resolverse habría que descartarlo.
-    // Sin esta guarda se recachearía una instantánea previa a la conversión
-    // recién guardada y quedaría oculta durante todo el TTL.
-    const generation = this.historyScanGeneration.get(userId) ?? 0;
+    // Generación antes de leer: si `recordConversion` invalida mientras el
+    // escaneo está en vuelo, al resolverse hay que descartarlo. Sin esta guarda
+    // se recachearía una instantánea previa a la conversión recién guardada y
+    // quedaría oculta durante todo el TTL.
+    const generation = this.historyCacheGeneration;
 
     // Se pide un documento de más: si llega, es que quedaron conversiones fuera.
     // Con `length >= MAX_HISTORY_SCAN` un usuario con exactamente ese número se
@@ -451,7 +459,7 @@ export class UsersService {
     const truncated = scanned.length > MAX_HISTORY_SCAN;
     const records = truncated ? scanned.slice(0, MAX_HISTORY_SCAN) : scanned;
 
-    if ((this.historyScanGeneration.get(userId) ?? 0) === generation) {
+    if (this.historyCacheGeneration === generation) {
       // Evitar que la caché crezca sin límite en instancias longevas
       if (this.historyScanCache.size >= MAX_HISTORY_CACHE_ENTRIES) {
         this.pruneHistoryScanCache();
@@ -469,10 +477,7 @@ export class UsersService {
 
   /** Invalida la caché del historial de un usuario (tras registrar una conversión). */
   private invalidateHistoryScanCache(userId: string): void {
-    this.historyScanGeneration.set(
-      userId,
-      (this.historyScanGeneration.get(userId) ?? 0) + 1,
-    );
+    this.historyCacheGeneration++;
     this.historyScanCache.delete(userId);
   }
 
@@ -486,11 +491,6 @@ export class UsersService {
     }
     if (this.historyScanCache.size >= MAX_HISTORY_CACHE_ENTRIES) {
       this.historyScanCache.clear();
-    }
-    // Las generaciones se podan con la caché: perder una solo hace que un
-    // escaneo en vuelo no se cachee, nunca que se sirvan datos obsoletos.
-    if (this.historyScanGeneration.size >= MAX_HISTORY_CACHE_ENTRIES) {
-      this.historyScanGeneration.clear();
     }
   }
 
@@ -584,15 +584,17 @@ export class UsersService {
   }
 
   /**
-   * Fuerza a UTC las fechas-hora sin offset. `@IsDateString()` acepta
-   * `2026-01-20T12:00:00` y `Date.parse` lo resuelve en la zona local del
-   * proceso: el mismo filtro significaría las 12:00 UTC en Cloud Run y las 18:00
-   * desarrollando en Mérida (GMT-6). Una fecha suelta (`YYYY-MM-DD`) ya es UTC
-   * por especificación, así que se deja intacta.
+   * Fuerza a UTC las fechas-hora sin offset. `2026-01-20T12:00:00` es válido y
+   * `Date.parse` lo resuelve en la zona local del proceso: el mismo filtro
+   * significaría las 12:00 UTC en Cloud Run y las 18:00 desarrollando en Mérida
+   * (GMT-6). Una fecha suelta (`YYYY-MM-DD`) ya es UTC por especificación, así
+   * que se deja intacta.
+   *
+   * El formato de entrada lo garantiza `ISO_DATE_PATTERN` en el DTO.
    */
   private assumeUtc(value: string): string {
     const hasTime = value.includes('T');
-    const hasZone = /(Z|[+-]\d{2}:?\d{2})$/.test(value);
+    const hasZone = /(Z|[+-]\d{2}:\d{2})$/.test(value);
     return hasTime && !hasZone ? `${value}Z` : value;
   }
 

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -90,6 +90,12 @@ export class UsersService {
   /** Caché por instancia del escaneo de historial (ver `getScannedHistory`). */
   private readonly historyScanCache = new Map<string, HistoryScanCacheEntry>();
 
+  /**
+   * Contador de invalidaciones por usuario. Permite detectar que una conversión
+   * se registró mientras un escaneo estaba en vuelo y descartar su resultado.
+   */
+  private readonly historyScanGeneration = new Map<string, number>();
+
   constructor(
     private readonly firestoreService: FirestoreService,
     private readonly firebaseAdminService: FirebaseAdminService,
@@ -429,6 +435,12 @@ export class UsersService {
       return { records: cached.records, truncated: cached.truncated };
     }
 
+    // Generación del usuario antes de leer: si `recordConversion` invalida
+    // mientras el escaneo está en vuelo, al resolverse habría que descartarlo.
+    // Sin esta guarda se recachearía una instantánea previa a la conversión
+    // recién guardada y quedaría oculta durante todo el TTL.
+    const generation = this.historyScanGeneration.get(userId) ?? 0;
+
     // Se pide un documento de más: si llega, es que quedaron conversiones fuera.
     // Con `length >= MAX_HISTORY_SCAN` un usuario con exactamente ese número se
     // marcaría como truncado sin haberse omitido nada.
@@ -439,22 +451,28 @@ export class UsersService {
     const truncated = scanned.length > MAX_HISTORY_SCAN;
     const records = truncated ? scanned.slice(0, MAX_HISTORY_SCAN) : scanned;
 
-    // Evitar que la caché crezca sin límite en instancias longevas
-    if (this.historyScanCache.size >= MAX_HISTORY_CACHE_ENTRIES) {
-      this.pruneHistoryScanCache();
-    }
+    if ((this.historyScanGeneration.get(userId) ?? 0) === generation) {
+      // Evitar que la caché crezca sin límite en instancias longevas
+      if (this.historyScanCache.size >= MAX_HISTORY_CACHE_ENTRIES) {
+        this.pruneHistoryScanCache();
+      }
 
-    this.historyScanCache.set(userId, {
-      records,
-      truncated,
-      expiresAt: Date.now() + HISTORY_SCAN_CACHE_TTL_MS,
-    });
+      this.historyScanCache.set(userId, {
+        records,
+        truncated,
+        expiresAt: Date.now() + HISTORY_SCAN_CACHE_TTL_MS,
+      });
+    }
 
     return { records, truncated };
   }
 
   /** Invalida la caché del historial de un usuario (tras registrar una conversión). */
   private invalidateHistoryScanCache(userId: string): void {
+    this.historyScanGeneration.set(
+      userId,
+      (this.historyScanGeneration.get(userId) ?? 0) + 1,
+    );
     this.historyScanCache.delete(userId);
   }
 
@@ -468,6 +486,11 @@ export class UsersService {
     }
     if (this.historyScanCache.size >= MAX_HISTORY_CACHE_ENTRIES) {
       this.historyScanCache.clear();
+    }
+    // Las generaciones se podan con la caché: perder una solo hace que un
+    // escaneo en vuelo no se cachee, nunca que se sirvan datos obsoletos.
+    if (this.historyScanGeneration.size >= MAX_HISTORY_CACHE_ENTRIES) {
+      this.historyScanGeneration.clear();
     }
   }
 
@@ -553,8 +576,24 @@ export class UsersService {
 
   private toTimestamp(value: Date | string | undefined): number | null {
     if (!value) return null;
-    const time = value instanceof Date ? value.getTime() : Date.parse(value);
+    const time =
+      value instanceof Date
+        ? value.getTime()
+        : Date.parse(this.assumeUtc(value));
     return Number.isNaN(time) ? null : time;
+  }
+
+  /**
+   * Fuerza a UTC las fechas-hora sin offset. `@IsDateString()` acepta
+   * `2026-01-20T12:00:00` y `Date.parse` lo resuelve en la zona local del
+   * proceso: el mismo filtro significaría las 12:00 UTC en Cloud Run y las 18:00
+   * desarrollando en Mérida (GMT-6). Una fecha suelta (`YYYY-MM-DD`) ya es UTC
+   * por especificación, así que se deja intacta.
+   */
+  private assumeUtc(value: string): string {
+    const hasTime = value.includes('T');
+    const hasZone = /(Z|[+-]\d{2}:?\d{2})$/.test(value);
+    return hasTime && !hasZone ? `${value}Z` : value;
   }
 
   /**

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -77,6 +77,8 @@ const DAY_IN_MS = 24 * 60 * 60 * 1000;
 
 interface HistoryScanCacheEntry {
   records: ConversionHistoryRecord[];
+  /** El usuario tiene más conversiones de las que cabían en el escaneo. */
+  truncated: boolean;
   expiresAt: number;
 }
 
@@ -378,8 +380,8 @@ export class UsersService {
     // Se lee un bloque acotado del historial y se filtra/ordena/pagina en memoria:
     // así `search`, `sortBy=labelCount` y las combinaciones de filtros no exigen
     // un índice compuesto por cada permutación (ver issue #89).
-    const scanned = await this.getScannedHistory(userId);
-    const truncated = scanned.length >= MAX_HISTORY_SCAN;
+    const { records: scanned, truncated } =
+      await this.getScannedHistory(userId);
 
     // Los facets salen del escaneo completo, no de la página: describen lo que
     // el usuario tiene, para que el frontend pueble los selects sin hardcodear.
@@ -421,16 +423,21 @@ export class UsersService {
    */
   private async getScannedHistory(
     userId: string,
-  ): Promise<ConversionHistoryRecord[]> {
+  ): Promise<{ records: ConversionHistoryRecord[]; truncated: boolean }> {
     const cached = this.historyScanCache.get(userId);
     if (cached && cached.expiresAt > Date.now()) {
-      return cached.records;
+      return { records: cached.records, truncated: cached.truncated };
     }
 
-    const records = await this.firestoreService.scanUserConversionHistory(
+    // Se pide un documento de más: si llega, es que quedaron conversiones fuera.
+    // Con `length >= MAX_HISTORY_SCAN` un usuario con exactamente ese número se
+    // marcaría como truncado sin haberse omitido nada.
+    const scanned = await this.firestoreService.scanUserConversionHistory(
       userId,
-      MAX_HISTORY_SCAN,
+      MAX_HISTORY_SCAN + 1,
     );
+    const truncated = scanned.length > MAX_HISTORY_SCAN;
+    const records = truncated ? scanned.slice(0, MAX_HISTORY_SCAN) : scanned;
 
     // Evitar que la caché crezca sin límite en instancias longevas
     if (this.historyScanCache.size >= MAX_HISTORY_CACHE_ENTRIES) {
@@ -439,10 +446,11 @@ export class UsersService {
 
     this.historyScanCache.set(userId, {
       records,
+      truncated,
       expiresAt: Date.now() + HISTORY_SCAN_CACHE_TTL_MS,
     });
 
-    return records;
+    return { records, truncated };
   }
 
   /** Invalida la caché del historial de un usuario (tras registrar una conversión). */


### PR DESCRIPTION
Closes #89

## El bug

`getUserHistory()` devolvía un array plano sin metadatos de paginación. El frontend calculaba `totalPages` con `Math.ceil(data.length / limit) || 1` y con una página llena (`data.length === limit`) eso da **siempre 1**, así que el bloque de controles (`totalPages > 1`) nunca se renderizaba: un usuario Pro Max con 300 conversiones solo veía las 10 más recientes, sin forma de avanzar de página.

## Qué cambia

La respuesta pasa a ser `{success, data, pagination, facets}` con `total` y `totalPages` reales **tras aplicar filtros**, y cada ítem incluye el `id` del documento de Firestore (necesario para las acciones por fila).

Query params nuevos, todos validados con `class-validator` en `GetHistoryQueryDto`:

| Param | Valores |
|---|---|
| `search` | prefijo de `jobId`, case-insensitive |
| `status` | `completed` \| `failed` |
| `outputFormat` | `pdf` \| `png` \| `jpeg` |
| `labelSize` | `2x1` \| `2x4` \| `4x2` \| `4x6` (enum `LabelSize`) |
| `dateFrom` / `dateTo` | ISO 8601 |
| `sortBy` | `createdAt` \| `labelCount` |
| `sortOrder` | `asc` \| `desc` |

`limit` gana `@Max(100)` y su default pasa de 50 a 25 (el del issue). Query params inválidos devuelven `400` del `ValidationPipe`, no `500`.

## Decisiones

**Filtrado en memoria (opción A del issue).** Se leen las `MAX_HISTORY_SCAN = 1000` conversiones más recientes con el índice ya existente (`userId` + `createdAt desc`) y se filtra, ordena y pagina en memoria. En Firestore cada combinación de `where` de igualdad + `orderBy` necesitaría su propio índice compuesto (~16), y ni la búsqueda de texto libre ni `sortBy=labelCount` combinado con un rango de fechas son expresables en una query. Si el usuario supera el tope, la respuesta trae `pagination.truncated: true` para detectarlo antes de que sea un problema.

**Caché en memoria de 60 s por usuario.** Absorbe el tecleo del buscador y los cambios de filtro/página, que si no repetirían hasta 1000 lecturas por pulsación. Es por instancia de Cloud Run y se invalida en `recordConversion()`, así que una conversión nueva aparece al instante.

**`facets`** lista los `labelSizes`, `outputFormats` y `statuses` realmente presentes en el historial del usuario, para que el frontend pueble los selects sin hardcodear las 4 medidas ni ofrecer filtros que no devuelven nada. Se calculan sobre el escaneo completo, no sobre la página filtrada.

**URLs firmadas solo de la página devuelta.** Antes se firmaba cada registro leído; ahora se firma después de filtrar y paginar, así que subir el `limit` no multiplica el coste de la request.

**`dateTo` sin hora cubre el día completo.** Un date-picker envía `YYYY-MM-DD` y `Date.parse` lo resuelve a medianoche: sin esto, el usuario perdería todas las conversiones del propio día que acaba de seleccionar. Un `dateTo` con hora se respeta al instante exacto.

## Compatibilidad

El frontend en producción ya acepta las tres formas de respuesta (`userService.ts:179-186`: array plano, `{data}` o `{history}`), así que devolver `{success, data, pagination}` **no rompe** la versión actual. Llamar sin ningún query param sigue devolviendo las conversiones más recientes primero.

`getUserConversionHistory()` se deja intacto — lo sigue usando `admin.service.ts:943`. El escaneo vive en un método nuevo, `scanUserConversionHistory()`.

## Verificación

- `npm run build` → TSC 0 issues
- `npx jest` → 359 tests, 14 suites en verde
- `npm run lint` → limpio
- 28 tests nuevos en `users.service.spec.ts` cubriendo paginación (incluido `page=2` devuelve registros distintos), orden, cada filtro y sus combinaciones, `truncated`, facets, firma acotada a la página, control de acceso por plan y comportamiento de la caché

No requiere índices de Firestore nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)