### PR TITLE
feat(users): dar al historial las acciones de borrar y reconvertir

### DIFF
--- a/.agent-docs/ENDPOINTS.md
+++ b/.agent-docs/ENDPOINTS.md
@@ -34,8 +34,34 @@ All endpoints are prefixed with `/api` (configured in `main.ts`).
 | GET | /users/verification-status | User | UsersController.getVerificationStatus | Check email verification status |
 | GET | /users/limits | User | UsersController.getUserLimits | Get plan limits and current usage |
 | GET | /users/history | User | UsersController.getUserHistory | Get conversion history (Pro+ only) |
+| DELETE | /users/history/:id | User | UsersController.deleteHistoryEntry | Delete a history record (Pro+ only) |
+| GET | /users/history/:id/zpl | User | UsersController.getHistoryZpl | Get the original ZPL to reconvert (Pro+ only) |
 
 **File:** `src/modules/users/users.controller.ts`
+
+### Acciones sobre el historial
+
+`:id` es el **doc id de `conversion_history`** (no el `jobId`), y viene en el campo
+`id` de cada ítem de `GET /users/history`.
+
+- **Ownership:** un registro ajeno responde `404 HISTORY_NOT_FOUND`, igual que uno
+  inexistente. Un `403` confirmaría que el id existe.
+- **Borrado real**, y no toca `usage`: si borrar filas descontara PDFs del período,
+  cualquiera reiniciaría su cuota vaciando el historial. Las métricas viven agregadas
+  en `daily_stats` / `global_totals`, así que tampoco se ven afectadas. El PDF de
+  Cloud Storage se queda donde está.
+- **Retención del ZPL: 15 días** (`ZPL_RETENTION_DAYS`). No la decide la aplicación:
+  la impone una regla de lifecycle del bucket `zplpdf-app-files` que borra el prefijo
+  `debug-zpl/` a los 15 días (`gsutil lifecycle get gs://zplpdf-app-files`). Si se
+  cambia esa regla hay que actualizar la constante.
+- Pasada esa ventana, `GET /users/history/:id/zpl` responde `410 ZPL_NOT_AVAILABLE`.
+  Para no descubrirlo a base de errores, cada ítem de `GET /users/history` trae
+  `canReconvert: boolean`, calculado por edad del registro (sin lecturas extra).
+- El ZPL **no** está en Firestore: `ConversionStatus.zplContent` existe en el tipo pero
+  nunca se escribe. La copia real vive en `debug-zpl/{userId}/{fecha}/{jobId}.zpl`,
+  indexada por jobId en `zpl_debug_files`.
+- La reconversión no tiene endpoint propio: el frontend precarga el ZPL y usa el flujo
+  normal `POST /zpl/convert`, que es donde se aplican los límites de plan.
 
 ## Payments (`/payments`)
 

--- a/.agent-docs/ENDPOINTS.md
+++ b/.agent-docs/ENDPOINTS.md
@@ -48,19 +48,21 @@ All endpoints are prefixed with `/api` (configured in `main.ts`).
   inexistente. Un `403` confirmaría que el id existe.
 - **Borrado real**, y no toca `usage`: si borrar filas descontara PDFs del período,
   cualquiera reiniciaría su cuota vaciando el historial. Las métricas viven agregadas
-  en `daily_stats` / `global_totals`, así que tampoco se ven afectadas. El PDF de
-  Cloud Storage se queda donde está.
+  en `daily_stats` / `global_totals`, así que tampoco se ven afectadas. Sí pierden la
+  fila los consumidores que leen `conversion_history` en crudo: `getTopUsers`,
+  `getUserUsageHistory`, `getUsersWithHighUsage` y `getConversionsPaginated` (la
+  lista de `/admin/conversions`). El PDF de Cloud Storage se queda donde está.
 - **Retención del ZPL: 15 días** (`ZPL_RETENTION_DAYS`). No la decide la aplicación:
   la impone una regla de lifecycle del bucket `zplpdf-app-files` que borra el prefijo
   `debug-zpl/` a los 15 días (`gsutil lifecycle get gs://zplpdf-app-files`). Si se
   cambia esa regla hay que actualizar la constante.
 - Pasada esa ventana, `GET /users/history/:id/zpl` responde `410 ZPL_NOT_AVAILABLE`.
   Para no descubrirlo a base de errores, cada ítem de `GET /users/history` trae
-  `canReconvert: boolean`. Son **dos** condiciones y hacen falta las dos: que el ZPL
-  se llegara a guardar (una consulta en lote a `zpl_debug_files`, solo con los jobIds
-  de la página; los docs usan el jobId como id) y que siga dentro de la ventana,
-  contada desde que se guardó el ZPL —no desde la fila del historial, que nace al
-  terminar la conversión mientras el objeto se sube al empezarla—.
+  `canReconvert: boolean`. Exige que el ZPL se llegara a guardar (una consulta en lote
+  a `zpl_debug_files`, solo con los jobIds de la página; los docs usan el jobId como
+  id), que siga dentro de la ventana —contada desde que se guardó el ZPL, no desde la
+  fila del historial— y que su `fileSize` conocido no supere
+  `MAX_RECONVERTIBLE_ZPL_SIZE_BYTES`. Un tamaño ausente no bloquea metadata antigua.
   Las filas creadas por batch **antes** de agosto de 2026 no tienen ZPL: el flujo
   batch registraba historial sin llamar a `saveZplForDebug`. Salen con
   `canReconvert: false` para siempre.

--- a/.agent-docs/ENDPOINTS.md
+++ b/.agent-docs/ENDPOINTS.md
@@ -56,7 +56,12 @@ All endpoints are prefixed with `/api` (configured in `main.ts`).
   cambia esa regla hay que actualizar la constante.
 - Pasada esa ventana, `GET /users/history/:id/zpl` responde `410 ZPL_NOT_AVAILABLE`.
   Para no descubrirlo a base de errores, cada ítem de `GET /users/history` trae
-  `canReconvert: boolean`, calculado por edad del registro (sin lecturas extra).
+  `canReconvert: boolean`. Son **dos** condiciones y hacen falta las dos: que el ZPL
+  se llegara a guardar (una consulta en lote a `zpl_debug_files` por página, los docs
+  usan el jobId como id) y que el registro siga dentro de la ventana de retención.
+  Las filas creadas por batch **antes** de agosto de 2026 no tienen ZPL: el flujo
+  batch registraba historial sin llamar a `saveZplForDebug`. Salen con
+  `canReconvert: false` para siempre.
 - El ZPL **no** está en Firestore: `ConversionStatus.zplContent` existe en el tipo pero
   nunca se escribe. La copia real vive en `debug-zpl/{userId}/{fecha}/{jobId}.zpl`,
   indexada por jobId en `zpl_debug_files`.

--- a/.agent-docs/SCHEMAS.md
+++ b/.agent-docs/SCHEMAS.md
@@ -127,15 +127,19 @@ interface ConversionHistoryRecord extends ConversionHistory {
 
 `DELETE /users/history/:id` hace **borrado real**. No toca `usage` (la cuota no puede
 depender de una tabla que el usuario puede vaciar) ni los agregados de `daily_stats` /
-`global_totals`, pero la fila sí desaparece de `/admin/conversions`, que lee de esta
-misma colección.
+`global_totals`. Sí reduce los datos de los consumidores que leen
+`conversion_history` en crudo: `getTopUsers`, `getUserUsageHistory`,
+`getUsersWithHighUsage` y `getConversionsPaginated` (la lista de
+`/admin/conversions`).
 
 `canReconvert` no se persiste ni vive en esta interfaz: es un campo de
-`ConversionHistoryItemDto` que se calcula al responder, y exige las dos condiciones —
-que exista el doc de `zpl_debug_files` con ese jobId (el ZPL se llegó a guardar) y que
-su `createdAt` esté dentro de `ZPL_RETENTION_DAYS` (15 días, impuestos por el lifecycle
-del bucket sobre `debug-zpl/`). Las filas que el flujo batch creó antes de agosto de 2026
-no tienen ZPL guardado y nunca son reconvertibles.
+`ConversionHistoryItemDto` que se calcula al responder, y exige que exista el doc de
+`zpl_debug_files` con ese jobId (el ZPL se llegó a guardar), que su `createdAt` esté
+dentro de `ZPL_RETENTION_DAYS` (15 días, impuestos por el lifecycle del bucket sobre
+`debug-zpl/`) y que el `fileSize` conocido no supere
+`MAX_RECONVERTIBLE_ZPL_SIZE_BYTES`. Un tamaño ausente no bloquea las metadata antiguas.
+Las filas que el flujo batch creó antes de agosto de 2026 no tienen ZPL guardado y
+nunca son reconvertibles.
 
 **Queries:**
 - User history: `firestore.collection('conversion_history').where('userId', '==', userId).orderBy('createdAt', 'desc').limit(50)`

--- a/.agent-docs/SCHEMAS.md
+++ b/.agent-docs/SCHEMAS.md
@@ -127,8 +127,11 @@ depender de una tabla que el usuario puede vaciar) ni los agregados de `daily_st
 `global_totals`, pero la fila sí desaparece de `/admin/conversions`, que lee de esta
 misma colección.
 
-`canReconvert` no se persiste: se calcula al leer comparando `createdAt` con
-`ZPL_RETENTION_DAYS` (15 días, impuestos por el lifecycle del bucket sobre `debug-zpl/`).
+`canReconvert` no se persiste: se calcula al leer, y exige las dos condiciones —
+que exista el doc de `zpl_debug_files` con ese jobId (el ZPL se llegó a guardar) y que
+`createdAt` esté dentro de `ZPL_RETENTION_DAYS` (15 días, impuestos por el lifecycle del
+bucket sobre `debug-zpl/`). Las filas que el flujo batch creó antes de agosto de 2026 no
+tienen ZPL guardado y nunca son reconvertibles.
 
 **Queries:**
 - User history: `firestore.collection('conversion_history').where('userId', '==', userId).orderBy('createdAt', 'desc').limit(50)`

--- a/.agent-docs/SCHEMAS.md
+++ b/.agent-docs/SCHEMAS.md
@@ -109,6 +109,7 @@ Record of each conversion (successful or failed).
 ```typescript
 // Interface: src/common/interfaces/conversion-history.interface.ts
 interface ConversionHistory {
+  id?: string;              // Doc id; solo al leer. Es el :id de DELETE /users/history/:id
   userId: string;
   jobId: string;
   labelCount: number;
@@ -117,8 +118,17 @@ interface ConversionHistory {
   outputFormat: 'pdf' | 'png' | 'jpeg';
   fileUrl?: string | null;  // Signed URL for completed
   createdAt: Date;
+  canReconvert?: boolean;   // Derivado, no almacenado: edad < ZPL_RETENTION_DAYS
 }
 ```
+
+`DELETE /users/history/:id` hace **borrado real**. No toca `usage` (la cuota no puede
+depender de una tabla que el usuario puede vaciar) ni los agregados de `daily_stats` /
+`global_totals`, pero la fila sí desaparece de `/admin/conversions`, que lee de esta
+misma colección.
+
+`canReconvert` no se persiste: se calcula al leer comparando `createdAt` con
+`ZPL_RETENTION_DAYS` (15 días, impuestos por el lifecycle del bucket sobre `debug-zpl/`).
 
 **Queries:**
 - User history: `firestore.collection('conversion_history').where('userId', '==', userId).orderBy('createdAt', 'desc').limit(50)`
@@ -135,7 +145,7 @@ interface ConversionStatus {
   userId?: string;
   resultUrl?: string;
   filename?: string;
-  zplContent?: string;
+  zplContent?: string;      // ⚠️ Declarado pero NUNCA escrito — ver nota
   labelSize?: string;
   outputFormat?: string;
   zplHash?: string;
@@ -149,6 +159,14 @@ interface ConversionStatus {
   chunksTotal?: number;
 }
 ```
+
+> **`zplContent` y `zplHash` no se escriben nunca.** Ninguna llamada a
+> `saveConversionStatus` / `updateConversionStatus` los informa, y un ZPL de varios MB
+> no cabría en un documento de Firestore (límite de 1 MiB). **La única copia del ZPL
+> original vive en Cloud Storage**, en `debug-zpl/{userId}/{YYYY-MM-DD}/{jobId}.zpl`,
+> indexada por jobId en `zpl_debug_files`. Ese prefijo se borra a los **15 días** por
+> lifecycle del bucket (`ZPL_RETENTION_DAYS`), que es lo que acota la ventana de
+> "reconvertir" en `GET /users/history/:id/zpl`.
 
 ### `daily_stats`
 

--- a/src/common/constants/error-codes.ts
+++ b/src/common/constants/error-codes.ts
@@ -27,6 +27,18 @@ export const ErrorCodes = {
   BATCH_NOT_FOUND: 'BATCH_NOT_FOUND',
   USER_NOT_FOUND: 'USER_NOT_FOUND',
   DOWNLOAD_NOT_AVAILABLE: 'DOWNLOAD_NOT_AVAILABLE',
+  /**
+   * El registro de historial no existe o no pertenece a quien pregunta. Un solo
+   * código para ambos casos a propósito: distinguirlos confirmaría al atacante
+   * que el id existe.
+   */
+  HISTORY_NOT_FOUND: 'HISTORY_NOT_FOUND',
+  /**
+   * El registro existe pero su ZPL original ya salió del bucket (lifecycle de
+   * `debug-zpl/`). Va aparte de HISTORY_NOT_FOUND porque la fila sigue ahí y el
+   * frontend debe seguir ofreciendo la descarga del PDF.
+   */
+  ZPL_NOT_AVAILABLE: 'ZPL_NOT_AVAILABLE',
 
   // Errores de estado (400)
   BATCH_PROCESSING: 'BATCH_PROCESSING',
@@ -80,9 +92,11 @@ export const ErrorHttpStatus: Record<ErrorCode, number> = {
   [ErrorCodes.BATCH_NOT_FOUND]: 404,
   [ErrorCodes.USER_NOT_FOUND]: 404,
   [ErrorCodes.DOWNLOAD_NOT_AVAILABLE]: 404,
+  [ErrorCodes.HISTORY_NOT_FOUND]: 404,
 
   // 410 Gone
   [ErrorCodes.JOB_EXPIRED]: 410,
+  [ErrorCodes.ZPL_NOT_AVAILABLE]: 410,
 
   // 413 Payload Too Large
   [ErrorCodes.FILE_TOO_LARGE]: 413,
@@ -123,6 +137,9 @@ export const ErrorMessagesEs: Record<ErrorCode, string> = {
   [ErrorCodes.USER_NOT_FOUND]: 'Usuario no encontrado',
   [ErrorCodes.DOWNLOAD_NOT_AVAILABLE]:
     'No hay archivos disponibles para descargar',
+  [ErrorCodes.HISTORY_NOT_FOUND]: 'Registro de historial no encontrado',
+  [ErrorCodes.ZPL_NOT_AVAILABLE]:
+    'El ZPL original de esta conversión ya no está disponible',
   [ErrorCodes.BATCH_PROCESSING]: 'El batch aún está procesándose',
   [ErrorCodes.JOB_NOT_COMPLETE]: 'La conversión no está completa',
   [ErrorCodes.SERVER_ERROR]: 'Error interno del servidor',
@@ -154,6 +171,9 @@ export const ErrorMessagesEn: Record<ErrorCode, string> = {
   [ErrorCodes.BATCH_NOT_FOUND]: 'Batch not found',
   [ErrorCodes.USER_NOT_FOUND]: 'User not found',
   [ErrorCodes.DOWNLOAD_NOT_AVAILABLE]: 'No files available for download',
+  [ErrorCodes.HISTORY_NOT_FOUND]: 'History record not found',
+  [ErrorCodes.ZPL_NOT_AVAILABLE]:
+    'The original ZPL for this conversion is no longer available',
   [ErrorCodes.BATCH_PROCESSING]: 'Batch is still processing',
   [ErrorCodes.JOB_NOT_COMPLETE]: 'Conversion is not complete',
   [ErrorCodes.SERVER_ERROR]: 'Internal server error',

--- a/src/common/interfaces/conversion-history.interface.ts
+++ b/src/common/interfaces/conversion-history.interface.ts
@@ -1,4 +1,10 @@
 export interface ConversionHistory {
+  /**
+   * Doc id de `conversion_history`. Opcional porque al guardar aún no existe:
+   * lo asigna Firestore. Al leer siempre viene informado — es la clave con la
+   * que el frontend borra la fila o recupera su ZPL.
+   */
+  id?: string;
   userId: string;
   jobId: string;
   labelCount: number;
@@ -7,4 +13,28 @@ export interface ConversionHistory {
   outputFormat: 'pdf' | 'png' | 'jpeg';
   fileUrl?: string;
   createdAt: Date;
+  /**
+   * Si el ZPL original sigue dentro de la ventana de retención y, por tanto,
+   * la fila admite "reconvertir". Se deriva de la edad del registro para no
+   * pagar una lectura por fila; ver ZPL_RETENTION_DAYS.
+   */
+  canReconvert?: boolean;
 }
+
+/**
+ * Días que sobrevive el ZPL original de una conversión.
+ *
+ * No es una decisión de la aplicación: la impone una regla de lifecycle del
+ * bucket `zplpdf-app-files` que borra todo lo que cuelga del prefijo
+ * `debug-zpl/` al cumplir 15 días. El código no puede consultar esa regla en
+ * caliente, así que la refleja aquí; si algún día se cambia el lifecycle en
+ * GCS, hay que cambiar también esta constante.
+ *
+ *   gsutil lifecycle get gs://zplpdf-app-files
+ *
+ * Se usa para calcular `canReconvert` sin tocar Storage. El borrado real lo
+ * ejecuta GCS de forma asíncrona (puede tardar hasta 24h más), de modo que el
+ * flag peca de conservador: un ZPL marcado como no reconvertible puede seguir
+ * existiendo un rato, nunca al revés.
+ */
+export const ZPL_RETENTION_DAYS = 15;

--- a/src/modules/cache/firestore.service.spec.ts
+++ b/src/modules/cache/firestore.service.spec.ts
@@ -1212,10 +1212,10 @@ describe('FirestoreService — la inactividad no depende del historial', () => {
     expect(resultado.users).toHaveLength(0);
   });
 
-  it('recurre al historial solo para quien todavía no tiene el campo', async () => {
+  it('no consulta el historial de quien el campo ya da por activo', async () => {
     const { service, historialConsultadoPara } = buildService([
       {
-        id: 'uid-con-campo',
+        id: 'uid-activo',
         data: {
           plan: 'pro',
           email: 'a@ejemplo.com',
@@ -1234,8 +1234,54 @@ describe('FirestoreService — la inactividad no depende del historial', () => {
       minDaysInactive: 30,
     });
 
-    // Una query menos por cada usuario que ya trae su actividad registrada.
+    // Una query menos por cada usuario que no es candidato a ninguna campaña.
     expect(historialConsultadoPara).toEqual(['uid-antiguo']);
     expect(resultado.users.map((u: any) => u.userId)).toEqual(['uid-antiguo']);
+  });
+
+  it('confirma contra el historial a quien el campo marca como inactivo', async () => {
+    // `lastActivityAt` se escribe fire-and-forget: si esa escritura falló, el
+    // campo se quedó viejo. Antes de mandarle un "te echamos de menos" a un
+    // cliente de pago conviene mirar la otra fuente.
+    const { service, historialConsultadoPara } = buildService([
+      {
+        id: 'uid-campo-desfasado',
+        data: {
+          plan: 'pro',
+          email: 'a@ejemplo.com',
+          createdAt: hace(400),
+          lastActivityAt: hace(90),
+        },
+        ultimaConversion: hace(2).toISOString(),
+      },
+    ]);
+
+    const resultado = await service.getProInactiveUsers({
+      minDaysInactive: 30,
+    });
+
+    expect(historialConsultadoPara).toEqual(['uid-campo-desfasado']);
+    expect(resultado.users).toHaveLength(0);
+  });
+
+  it('sigue dando por inactivo a quien lo está en las dos fuentes', async () => {
+    const { service } = buildService([
+      {
+        id: 'uid-inactivo',
+        data: {
+          plan: 'pro',
+          email: 'a@ejemplo.com',
+          createdAt: hace(400),
+          lastActivityAt: hace(90),
+        },
+        ultimaConversion: hace(95).toISOString(),
+      },
+    ]);
+
+    const resultado = await service.getProInactiveUsers({
+      minDaysInactive: 30,
+    });
+
+    expect(resultado.users.map((u: any) => u.userId)).toEqual(['uid-inactivo']);
   });
 });

--- a/src/modules/cache/firestore.service.spec.ts
+++ b/src/modules/cache/firestore.service.spec.ts
@@ -1117,3 +1117,125 @@ describe('FirestoreService — la baja y su evento van en la misma transacción'
     expect(set).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * `getProInactiveUsers` decide a quién se le manda un email de "te echamos de
+ * menos". Derivaba la última actividad del historial de conversiones, que desde
+ * `DELETE /users/history/:id` el propio usuario puede vaciar: un cliente de pago
+ * que convierte a diario y limpia su historial pasaba a parecer inactivo desde
+ * su fecha de alta.
+ */
+describe('FirestoreService — la inactividad no depende del historial', () => {
+  function buildService(
+    usuarios: Array<{
+      id: string;
+      data: Record<string, unknown>;
+      ultimaConversion?: string;
+    }>,
+  ) {
+    const historialConsultadoPara: string[] = [];
+    const service: any = Object.create(FirestoreService.prototype);
+    service.usersCollection = 'users';
+    service.historyCollection = 'conversion_history';
+    service.usageCollection = 'usage';
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+
+    service.firestore = {
+      getAll: async (...refs: Array<{ id: string }>) =>
+        refs.map((r) => ({ id: r.id, exists: false, data: () => undefined })),
+      collection: (nombre: string) => {
+        let userIdFiltrado: string | undefined;
+        const q: any = {
+          doc: (id: string) => ({ id }),
+          where: (campo: string, _op: string, valor: any) => {
+            if (campo === 'userId') userIdFiltrado = valor;
+            return q;
+          },
+          select: () => q,
+          orderBy: () => q,
+          limit: () => q,
+          get: async () => {
+            if (nombre === 'users') {
+              return {
+                docs: usuarios.map((u) => ({
+                  id: u.id,
+                  exists: true,
+                  data: () => u.data,
+                })),
+                empty: usuarios.length === 0,
+              };
+            }
+            if (nombre === 'conversion_history') {
+              historialConsultadoPara.push(userIdFiltrado);
+              const u = usuarios.find((x) => x.id === userIdFiltrado);
+              const docs = u?.ultimaConversion
+                ? [
+                    {
+                      data: () => ({ createdAt: new Date(u.ultimaConversion) }),
+                    },
+                  ]
+                : [];
+              return { docs, empty: docs.length === 0 };
+            }
+            return { docs: [], empty: true };
+          },
+        };
+        return q;
+      },
+    };
+
+    return { service, historialConsultadoPara };
+  }
+
+  const hace = (dias: number) =>
+    new Date(Date.now() - dias * 24 * 60 * 60 * 1000);
+
+  it('no da por inactivo a quien convirtió hoy aunque haya vaciado su historial', async () => {
+    const { service } = buildService([
+      {
+        id: 'uid-activo',
+        // Convirtió hoy: el campo lo escribe recordConversion y el usuario no
+        // puede borrarlo. Su historial, en cambio, está vacío.
+        data: {
+          plan: 'pro',
+          email: 'pro@ejemplo.com',
+          createdAt: hace(400),
+          lastActivityAt: hace(0),
+        },
+      },
+    ]);
+
+    const resultado = await service.getProInactiveUsers({
+      minDaysInactive: 30,
+    });
+
+    expect(resultado.users).toHaveLength(0);
+  });
+
+  it('recurre al historial solo para quien todavía no tiene el campo', async () => {
+    const { service, historialConsultadoPara } = buildService([
+      {
+        id: 'uid-con-campo',
+        data: {
+          plan: 'pro',
+          email: 'a@ejemplo.com',
+          createdAt: hace(400),
+          lastActivityAt: hace(1),
+        },
+      },
+      {
+        id: 'uid-antiguo',
+        data: { plan: 'pro', email: 'b@ejemplo.com', createdAt: hace(400) },
+        ultimaConversion: hace(50).toISOString(),
+      },
+    ]);
+
+    const resultado = await service.getProInactiveUsers({
+      minDaysInactive: 30,
+    });
+
+    // Una query menos por cada usuario que ya trae su actividad registrada.
+    expect(historialConsultadoPara).toEqual(['uid-antiguo']);
+    expect(resultado.users.map((u: any) => u.userId)).toEqual(['uid-antiguo']);
+  });
+});

--- a/src/modules/cache/firestore.service.spec.ts
+++ b/src/modules/cache/firestore.service.spec.ts
@@ -137,6 +137,58 @@ describe('FirestoreService — updateUserSubscriptionState', () => {
 });
 
 /**
+ * Borrar varias filas a la vez no puede hacer retroceder la actividad: la
+ * comparación y la escritura deben compartir la misma transacción para que
+ * Firestore reintente si otro borrado modifica el usuario entre ambas.
+ */
+describe('FirestoreService — preserveLastActivityAt', () => {
+  it('escribe el máximo dentro de una transacción aunque el candidato sea anterior', async () => {
+    const registrada = new Date('2026-08-06T12:00:00.000Z');
+    const posterior = new Date('2026-08-07T12:00:00.000Z');
+    const docData: { lastActivityAt: unknown } = {
+      lastActivityAt: { toDate: () => registrada },
+    };
+    const ref = { id: 'uid-1' };
+    const update = jest
+      .fn()
+      .mockImplementation((_ref: unknown, data: Record<string, unknown>) => {
+        docData.lastActivityAt = data.lastActivityAt;
+      });
+    const runTransaction = jest
+      .fn()
+      .mockImplementation((fn: (transaction: unknown) => Promise<void>) =>
+        fn({
+          get: async () => ({ data: () => docData }),
+          update,
+        }),
+      );
+
+    const service: any = Object.create(FirestoreService.prototype);
+    service.usersCollection = 'users';
+    service.firestore = {
+      collection: () => ({ doc: () => ref }),
+      runTransaction,
+    };
+
+    await service.preserveLastActivityAt(
+      'uid-1',
+      new Date('2026-08-05T12:00:00.000Z'),
+    );
+    await service.preserveLastActivityAt('uid-1', posterior);
+
+    expect(runTransaction).toHaveBeenCalledTimes(2);
+    expect(update).toHaveBeenNthCalledWith(1, ref, {
+      lastActivityAt: registrada,
+      updatedAt: expect.any(Date),
+    });
+    expect(update).toHaveBeenNthCalledWith(2, ref, {
+      lastActivityAt: posterior,
+      updatedAt: expect.any(Date),
+    });
+  });
+});
+
+/**
  * La clave protege del doble cargo del MISMO upgrade, pero dos upgrades a
  * destinos DISTINTOS no pueden compartirla: si el segundo sobrescribe al
  * primero, Stripe procesa ambas mutaciones (issue #73).

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -605,6 +605,45 @@ export class FirestoreService {
   }
 
   /**
+   * Conserva atómicamente la actividad más reciente conocida del usuario.
+   *
+   * La comparación vive dentro de la transacción porque dos borrados de
+   * historial pueden llegar en paralelo. Firestore reintenta la operación si
+   * cambia el documento leído, evitando que una fecha antigua se confirme
+   * después de una más reciente y haga retroceder `lastActivityAt`.
+   */
+  async preserveLastActivityAt(userId: string, candidate: Date): Promise<void> {
+    const ref = this.firestore.collection(this.usersCollection).doc(userId);
+
+    const toMilliseconds = (value: unknown): number | null => {
+      const normalized =
+        (value as { toDate?: () => Date })?.toDate?.() ?? value;
+      const date =
+        normalized instanceof Date
+          ? normalized
+          : new Date(normalized as string);
+      const milliseconds = date.getTime();
+      return Number.isNaN(milliseconds) ? null : milliseconds;
+    };
+
+    await this.firestore.runTransaction(async (transaction) => {
+      const snapshot = await transaction.get(ref);
+      const activityDates = [candidate, snapshot.data()?.lastActivityAt]
+        .map(toMilliseconds)
+        .filter((value): value is number => value !== null);
+
+      if (activityDates.length === 0) {
+        throw new Error('No valid activity date was found');
+      }
+
+      transaction.update(ref, {
+        lastActivityAt: new Date(Math.max(...activityDates)),
+        updatedAt: new Date(),
+      });
+    });
+  }
+
+  /**
    * Adquiere de forma ATÓMICA la clave de idempotencia del upgrade en curso.
    *
    * Leer y escribir por separado permitiría que dos upgrades simultáneos vieran

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -7155,6 +7155,36 @@ export class FirestoreService {
     }
   }
 
+  /**
+   * De una lista de jobIds, devuelve los que tienen ZPL guardado.
+   *
+   * Una sola llamada para toda la página del historial: los docs de
+   * `zpl_debug_files` usan el jobId como id, así que se resuelven con un
+   * `getAll` en vez de una query por fila.
+   *
+   * Responde a "¿se llegó a guardar el ZPL?", no a "¿sigue en el bucket?" — el
+   * doc sobrevive al archivo, que caduca por lifecycle. Quien llama combina
+   * este dato con la edad del registro.
+   */
+  async getJobIdsWithSavedZpl(jobIds: string[]): Promise<Set<string>> {
+    const unicos = [...new Set(jobIds.filter(Boolean))];
+    if (unicos.length === 0) {
+      return new Set();
+    }
+
+    try {
+      const refs = unicos.map((jobId) =>
+        this.firestore.collection(this.zplDebugCollection).doc(jobId),
+      );
+      const docs = await this.firestore.getAll(...refs);
+
+      return new Set(docs.filter((doc) => doc.exists).map((doc) => doc.id));
+    } catch (error) {
+      this.logger.error(`Error comprobando ZPLs guardados: ${error.message}`);
+      throw error;
+    }
+  }
+
   async getZplDebugFileByJobId(jobId: string): Promise<{
     id: string;
     userId: string;

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -7156,20 +7156,28 @@ export class FirestoreService {
   }
 
   /**
-   * De una lista de jobIds, devuelve los que tienen ZPL guardado.
+   * De una lista de jobIds, devuelve los que tienen ZPL guardado y **cuándo** se
+   * guardó. Los que no aparecen en el mapa no tienen copia.
    *
    * Una sola llamada para toda la página del historial: los docs de
    * `zpl_debug_files` usan el jobId como id, así que se resuelven con un
    * `getAll` en vez de una query por fila.
    *
+   * La fecha importa: el lifecycle del bucket cuenta desde que se subió el
+   * objeto, y eso ocurre al empezar la conversión, no al terminarla — la fila
+   * del historial nace después. Fechar la caducidad con el historial haría
+   * parecer al ZPL más joven de lo que es, y el flag prometería de más justo en
+   * el borde de la ventana.
+   *
    * Responde a "¿se llegó a guardar el ZPL?", no a "¿sigue en el bucket?" — el
-   * doc sobrevive al archivo, que caduca por lifecycle. Quien llama combina
-   * este dato con la edad del registro.
+   * doc sobrevive al archivo que el lifecycle ya borró.
    */
-  async getJobIdsWithSavedZpl(jobIds: string[]): Promise<Set<string>> {
+  async getSavedZplDatesByJobId(
+    jobIds: string[],
+  ): Promise<Map<string, Date | null>> {
     const unicos = [...new Set(jobIds.filter(Boolean))];
     if (unicos.length === 0) {
-      return new Set();
+      return new Map();
     }
 
     try {
@@ -7178,7 +7186,14 @@ export class FirestoreService {
       );
       const docs = await this.firestore.getAll(...refs);
 
-      return new Set(docs.filter((doc) => doc.exists).map((doc) => doc.id));
+      return new Map(
+        docs
+          .filter((doc) => doc.exists)
+          .map((doc) => {
+            const createdAt = doc.data()?.createdAt;
+            return [doc.id, createdAt?.toDate?.() || createdAt || null];
+          }),
+      );
     } catch (error) {
       this.logger.error(`Error comprobando ZPLs guardados: ${error.message}`);
       throw error;

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -6045,20 +6045,33 @@ export class FirestoreService {
       // tienen el campo (convirtieron por última vez antes de que existiera).
       // Eso además ahorra una query por usuario en el caso normal.
       const lastActiveAtMap = new Map<string, Date | null>();
-      const sinCampoDeActividad: FirebaseFirestore.QueryDocumentSnapshot[] = [];
+      const porConfirmar: FirebaseFirestore.QueryDocumentSnapshot[] = [];
+
+      // Umbral a partir del cual el usuario empieza a ser candidato a una
+      // campaña: por debajo de él no hay decisión que tomar, así que no hace
+      // falta confirmar nada. El 7 es el periodo más corto del summary.
+      const umbralDeCandidatura = Math.min(7, minDaysInactive);
+      const fechaDeCandidatura = new Date(
+        now.getTime() - umbralDeCandidatura * 24 * 60 * 60 * 1000,
+      );
 
       for (const doc of usersSnapshot.docs) {
         const registrada = doc.data().lastActivityAt;
         const fecha = registrada?.toDate?.() || registrada || null;
-        if (fecha) {
-          lastActiveAtMap.set(doc.id, fecha);
-        } else {
-          sinCampoDeActividad.push(doc);
+        lastActiveAtMap.set(doc.id, fecha);
+
+        // Solo se consulta el historial de quien el campo deja como candidato
+        // (o de quien no lo tiene). El campo se escribe fire-and-forget en
+        // recordConversion, así que puede haber fallado y estar desfasado: para
+        // quien va a recibir un email conviene confirmarlo contra el historial,
+        // que se escribe con await. Para el resto sería una query por cabeza.
+        if (!fecha || fecha <= fechaDeCandidatura) {
+          porConfirmar.push(doc);
         }
       }
 
       const historySnapshots = await Promise.all(
-        sinCampoDeActividad.map((doc) =>
+        porConfirmar.map((doc) =>
           this.firestore
             .collection(this.historyCollection)
             .where('userId', '==', doc.id)
@@ -6070,14 +6083,23 @@ export class FirestoreService {
       );
 
       historySnapshots.forEach((snapshot, index) => {
-        if (snapshot && !snapshot.empty) {
-          const historyData = snapshot.docs[0].data();
-          const lastActiveAt =
-            historyData.createdAt?.toDate?.() || historyData.createdAt || null;
-          lastActiveAtMap.set(sinCampoDeActividad[index].id, lastActiveAt);
-        } else {
-          lastActiveAtMap.set(sinCampoDeActividad[index].id, null);
-        }
+        if (!snapshot || snapshot.empty) return;
+
+        const historyData = snapshot.docs[0].data();
+        const delHistorial =
+          historyData.createdAt?.toDate?.() || historyData.createdAt || null;
+        if (!delHistorial) return;
+
+        // La más reciente de las dos fuentes. Ninguna es fiable por sí sola: el
+        // historial lo puede vaciar el usuario y el campo puede no haberse
+        // escrito. Quedarse con la mayor solo puede evitar un email de
+        // retención a alguien activo, nunca provocarlo.
+        const userId = porConfirmar[index].id;
+        const registrada = lastActiveAtMap.get(userId);
+        lastActiveAtMap.set(
+          userId,
+          !registrada || delHistorial > registrada ? delHistorial : registrada,
+        );
       });
 
       // PHASE 2: Calculate summary and collect filtered users

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -1317,11 +1317,62 @@ export class FirestoreService {
         const data = doc.data();
         return {
           ...data,
+          id: doc.id,
           createdAt: data.createdAt?.toDate?.() || data.createdAt,
         } as ConversionHistory;
       });
     } catch (error) {
       this.logger.error(`Error al obtener historial: ${error.message}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Devuelve un registro de historial por su doc id, o `null` si no existe.
+   * No filtra por usuario: el ownership lo valida quien llama, que es también
+   * quien decide qué error presentar.
+   */
+  async getConversionHistoryById(
+    id: string,
+  ): Promise<ConversionHistory | null> {
+    try {
+      const doc = await this.firestore
+        .collection(this.historyCollection)
+        .doc(id)
+        .get();
+
+      if (!doc.exists) {
+        return null;
+      }
+
+      const data = doc.data();
+      return {
+        ...data,
+        id: doc.id,
+        createdAt: data.createdAt?.toDate?.() || data.createdAt,
+      } as ConversionHistory;
+    } catch (error) {
+      this.logger.error(
+        `Error al obtener registro de historial ${id}: ${error.message}`,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Borra un registro de historial. Borrado real: el historial es un registro
+   * de consulta del usuario, no la fuente de las métricas — esas viven
+   * agregadas en `daily_stats` y `global_totals`, y el consumo del período en
+   * `usage`. Ninguno de los tres se toca aquí.
+   */
+  async deleteConversionHistory(id: string): Promise<void> {
+    try {
+      await this.firestore.collection(this.historyCollection).doc(id).delete();
+      this.logger.log(`Registro de historial eliminado: ${id}`);
+    } catch (error) {
+      this.logger.error(
+        `Error al eliminar registro de historial ${id}: ${error.message}`,
+      );
       throw error;
     }
   }

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -5999,30 +5999,49 @@ export class FirestoreService {
         plan: string;
       }> = [];
 
-      // PHASE 1: Get lastActiveAt from conversion history for all users (parallel queries)
-      // lastActiveAt is NOT stored in user document - it must be calculated from conversions history
-      const historyPromises = usersSnapshot.docs.map(
-        (doc) =>
+      // PHASE 1: la última actividad sale de `users.lastActivityAt`, que
+      // recordConversion escribe en cada conversión. Es la fuente correcta
+      // porque el usuario no puede borrarla: derivarla del historial hacía que
+      // quien vacía su historial —ahora puede, con DELETE /users/history/:id—
+      // pareciera inactivo desde su alta y recibiera emails de retención el día
+      // después de convertir.
+      //
+      // El historial sigue como respaldo, y solo para los usuarios que aún no
+      // tienen el campo (convirtieron por última vez antes de que existiera).
+      // Eso además ahorra una query por usuario en el caso normal.
+      const lastActiveAtMap = new Map<string, Date | null>();
+      const sinCampoDeActividad: FirebaseFirestore.QueryDocumentSnapshot[] = [];
+
+      for (const doc of usersSnapshot.docs) {
+        const registrada = doc.data().lastActivityAt;
+        const fecha = registrada?.toDate?.() || registrada || null;
+        if (fecha) {
+          lastActiveAtMap.set(doc.id, fecha);
+        } else {
+          sinCampoDeActividad.push(doc);
+        }
+      }
+
+      const historySnapshots = await Promise.all(
+        sinCampoDeActividad.map((doc) =>
           this.firestore
             .collection(this.historyCollection)
             .where('userId', '==', doc.id)
             .orderBy('createdAt', 'desc')
             .limit(1)
             .get()
-            .catch(() => null), // Ignore errors (e.g., no index)
+            .catch(() => null),
+        ), // Ignore errors (e.g., no index)
       );
-      const historySnapshots = await Promise.all(historyPromises);
 
-      // Create Map of userId -> lastActiveAt
-      const lastActiveAtMap = new Map<string, Date | null>();
       historySnapshots.forEach((snapshot, index) => {
         if (snapshot && !snapshot.empty) {
           const historyData = snapshot.docs[0].data();
           const lastActiveAt =
             historyData.createdAt?.toDate?.() || historyData.createdAt || null;
-          lastActiveAtMap.set(usersSnapshot.docs[index].id, lastActiveAt);
+          lastActiveAtMap.set(sinCampoDeActividad[index].id, lastActiveAt);
         } else {
-          lastActiveAtMap.set(usersSnapshot.docs[index].id, null);
+          lastActiveAtMap.set(sinCampoDeActividad[index].id, null);
         }
       });
 

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -392,6 +392,7 @@ export class FirestoreService {
           data.subscriptionPeriodStart,
         subscriptionPeriodEnd:
           data.subscriptionPeriodEnd?.toDate?.() || data.subscriptionPeriodEnd,
+        lastActivityAt: data.lastActivityAt?.toDate?.() || data.lastActivityAt,
       } as User;
     } catch (error) {
       this.logger.error(`Error al obtener usuario: ${error.message}`);

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -1435,10 +1435,12 @@ export class FirestoreService {
   }
 
   /**
-   * Borra un registro de historial. Borrado real: el historial es un registro
-   * de consulta del usuario, no la fuente de las métricas — esas viven
-   * agregadas en `daily_stats` y `global_totals`, y el consumo del período en
-   * `usage`. Ninguno de los tres se toca aquí.
+   * Borra un registro de historial. El borrado no revierte `daily_stats`,
+   * `global_totals` ni `usage`, pero sí reduce los datos que leen directamente
+   * de `conversion_history`: `getTopUsers`, `getUserUsageHistory`,
+   * `getUsersWithHighUsage` y `getConversionsPaginated` (la lista de
+   * `/admin/conversions`). Ese efecto es deliberado porque el producto exige
+   * borrado físico, no soft delete.
    */
   async deleteConversionHistory(id: string): Promise<void> {
     try {
@@ -7272,8 +7274,8 @@ export class FirestoreService {
   }
 
   /**
-   * De una lista de jobIds, devuelve los que tienen ZPL guardado y **cuándo** se
-   * guardó. Los que no aparecen en el mapa no tienen copia.
+   * De una lista de jobIds, devuelve los que tienen ZPL guardado, **cuándo** se
+   * guardó y su tamaño. Los que no aparecen en el mapa no tienen copia.
    *
    * Una sola llamada para toda la página del historial: los docs de
    * `zpl_debug_files` usan el jobId como id, así que se resuelven con un
@@ -7290,7 +7292,7 @@ export class FirestoreService {
    */
   async getSavedZplDatesByJobId(
     jobIds: string[],
-  ): Promise<Map<string, Date | null>> {
+  ): Promise<Map<string, { createdAt: Date | null; fileSize: number | null }>> {
     const unicos = [...new Set(jobIds.filter(Boolean))];
     if (unicos.length === 0) {
       return new Map();
@@ -7306,8 +7308,16 @@ export class FirestoreService {
         docs
           .filter((doc) => doc.exists)
           .map((doc) => {
-            const createdAt = doc.data()?.createdAt;
-            return [doc.id, createdAt?.toDate?.() || createdAt || null];
+            const data = doc.data();
+            const createdAt = data?.createdAt;
+            return [
+              doc.id,
+              {
+                createdAt: createdAt?.toDate?.() || createdAt || null,
+                fileSize:
+                  typeof data?.fileSize === 'number' ? data.fileSize : null,
+              },
+            ];
           }),
       );
     } catch (error) {

--- a/src/modules/storage/storage.service.spec.ts
+++ b/src/modules/storage/storage.service.spec.ts
@@ -1,0 +1,28 @@
+// Evitar la conexión real a Google Cloud Storage al construir el servicio.
+jest.mock('@google-cloud/storage', () => ({
+  Storage: jest.fn().mockImplementation(() => ({ bucket: jest.fn() })),
+}));
+
+import { StorageService } from './storage.service.js';
+
+/**
+ * El bucket lo resuelven tres servicios por separado (ZplService, AdminService
+ * y este) leyendo la misma variable. Los otros dos caen en `zplpdf-app-files`
+ * cuando falta; si este no lo hiciera, el lector iría a un bucket distinto del
+ * que escribe el escritor y un ZPL guardado no se podría recuperar — con un 500
+ * opaco en `.bucket(undefined)`, no con un error que explique nada.
+ */
+describe('StorageService — resolución del bucket', () => {
+  function buildService(bucket?: string) {
+    const configService: any = { get: jest.fn().mockReturnValue(bucket) };
+    return new StorageService(configService, {}) as any;
+  }
+
+  it('usa el bucket configurado', () => {
+    expect(buildService('mi-bucket').bucketName).toBe('mi-bucket');
+  });
+
+  it('cae en el mismo fallback que ZplService cuando falta la variable', () => {
+    expect(buildService(undefined).bucketName).toBe('zplpdf-app-files');
+  });
+});

--- a/src/modules/storage/storage.service.ts
+++ b/src/modules/storage/storage.service.ts
@@ -92,6 +92,35 @@ export class StorageService {
   }
 
   /**
+   * Lee un archivo de texto del bucket.
+   *
+   * Devuelve `null` cuando el objeto ya no existe (404 de GCS) en vez de
+   * lanzar: los archivos con ciclo de vida — el ZPL original de una conversión
+   * caduca a los 15 días — desaparecen por diseño, y quien llama traduce esa
+   * ausencia a un 410, no a un 500.
+   *
+   * @param filePath Path del archivo en el bucket (ej: debug-zpl/uid/2026-08-08/job.zpl)
+   */
+  async readTextFile(filePath: string): Promise<string | null> {
+    try {
+      const [contents] = await this.storage
+        .bucket(this.bucketName)
+        .file(filePath)
+        .download();
+
+      return contents.toString('utf-8');
+    } catch (error) {
+      if (error?.code === 404) {
+        return null;
+      }
+      this.logger.error(
+        `Error al leer el archivo ${filePath}: ${error.message}`,
+      );
+      throw error;
+    }
+  }
+
+  /**
    * Genera una URL firmada para cualquier archivo en el bucket
    * @param filePath Path del archivo en el bucket (ej: label-xxx.pdf)
    * @param downloadFilename Nombre del archivo para descarga (opcional)

--- a/src/modules/storage/storage.service.ts
+++ b/src/modules/storage/storage.service.ts
@@ -14,7 +14,13 @@ export class StorageService {
     private configService: ConfigService,
     @Inject('GOOGLE_AUTH_OPTIONS') private googleAuthOptions: any,
   ) {
-    this.bucketName = this.configService.get<string>('GCP_STORAGE_BUCKET');
+    // Mismo fallback que ZplService, AdminService y app.config: sin él, este
+    // servicio resolvía `undefined` y leía de un bucket distinto al que escribe
+    // quien guarda los archivos. Un ZPL guardado por ZplService no se podría
+    // recuperar, y el fallo sería un 500 opaco en `.bucket(undefined)`.
+    this.bucketName =
+      this.configService.get<string>('GCP_STORAGE_BUCKET') ||
+      'zplpdf-app-files';
     this.storage = new Storage(this.googleAuthOptions);
   }
 

--- a/src/modules/users/users.controller.spec.ts
+++ b/src/modules/users/users.controller.spec.ts
@@ -1,0 +1,133 @@
+import { Test } from '@nestjs/testing';
+import type { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { UsersController } from './users.controller.js';
+import { UsersService } from './users.service.js';
+import { FirebaseAuthGuard } from '../../common/guards/firebase-auth.guard.js';
+import { HttpExceptionFilter } from '../../common/filters/http-exception.filter.js';
+
+/**
+ * Verifica el contrato HTTP de las acciones del historial: que Nest resuelve
+ * las rutas con parámetro (`history/:id` no se come `history`), que el id llega
+ * al servicio y que la respuesta tiene la forma `{ success, data }` que espera
+ * el frontend.
+ *
+ * El servicio va mockeado a propósito: su lógica se prueba en
+ * users.service.spec.ts. Lo que aquí puede romperse es el cableado.
+ */
+describe('UsersController — rutas del historial', () => {
+  const UID = 'uid-propietario';
+
+  let app: INestApplication;
+  let usersService: {
+    getUserHistory: jest.Mock;
+    deleteHistoryEntry: jest.Mock;
+    getHistoryZpl: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    usersService = {
+      getUserHistory: jest.fn().mockResolvedValue([]),
+      deleteHistoryEntry: jest
+        .fn()
+        .mockResolvedValue({ id: 'hist-1', deleted: true }),
+      getHistoryZpl: jest.fn().mockResolvedValue({
+        zplContent: '^XA^FDhola^FS^XZ',
+        labelSize: '4x6',
+        outputFormat: 'pdf',
+      }),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [{ provide: UsersService, useValue: usersService }],
+    })
+      .overrideGuard(FirebaseAuthGuard)
+      .useValue({
+        canActivate: (context) => {
+          context.switchToHttp().getRequest().user = { uid: UID };
+          return true;
+        },
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalFilters(new HttpExceptionFilter());
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('DELETE /users/history/:id pasa el id y devuelve { success, data }', async () => {
+    const response = await request(app.getHttpServer())
+      .delete('/users/history/hist-1')
+      .expect(200);
+
+    expect(usersService.deleteHistoryEntry).toHaveBeenCalledWith(UID, 'hist-1');
+    expect(response.body).toEqual({
+      success: true,
+      data: { id: 'hist-1', deleted: true },
+    });
+  });
+
+  it('GET /users/history/:id/zpl devuelve el ZPL con su tamaño y formato', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/users/history/hist-1/zpl')
+      .expect(200);
+
+    expect(usersService.getHistoryZpl).toHaveBeenCalledWith(UID, 'hist-1');
+    expect(response.body).toEqual({
+      success: true,
+      data: {
+        zplContent: '^XA^FDhola^FS^XZ',
+        labelSize: '4x6',
+        outputFormat: 'pdf',
+      },
+    });
+  });
+
+  it('GET /users/history sigue resolviendo al listado, no a la ruta con parámetro', async () => {
+    await request(app.getHttpServer()).get('/users/history').expect(200);
+
+    expect(usersService.getUserHistory).toHaveBeenCalledWith(UID, 1, 50);
+    expect(usersService.getHistoryZpl).not.toHaveBeenCalled();
+  });
+
+  it('propaga el 410 del ZPL caducado con su código de error', async () => {
+    // El frontend distingue "ya no está" de "no existe" por este código.
+    const { GoneException } = await import('@nestjs/common');
+    usersService.getHistoryZpl.mockRejectedValue(
+      new GoneException({
+        error: 'ZPL_NOT_AVAILABLE',
+        message: 'gone',
+        data: { retentionDays: 15 },
+      }),
+    );
+
+    const response = await request(app.getHttpServer())
+      .get('/users/history/hist-1/zpl')
+      .expect(410);
+
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toBe('ZPL_NOT_AVAILABLE');
+    expect(response.body.data).toEqual({ retentionDays: 15 });
+  });
+
+  it('propaga el 404 de un registro ajeno o inexistente', async () => {
+    const { NotFoundException } = await import('@nestjs/common');
+    usersService.deleteHistoryEntry.mockRejectedValue(
+      new NotFoundException({
+        error: 'HISTORY_NOT_FOUND',
+        message: 'History record not found',
+      }),
+    );
+
+    const response = await request(app.getHttpServer())
+      .delete('/users/history/hist-ajeno')
+      .expect(404);
+
+    expect(response.body.error).toBe('HISTORY_NOT_FOUND');
+  });
+});

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -1,6 +1,8 @@
 import {
   Controller,
+  Delete,
   Get,
+  Param,
   Post,
   Query,
   UseGuards,
@@ -14,6 +16,7 @@ import {
   ApiOperation,
   ApiResponse,
   ApiBearerAuth,
+  ApiParam,
   ApiQuery,
 } from '@nestjs/swagger';
 import { UsersService } from './users.service.js';
@@ -23,6 +26,7 @@ import type { FirebaseUser } from '../../common/decorators/current-user.decorato
 import { UserProfileDto } from './dto/user-profile.dto.js';
 import { UserLimitsDto } from './dto/user-limits.dto.js';
 import { VerificationStatusDto } from './dto/verification-status.dto.js';
+import { ZPL_RETENTION_DAYS } from '../../common/interfaces/conversion-history.interface.js';
 
 @ApiTags('users')
 @ApiBearerAuth()
@@ -154,7 +158,10 @@ export class UsersController {
   })
   @ApiResponse({
     status: 200,
-    description: 'Conversion history',
+    description:
+      'Conversion history. Cada ítem incluye `id` (para borrar o recuperar su ZPL) ' +
+      'y `canReconvert`, que indica si el ZPL original sigue dentro de la ventana ' +
+      `de retención de ${ZPL_RETENTION_DAYS} días.`,
   })
   @ApiResponse({
     status: 403,
@@ -170,5 +177,88 @@ export class UsersController {
       page ? Number(page) : 1,
       limit ? Number(limit) : 50,
     );
+  }
+
+  @Delete('history/:id')
+  @ApiOperation({
+    summary: 'Delete a conversion history record (Pro/Enterprise only)',
+    description:
+      'Borra el registro del historial del usuario autenticado. No modifica el uso ' +
+      'mensual (`usage`) ni las métricas agregadas, y no borra el PDF de Cloud Storage: ' +
+      'el historial es un registro de consulta, la cuota se lleva aparte.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Doc id del registro de `conversion_history`',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Record deleted',
+    schema: {
+      example: { success: true, data: { id: 'abc123', deleted: true } },
+    },
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'History is only available for Pro and Enterprise plans',
+  })
+  @ApiResponse({
+    status: 404,
+    description:
+      'El registro no existe o no pertenece al usuario autenticado (mismo código ' +
+      'en ambos casos: distinguirlos confirmaría que el id existe)',
+  })
+  async deleteHistoryEntry(
+    @CurrentUser() user: FirebaseUser,
+    @Param('id') id: string,
+  ) {
+    const data = await this.usersService.deleteHistoryEntry(user.uid, id);
+    return { success: true, data };
+  }
+
+  @Get('history/:id/zpl')
+  @ApiOperation({
+    summary: 'Get the original ZPL of a conversion (Pro/Enterprise only)',
+    description:
+      'Devuelve el ZPL original para precargarlo en el conversor. La reconversión ' +
+      'pasa después por el flujo normal (`POST /zpl/convert`), que es donde se ' +
+      `aplican los límites de plan. El ZPL solo se conserva ${ZPL_RETENTION_DAYS} días.`,
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Doc id del registro de `conversion_history`',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Original ZPL content',
+    schema: {
+      example: {
+        success: true,
+        data: {
+          zplContent: '^XA^FO50,50^ADN,36,20^FDHola^FS^XZ',
+          labelSize: '4x6',
+          outputFormat: 'pdf',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'History is only available for Pro and Enterprise plans',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'El registro no existe o no pertenece al usuario autenticado',
+  })
+  @ApiResponse({
+    status: 410,
+    description: `El ZPL original ya salió de la ventana de retención de ${ZPL_RETENTION_DAYS} días`,
+  })
+  async getHistoryZpl(
+    @CurrentUser() user: FirebaseUser,
+    @Param('id') id: string,
+  ) {
+    const data = await this.usersService.getHistoryZpl(user.uid, id);
+    return { success: true, data };
   }
 }

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -1179,20 +1179,26 @@ describe('UsersService — acciones sobre el historial', () => {
     it('solo consulta los ZPLs de la página, no los del escaneo entero', async () => {
       // El escaneo llega hasta MAX_HISTORY_SCAN registros; resolver el flag para
       // todos costaría cientos de lecturas por request.
+      //
+      // Cada registro lleva su propia fecha, decreciente: con la fecha por
+      // defecto los 40 `new Date()` caen en el mismo milisegundo casi siempre,
+      // pero si el bucle cruza uno el orden cambia y con él la página.
       const { service, firestoreService } = buildService({
         history: Array.from({ length: 40 }, (_, i) =>
-          registroDeHistorial({ id: `hist-${i}`, jobId: `job-${i}` }),
+          registroDeHistorial({
+            id: `hist-${i}`,
+            jobId: `job-${i}`,
+            createdAt: new Date(Date.now() - i * 60_000),
+          }),
         ),
       });
 
       await service.getUserHistory(UID, { limit: 10 });
 
+      // Los diez más recientes, en orden: nada del resto del escaneo.
       expect(firestoreService.getSavedZplDatesByJobId).toHaveBeenCalledWith(
-        expect.arrayContaining(['job-0']),
+        Array.from({ length: 10 }, (_, i) => `job-${i}`),
       );
-      expect(
-        firestoreService.getSavedZplDatesByJobId.mock.calls[0][0],
-      ).toHaveLength(10);
     });
   });
 });

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -782,7 +782,7 @@ describe('UsersService — acciones sobre el historial', () => {
     zplContent?: string | null;
     history?: Record<string, unknown>[];
     zplsGuardados?: Map<string, Date | null> | Error;
-    updateUserError?: Error;
+    preserveLastActivityAtError?: Error;
   }) {
     const firestoreService = {
       getUserById: jest
@@ -800,8 +800,8 @@ describe('UsersService — acciones sobre el historial', () => {
             : overrides.record,
         ),
       deleteConversionHistory: jest.fn().mockResolvedValue(undefined),
-      updateUser: overrides.updateUserError
-        ? jest.fn().mockRejectedValue(overrides.updateUserError)
+      preserveLastActivityAt: overrides.preserveLastActivityAtError
+        ? jest.fn().mockRejectedValue(overrides.preserveLastActivityAtError)
         : jest.fn().mockResolvedValue(undefined),
       getZplDebugFileByJobId: jest.fn().mockResolvedValue(
         overrides.debugFile === undefined
@@ -884,17 +884,18 @@ describe('UsersService — acciones sobre el historial', () => {
 
       await service.deleteHistoryEntry(UID, HISTORY_ID);
 
-      expect(firestoreService.updateUser).toHaveBeenCalledWith(UID, {
-        lastActivityAt: createdAt,
-      });
+      expect(firestoreService.preserveLastActivityAt).toHaveBeenCalledWith(
+        UID,
+        createdAt,
+      );
       expect(
-        firestoreService.updateUser.mock.invocationCallOrder[0],
+        firestoreService.preserveLastActivityAt.mock.invocationCallOrder[0],
       ).toBeLessThan(
         firestoreService.deleteConversionHistory.mock.invocationCallOrder[0],
       );
 
       const fallo = buildService({
-        updateUserError: new Error('Firestore no disponible'),
+        preserveLastActivityAtError: new Error('Firestore no disponible'),
       });
 
       await expect(
@@ -904,29 +905,6 @@ describe('UsersService — acciones sobre el historial', () => {
       expect(fallo.service.logger.warn).toHaveBeenCalledWith(
         expect.stringContaining('Failed to preserve lastActivityAt'),
       );
-    });
-
-    it('conserva la actividad más reciente cuando Firestore devuelve un Timestamp', async () => {
-      const createdAt = new Date('2026-08-05T12:00:00.000Z');
-      const lastActivityAt = new Date('2026-08-06T12:00:00.000Z');
-      const { service, firestoreService } = buildService({
-        user: {
-          id: UID,
-          plan: 'pro',
-          role: 'user',
-          lastActivityAt: { toDate: () => lastActivityAt },
-        },
-        record: registroDeHistorial({ createdAt }),
-      });
-
-      await service.deleteHistoryEntry(UID, HISTORY_ID);
-
-      expect(firestoreService.updateUser).toHaveBeenCalledWith(UID, {
-        lastActivityAt,
-      });
-      expect(firestoreService.updateUser).not.toHaveBeenCalledWith(UID, {
-        lastActivityAt: createdAt,
-      });
     });
 
     it('no toca el uso mensual al borrar', async () => {
@@ -1023,6 +1001,38 @@ describe('UsersService — acciones sobre el historial', () => {
       const { labelSize } = await service.getHistoryZpl(UID, HISTORY_ID);
 
       expect(labelSize).toBe('2x1');
+    });
+
+    it('normaliza el alias jpg al valor JPEG que acepta la reconversión', async () => {
+      const { service } = buildService({
+        record: registroDeHistorial({ outputFormat: 'jpg' }),
+      });
+
+      const { outputFormat } = await service.getHistoryZpl(UID, HISTORY_ID);
+
+      expect(outputFormat).toBe('jpeg');
+    });
+
+    it('devuelve JPEG para PDF porque el batch lo procesó como imagen', async () => {
+      // `processBatchFiles` compara con `pdf` antes de elegir la rama de
+      // imagen; `PDF` cae en JPEG aunque parezca un alias natural de PDF.
+      const { service } = buildService({
+        record: registroDeHistorial({ outputFormat: 'PDF' }),
+      });
+
+      const { outputFormat } = await service.getHistoryZpl(UID, HISTORY_ID);
+
+      expect(outputFormat).toBe('jpeg');
+    });
+
+    it('devuelve JPEG para un formato desconocido, igual que el batch', async () => {
+      const { service } = buildService({
+        record: registroDeHistorial({ outputFormat: 'webp' }),
+      });
+
+      const { outputFormat } = await service.getHistoryZpl(UID, HISTORY_ID);
+
+      expect(outputFormat).toBe('jpeg');
     });
 
     it('responde 404 ante un registro de otro usuario, sin leer el ZPL', async () => {

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -906,6 +906,29 @@ describe('UsersService — acciones sobre el historial', () => {
       );
     });
 
+    it('conserva la actividad más reciente cuando Firestore devuelve un Timestamp', async () => {
+      const createdAt = new Date('2026-08-05T12:00:00.000Z');
+      const lastActivityAt = new Date('2026-08-06T12:00:00.000Z');
+      const { service, firestoreService } = buildService({
+        user: {
+          id: UID,
+          plan: 'pro',
+          role: 'user',
+          lastActivityAt: { toDate: () => lastActivityAt },
+        },
+        record: registroDeHistorial({ createdAt }),
+      });
+
+      await service.deleteHistoryEntry(UID, HISTORY_ID);
+
+      expect(firestoreService.updateUser).toHaveBeenCalledWith(UID, {
+        lastActivityAt,
+      });
+      expect(firestoreService.updateUser).not.toHaveBeenCalledWith(UID, {
+        lastActivityAt: createdAt,
+      });
+    });
+
     it('no toca el uso mensual al borrar', async () => {
       // Si el borrado descontara PDFs del período, bastaría con vaciar el
       // historial para reiniciar la cuota del mes.

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -26,6 +26,9 @@ describe('UsersService — acciones sobre el historial', () => {
   const OTRO_UID = 'uid-ajeno';
   const HISTORY_ID = 'hist-1';
 
+  const diasAtras = (dias: number) =>
+    new Date(Date.now() - dias * 24 * 60 * 60 * 1000);
+
   function registroDeHistorial(overrides: Record<string, unknown> = {}) {
     return {
       id: HISTORY_ID,
@@ -46,6 +49,7 @@ describe('UsersService — acciones sobre el historial', () => {
     debugFile?: Record<string, unknown> | null;
     zplContent?: string | null;
     history?: Record<string, unknown>[];
+    jobIdsConZpl?: Set<string> | Error;
   }) {
     const firestoreService = {
       getUserById: jest
@@ -73,6 +77,15 @@ describe('UsersService — acciones sobre el historial', () => {
       getUserConversionHistory: jest
         .fn()
         .mockResolvedValue(overrides.history ?? []),
+      getJobIdsWithSavedZpl: jest
+        .fn()
+        .mockImplementation((jobIds: string[]) => {
+          if (overrides.jobIdsConZpl instanceof Error) {
+            return Promise.reject(overrides.jobIdsConZpl);
+          }
+          // Por defecto, todos los jobs del historial tienen su ZPL guardado.
+          return Promise.resolve(overrides.jobIdsConZpl ?? new Set(jobIds));
+        }),
       // Si algún camino intentara tocar la cuota, el test lo vería aquí.
       incrementUsage: jest.fn(),
       updateUsage: jest.fn(),
@@ -216,9 +229,6 @@ describe('UsersService — acciones sobre el historial', () => {
   });
 
   describe('getUserHistory — flag canReconvert', () => {
-    const diasAtras = (dias: number) =>
-      new Date(Date.now() - dias * 24 * 60 * 60 * 1000);
-
     it('marca reconvertible lo que sigue dentro de la ventana de retención', async () => {
       const { service } = buildService({
         history: [registroDeHistorial({ createdAt: diasAtras(1) })],
@@ -250,6 +260,33 @@ describe('UsersService — acciones sobre el historial', () => {
       const [record] = await service.getUserHistory(UID);
 
       expect(record.id).toBe(HISTORY_ID);
+    });
+
+    it('no promete reconvertir una fila cuyo ZPL nunca se guardó', async () => {
+      // Las filas que el flujo batch creó antes de que guardara el ZPL son
+      // recientes pero irrecuperables: por edad saldrían como reconvertibles y
+      // el botón devolvería 410 al pulsarlo.
+      const { service } = buildService({
+        history: [registroDeHistorial({ createdAt: diasAtras(1) })],
+        jobIdsConZpl: new Set<string>(),
+      });
+
+      const [record] = await service.getUserHistory(UID);
+
+      expect(record.canReconvert).toBe(false);
+    });
+
+    it('degrada a no reconvertible si la consulta de ZPLs falla', async () => {
+      // Un botón de más deshabilitado es preferible a prometer un 410, y a que
+      // el listado entero reviente por un flag.
+      const { service } = buildService({
+        history: [registroDeHistorial({ createdAt: diasAtras(1) })],
+        jobIdsConZpl: new Error('firestore caído'),
+      });
+
+      const [record] = await service.getUserHistory(UID);
+
+      expect(record.canReconvert).toBe(false);
     });
   });
 });

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -937,6 +937,29 @@ describe('UsersService — acciones sobre el historial', () => {
       );
     });
 
+    it('normaliza el tamaño del batch al valor que acepta POST /zpl/convert', async () => {
+      // El batch guarda el tamaño como llegó (`large`), pero ConvertZplDto lo
+      // valida con @IsEnum(LabelSize): devolverlo crudo haría que reconvertir
+      // fallara con un 400 usando el tamaño con el que ya funcionó.
+      const { service } = buildService({
+        record: registroDeHistorial({ labelSize: 'large' }),
+      });
+
+      const { labelSize } = await service.getHistoryZpl(UID, HISTORY_ID);
+
+      expect(labelSize).toBe('4x6');
+    });
+
+    it('devuelve 2x1 para un tamaño desconocido, que es con el que se convirtió', async () => {
+      const { service } = buildService({
+        record: registroDeHistorial({ labelSize: '4x4' }),
+      });
+
+      const { labelSize } = await service.getHistoryZpl(UID, HISTORY_ID);
+
+      expect(labelSize).toBe('2x1');
+    });
+
     it('responde 404 ante un registro de otro usuario, sin leer el ZPL', async () => {
       const { service, storageService, firestoreService } = buildService({
         record: registroDeHistorial({ userId: OTRO_UID }),

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -782,6 +782,7 @@ describe('UsersService — acciones sobre el historial', () => {
     zplContent?: string | null;
     history?: Record<string, unknown>[];
     zplsGuardados?: Map<string, Date | null> | Error;
+    updateUserError?: Error;
   }) {
     const firestoreService = {
       getUserById: jest
@@ -799,13 +800,18 @@ describe('UsersService — acciones sobre el historial', () => {
             : overrides.record,
         ),
       deleteConversionHistory: jest.fn().mockResolvedValue(undefined),
-      getZplDebugFileByJobId: jest
-        .fn()
-        .mockResolvedValue(
-          overrides.debugFile === undefined
-            ? { userId: UID, storagePath: 'debug-zpl/uid/2026-08-08/job-1.zpl' }
-            : overrides.debugFile,
-        ),
+      updateUser: overrides.updateUserError
+        ? jest.fn().mockRejectedValue(overrides.updateUserError)
+        : jest.fn().mockResolvedValue(undefined),
+      getZplDebugFileByJobId: jest.fn().mockResolvedValue(
+        overrides.debugFile === undefined
+          ? {
+              userId: UID,
+              storagePath: 'debug-zpl/uid/2026-08-08/job-1.zpl',
+              createdAt: new Date(),
+            }
+          : overrides.debugFile,
+      ),
       scanUserConversionHistory: jest
         .fn()
         .mockResolvedValue(overrides.history ?? []),
@@ -861,6 +867,42 @@ describe('UsersService — acciones sobre el historial', () => {
       ).resolves.toEqual({ id: HISTORY_ID, deleted: true });
       expect(firestoreService.deleteConversionHistory).toHaveBeenCalledWith(
         HISTORY_ID,
+      );
+    });
+
+    it('preserva la actividad del registro antes de borrarlo y no bloquea el borrado si falla', async () => {
+      const createdAt = diasAtras(1);
+      const { service, firestoreService } = buildService({
+        user: {
+          id: UID,
+          plan: 'pro',
+          role: 'user',
+          lastActivityAt: diasAtras(30),
+        },
+        record: registroDeHistorial({ createdAt }),
+      });
+
+      await service.deleteHistoryEntry(UID, HISTORY_ID);
+
+      expect(firestoreService.updateUser).toHaveBeenCalledWith(UID, {
+        lastActivityAt: createdAt,
+      });
+      expect(
+        firestoreService.updateUser.mock.invocationCallOrder[0],
+      ).toBeLessThan(
+        firestoreService.deleteConversionHistory.mock.invocationCallOrder[0],
+      );
+
+      const fallo = buildService({
+        updateUserError: new Error('Firestore no disponible'),
+      });
+
+      await expect(
+        fallo.service.deleteHistoryEntry(UID, HISTORY_ID),
+      ).resolves.toEqual({ id: HISTORY_ID, deleted: true });
+      expect(fallo.firestoreService.deleteConversionHistory).toHaveBeenCalled();
+      expect(fallo.service.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to preserve lastActivityAt'),
       );
     });
 
@@ -980,6 +1022,23 @@ describe('UsersService — acciones sobre el historial', () => {
       await expect(
         service.getHistoryZpl(UID, HISTORY_ID),
       ).rejects.toBeInstanceOf(GoneException);
+    });
+
+    it('responde 410 sin leer GCS cuando el ZPL ya superó la retención', async () => {
+      // El lifecycle puede tardar en borrar el objeto; su existencia física no
+      // debe ampliar el plazo que el endpoint promete al usuario.
+      const { service, storageService } = buildService({
+        debugFile: {
+          userId: UID,
+          storagePath: 'debug-zpl/uid/2026-08-08/job-1.zpl',
+          createdAt: diasAtras(ZPL_RETENTION_DAYS + 1),
+        },
+      });
+
+      await expect(
+        service.getHistoryZpl(UID, HISTORY_ID),
+      ).rejects.toBeInstanceOf(GoneException);
+      expect(storageService.readTextFile).not.toHaveBeenCalled();
     });
 
     it('responde 410 cuando nunca se guardó el ZPL del job', async () => {

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -11,7 +11,11 @@ import {
   GoneException,
   NotFoundException,
 } from '@nestjs/common';
-import { UsersService, MAX_HISTORY_SCAN } from './users.service.js';
+import {
+  UsersService,
+  MAX_HISTORY_SCAN,
+  MAX_RECONVERTIBLE_ZPL_SIZE_BYTES,
+} from './users.service.js';
 import { ZPL_RETENTION_DAYS } from '../../common/interfaces/conversion-history.interface.js';
 import {
   GetHistoryQueryDto,
@@ -76,7 +80,12 @@ describe('UsersService — getUserHistory', () => {
         .fn()
         .mockImplementation(
           async (jobIds: string[]) =>
-            new Map(jobIds.map((jobId) => [jobId, new Date()])),
+            new Map(
+              jobIds.map((jobId) => [
+                jobId,
+                { createdAt: new Date(), fileSize: null },
+              ]),
+            ),
         ),
     };
     service.storageService = { generateSignedUrlForPath };
@@ -781,7 +790,9 @@ describe('UsersService — acciones sobre el historial', () => {
     debugFile?: Record<string, unknown> | null;
     zplContent?: string | null;
     history?: Record<string, unknown>[];
-    zplsGuardados?: Map<string, Date | null> | Error;
+    zplsGuardados?:
+      | Map<string, { createdAt: Date | null; fileSize: number | null }>
+      | Error;
     preserveLastActivityAtError?: Error;
   }) {
     const firestoreService = {
@@ -824,7 +835,12 @@ describe('UsersService — acciones sobre el historial', () => {
           // Por defecto, todos los jobs tienen su ZPL guardado hoy mismo.
           return Promise.resolve(
             overrides.zplsGuardados ??
-              new Map(jobIds.map((jobId) => [jobId, new Date()])),
+              new Map(
+                jobIds.map((jobId) => [
+                  jobId,
+                  { createdAt: new Date(), fileSize: null },
+                ]),
+              ),
           );
         }),
       // Si algún camino intentara tocar la cuota, el test lo vería aquí.
@@ -1074,6 +1090,25 @@ describe('UsersService — acciones sobre el historial', () => {
       expect(storageService.readTextFile).not.toHaveBeenCalled();
     });
 
+    it('usa la fecha reciente del historial cuando la metadata no trae createdAt', async () => {
+      const { service, storageService } = buildService({
+        record: registroDeHistorial({ createdAt: diasAtras(1) }),
+        debugFile: {
+          userId: UID,
+          storagePath: 'debug-zpl/uid/2026-08-08/job-1.zpl',
+        },
+      });
+
+      await expect(service.getHistoryZpl(UID, HISTORY_ID)).resolves.toEqual({
+        zplContent: '^XA^FDhola^FS^XZ',
+        labelSize: '4x6',
+        outputFormat: 'pdf',
+      });
+      expect(storageService.readTextFile).toHaveBeenCalledWith(
+        'debug-zpl/uid/2026-08-08/job-1.zpl',
+      );
+    });
+
     it('responde 410 cuando nunca se guardó el ZPL del job', async () => {
       // saveZplForDebug es fire-and-forget: puede haber fallado.
       const { service } = buildService({ debugFile: null });
@@ -1111,7 +1146,15 @@ describe('UsersService — acciones sobre el historial', () => {
         history: [
           registroDeHistorial({ createdAt: diasAtras(ZPL_RETENTION_DAYS + 1) }),
         ],
-        zplsGuardados: new Map([['job-1', diasAtras(ZPL_RETENTION_DAYS + 1)]]),
+        zplsGuardados: new Map([
+          [
+            'job-1',
+            {
+              createdAt: diasAtras(ZPL_RETENTION_DAYS + 1),
+              fileSize: null,
+            },
+          ],
+        ]),
       });
 
       const { data } = await service.getUserHistory(UID, {});
@@ -1129,7 +1172,13 @@ describe('UsersService — acciones sobre el historial', () => {
           }),
         ],
         zplsGuardados: new Map([
-          ['job-1', diasAtras(ZPL_RETENTION_DAYS + 0.5)],
+          [
+            'job-1',
+            {
+              createdAt: diasAtras(ZPL_RETENTION_DAYS + 0.5),
+              fileSize: null,
+            },
+          ],
         ]),
       });
 
@@ -1141,7 +1190,60 @@ describe('UsersService — acciones sobre el historial', () => {
     it('recurre a la fecha del historial si el doc de metadata no la trae', async () => {
       const { service } = buildService({
         history: [registroDeHistorial({ createdAt: diasAtras(1) })],
-        zplsGuardados: new Map([['job-1', null]]),
+        zplsGuardados: new Map([
+          ['job-1', { createdAt: null, fileSize: null }],
+        ]),
+      });
+
+      const { data } = await service.getUserHistory(UID, {});
+
+      expect(data[0].canReconvert).toBe(true);
+    });
+
+    it('no promete reconvertir un ZPL cuyo tamaño conocido supera el tope del body', async () => {
+      const { service } = buildService({
+        history: [registroDeHistorial({ createdAt: diasAtras(1) })],
+        zplsGuardados: new Map([
+          [
+            'job-1',
+            {
+              createdAt: diasAtras(1),
+              fileSize: MAX_RECONVERTIBLE_ZPL_SIZE_BYTES + 1,
+            },
+          ],
+        ]),
+      });
+
+      const { data } = await service.getUserHistory(UID, {});
+
+      expect(data[0].canReconvert).toBe(false);
+    });
+
+    it('permite reconvertir un ZPL cuyo tamaño conocido queda bajo el tope', async () => {
+      const { service } = buildService({
+        history: [registroDeHistorial({ createdAt: diasAtras(1) })],
+        zplsGuardados: new Map([
+          [
+            'job-1',
+            {
+              createdAt: diasAtras(1),
+              fileSize: MAX_RECONVERTIBLE_ZPL_SIZE_BYTES - 1,
+            },
+          ],
+        ]),
+      });
+
+      const { data } = await service.getUserHistory(UID, {});
+
+      expect(data[0].canReconvert).toBe(true);
+    });
+
+    it('no bloquea la reconversión cuando la metadata antigua no trae tamaño', async () => {
+      const { service } = buildService({
+        history: [registroDeHistorial({ createdAt: diasAtras(1) })],
+        zplsGuardados: new Map([
+          ['job-1', { createdAt: diasAtras(1), fileSize: null }],
+        ]),
       });
 
       const { data } = await service.getUserHistory(UID, {});
@@ -1155,7 +1257,10 @@ describe('UsersService — acciones sobre el historial', () => {
       // el botón devolvería 410 al pulsarlo.
       const { service } = buildService({
         history: [registroDeHistorial({ createdAt: diasAtras(1) })],
-        zplsGuardados: new Map<string, Date | null>(),
+        zplsGuardados: new Map<
+          string,
+          { createdAt: Date | null; fileSize: number | null }
+        >(),
       });
 
       const { data } = await service.getUserHistory(UID, {});

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -1,0 +1,255 @@
+// Evitar la conexión real a Stripe al cargar el módulo.
+jest.mock('stripe', () => jest.fn());
+
+import {
+  ForbiddenException,
+  GoneException,
+  NotFoundException,
+} from '@nestjs/common';
+import { UsersService } from './users.service.js';
+import { ZPL_RETENTION_DAYS } from '../../common/interfaces/conversion-history.interface.js';
+
+/**
+ * Acciones del historial: borrar una fila y recuperar el ZPL original para
+ * reconvertir.
+ *
+ * Dos riesgos concretos guían estos tests:
+ *
+ *  1. El id de `conversion_history` viaja en la URL. Sin comprobación de
+ *     ownership, cualquier usuario con plan de pago leería el ZPL de otro —
+ *     que es su dato de negocio (SKUs, direcciones, lotes).
+ *  2. El contador mensual no puede depender del historial. Si borrar filas
+ *     descontara PDFs, la cuota se reiniciaría vaciando la tabla.
+ */
+describe('UsersService — acciones sobre el historial', () => {
+  const UID = 'uid-propietario';
+  const OTRO_UID = 'uid-ajeno';
+  const HISTORY_ID = 'hist-1';
+
+  function registroDeHistorial(overrides: Record<string, unknown> = {}) {
+    return {
+      id: HISTORY_ID,
+      userId: UID,
+      jobId: 'job-1',
+      labelCount: 3,
+      labelSize: '4x6',
+      status: 'completed',
+      outputFormat: 'pdf',
+      createdAt: new Date(),
+      ...overrides,
+    };
+  }
+
+  function buildService(overrides: {
+    user?: Record<string, unknown> | null;
+    record?: Record<string, unknown> | null;
+    debugFile?: Record<string, unknown> | null;
+    zplContent?: string | null;
+    history?: Record<string, unknown>[];
+  }) {
+    const firestoreService = {
+      getUserById: jest
+        .fn()
+        .mockResolvedValue(
+          overrides.user === undefined
+            ? { id: UID, plan: 'pro', role: 'user' }
+            : overrides.user,
+        ),
+      getConversionHistoryById: jest
+        .fn()
+        .mockResolvedValue(
+          overrides.record === undefined
+            ? registroDeHistorial()
+            : overrides.record,
+        ),
+      deleteConversionHistory: jest.fn().mockResolvedValue(undefined),
+      getZplDebugFileByJobId: jest
+        .fn()
+        .mockResolvedValue(
+          overrides.debugFile === undefined
+            ? { userId: UID, storagePath: 'debug-zpl/uid/2026-08-08/job-1.zpl' }
+            : overrides.debugFile,
+        ),
+      getUserConversionHistory: jest
+        .fn()
+        .mockResolvedValue(overrides.history ?? []),
+      // Si algún camino intentara tocar la cuota, el test lo vería aquí.
+      incrementUsage: jest.fn(),
+      updateUsage: jest.fn(),
+      resetUsage: jest.fn(),
+    };
+
+    const storageService = {
+      readTextFile: jest
+        .fn()
+        .mockResolvedValue(
+          overrides.zplContent === undefined
+            ? '^XA^FDhola^FS^XZ'
+            : overrides.zplContent,
+        ),
+      generateSignedUrlForPath: jest
+        .fn()
+        .mockResolvedValue('https://signed.example/file.pdf'),
+    };
+
+    const service = Object.create(UsersService.prototype) as UsersService;
+    Object.assign(service, {
+      logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+      firestoreService,
+      storageService,
+    });
+
+    return { service, firestoreService, storageService };
+  }
+
+  describe('deleteHistoryEntry', () => {
+    it('borra el registro y devuelve el id', async () => {
+      const { service, firestoreService } = buildService({});
+
+      await expect(
+        service.deleteHistoryEntry(UID, HISTORY_ID),
+      ).resolves.toEqual({ id: HISTORY_ID, deleted: true });
+      expect(firestoreService.deleteConversionHistory).toHaveBeenCalledWith(
+        HISTORY_ID,
+      );
+    });
+
+    it('no toca el uso mensual al borrar', async () => {
+      // Si el borrado descontara PDFs del período, bastaría con vaciar el
+      // historial para reiniciar la cuota del mes.
+      const { service, firestoreService } = buildService({});
+
+      await service.deleteHistoryEntry(UID, HISTORY_ID);
+
+      expect(firestoreService.incrementUsage).not.toHaveBeenCalled();
+      expect(firestoreService.updateUsage).not.toHaveBeenCalled();
+      expect(firestoreService.resetUsage).not.toHaveBeenCalled();
+    });
+
+    it('responde 404 —no 403— ante un registro de otro usuario, y no lo borra', async () => {
+      // Un 403 confirmaría que el id existe; el id va en la URL y es adivinable.
+      const { service, firestoreService } = buildService({
+        record: registroDeHistorial({ userId: OTRO_UID }),
+      });
+
+      await expect(
+        service.deleteHistoryEntry(UID, HISTORY_ID),
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(firestoreService.deleteConversionHistory).not.toHaveBeenCalled();
+    });
+
+    it('responde 404 cuando el registro no existe', async () => {
+      const { service } = buildService({ record: null });
+
+      await expect(
+        service.deleteHistoryEntry(UID, HISTORY_ID),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('rechaza a los planes sin historial antes de leer nada', async () => {
+      const { service, firestoreService } = buildService({
+        user: { id: UID, plan: 'lite', role: 'user' },
+      });
+
+      await expect(
+        service.deleteHistoryEntry(UID, HISTORY_ID),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(firestoreService.getConversionHistoryById).not.toHaveBeenCalled();
+      expect(firestoreService.deleteConversionHistory).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getHistoryZpl', () => {
+    it('devuelve el ZPL con el tamaño y el formato del registro', async () => {
+      const { service, storageService } = buildService({});
+
+      await expect(service.getHistoryZpl(UID, HISTORY_ID)).resolves.toEqual({
+        zplContent: '^XA^FDhola^FS^XZ',
+        labelSize: '4x6',
+        outputFormat: 'pdf',
+      });
+      expect(storageService.readTextFile).toHaveBeenCalledWith(
+        'debug-zpl/uid/2026-08-08/job-1.zpl',
+      );
+    });
+
+    it('responde 404 ante un registro de otro usuario, sin leer el ZPL', async () => {
+      const { service, storageService, firestoreService } = buildService({
+        record: registroDeHistorial({ userId: OTRO_UID }),
+      });
+
+      await expect(
+        service.getHistoryZpl(UID, HISTORY_ID),
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(firestoreService.getZplDebugFileByJobId).not.toHaveBeenCalled();
+      expect(storageService.readTextFile).not.toHaveBeenCalled();
+    });
+
+    it('responde 410 —no 500— cuando el archivo ya salió del bucket', async () => {
+      // El lifecycle de `debug-zpl/` borra en GCS pero deja el doc de
+      // `zpl_debug_files`: la ausencia solo se ve al leer el objeto.
+      const { service } = buildService({ zplContent: null });
+
+      await expect(
+        service.getHistoryZpl(UID, HISTORY_ID),
+      ).rejects.toBeInstanceOf(GoneException);
+    });
+
+    it('responde 410 cuando nunca se guardó el ZPL del job', async () => {
+      // saveZplForDebug es fire-and-forget: puede haber fallado.
+      const { service } = buildService({ debugFile: null });
+
+      await expect(
+        service.getHistoryZpl(UID, HISTORY_ID),
+      ).rejects.toBeInstanceOf(GoneException);
+    });
+
+    it('rechaza a los planes sin historial', async () => {
+      const { service } = buildService({
+        user: { id: UID, plan: 'free', role: 'user' },
+      });
+
+      await expect(
+        service.getHistoryZpl(UID, HISTORY_ID),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+  });
+
+  describe('getUserHistory — flag canReconvert', () => {
+    const diasAtras = (dias: number) =>
+      new Date(Date.now() - dias * 24 * 60 * 60 * 1000);
+
+    it('marca reconvertible lo que sigue dentro de la ventana de retención', async () => {
+      const { service } = buildService({
+        history: [registroDeHistorial({ createdAt: diasAtras(1) })],
+      });
+
+      const [record] = await service.getUserHistory(UID);
+
+      expect(record.canReconvert).toBe(true);
+    });
+
+    it('marca no reconvertible lo que ya la superó', async () => {
+      // El frontend deshabilita el botón con esto en vez de descubrirlo con un 410.
+      const { service } = buildService({
+        history: [
+          registroDeHistorial({ createdAt: diasAtras(ZPL_RETENTION_DAYS + 1) }),
+        ],
+      });
+
+      const [record] = await service.getUserHistory(UID);
+
+      expect(record.canReconvert).toBe(false);
+    });
+
+    it('expone el id del documento, que es la clave de las dos acciones nuevas', async () => {
+      const { service } = buildService({
+        history: [registroDeHistorial()],
+      });
+
+      const [record] = await service.getUserHistory(UID);
+
+      expect(record.id).toBe(HISTORY_ID);
+    });
+  });
+});

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -49,7 +49,7 @@ describe('UsersService — acciones sobre el historial', () => {
     debugFile?: Record<string, unknown> | null;
     zplContent?: string | null;
     history?: Record<string, unknown>[];
-    jobIdsConZpl?: Set<string> | Error;
+    zplsGuardados?: Map<string, Date | null> | Error;
   }) {
     const firestoreService = {
       getUserById: jest
@@ -77,14 +77,17 @@ describe('UsersService — acciones sobre el historial', () => {
       getUserConversionHistory: jest
         .fn()
         .mockResolvedValue(overrides.history ?? []),
-      getJobIdsWithSavedZpl: jest
+      getSavedZplDatesByJobId: jest
         .fn()
         .mockImplementation((jobIds: string[]) => {
-          if (overrides.jobIdsConZpl instanceof Error) {
-            return Promise.reject(overrides.jobIdsConZpl);
+          if (overrides.zplsGuardados instanceof Error) {
+            return Promise.reject(overrides.zplsGuardados);
           }
-          // Por defecto, todos los jobs del historial tienen su ZPL guardado.
-          return Promise.resolve(overrides.jobIdsConZpl ?? new Set(jobIds));
+          // Por defecto, todos los jobs tienen su ZPL guardado hoy mismo.
+          return Promise.resolve(
+            overrides.zplsGuardados ??
+              new Map(jobIds.map((jobId) => [jobId, new Date()])),
+          );
         }),
       // Si algún camino intentara tocar la cuota, el test lo vería aquí.
       incrementUsage: jest.fn(),
@@ -245,11 +248,42 @@ describe('UsersService — acciones sobre el historial', () => {
         history: [
           registroDeHistorial({ createdAt: diasAtras(ZPL_RETENTION_DAYS + 1) }),
         ],
+        zplsGuardados: new Map([['job-1', diasAtras(ZPL_RETENTION_DAYS + 1)]]),
       });
 
       const [record] = await service.getUserHistory(UID);
 
       expect(record.canReconvert).toBe(false);
+    });
+
+    it('cuenta la ventana desde que se guardó el ZPL, no desde la fila del historial', async () => {
+      // El objeto se sube al empezar la conversión y la fila nace al terminarla:
+      // en el borde de la ventana, fecharlo por el historial promete de más.
+      const { service } = buildService({
+        history: [
+          registroDeHistorial({
+            createdAt: diasAtras(ZPL_RETENTION_DAYS - 0.5),
+          }),
+        ],
+        zplsGuardados: new Map([
+          ['job-1', diasAtras(ZPL_RETENTION_DAYS + 0.5)],
+        ]),
+      });
+
+      const [record] = await service.getUserHistory(UID);
+
+      expect(record.canReconvert).toBe(false);
+    });
+
+    it('recurre a la fecha del historial si el doc de metadata no la trae', async () => {
+      const { service } = buildService({
+        history: [registroDeHistorial({ createdAt: diasAtras(1) })],
+        zplsGuardados: new Map([['job-1', null]]),
+      });
+
+      const [record] = await service.getUserHistory(UID);
+
+      expect(record.canReconvert).toBe(true);
     });
 
     it('expone el id del documento, que es la clave de las dos acciones nuevas', async () => {
@@ -268,7 +302,7 @@ describe('UsersService — acciones sobre el historial', () => {
       // el botón devolvería 410 al pulsarlo.
       const { service } = buildService({
         history: [registroDeHistorial({ createdAt: diasAtras(1) })],
-        jobIdsConZpl: new Set<string>(),
+        zplsGuardados: new Map<string, Date | null>(),
       });
 
       const [record] = await service.getUserHistory(UID);
@@ -281,7 +315,7 @@ describe('UsersService — acciones sobre el historial', () => {
       // el listado entero reviente por un flag.
       const { service } = buildService({
         history: [registroDeHistorial({ createdAt: diasAtras(1) })],
-        jobIdsConZpl: new Error('firestore caído'),
+        zplsGuardados: new Error('firestore caído'),
       });
 
       const [record] = await service.getUserHistory(UID);

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -47,6 +47,7 @@ import { GeoService } from '../admin/services/geo.service.js';
 import { EmailService } from '../email/email.service.js';
 import { StorageService } from '../storage/storage.service.js';
 import { normalizeLabelSize } from '../zpl/enums/label-size.enum.js';
+import { normalizeOutputFormat } from '../zpl/enums/output-format.enum.js';
 
 export interface CheckCanConvertResult {
   allowed: boolean;
@@ -780,30 +781,12 @@ export class UsersService {
     // falló, borrar esta fila eliminaría la única fecha fiable y podría hacer
     // que un cliente recién activo pareciera inactivo desde su alta.
     try {
-      const user = await this.firestoreService.getUserById(userId);
-      // Aunque getUserById normaliza el Timestamp, esta defensa también cubre
-      // adaptadores y registros antiguos con fechas ISO. Comparar los valores
-      // crudos haría que JavaScript comparase strings según el día de la semana.
-      const toMilliseconds = (value: unknown): number | null => {
-        const normalized =
-          (value as { toDate?: () => Date })?.toDate?.() ?? value;
-        const date =
-          normalized instanceof Date
-            ? normalized
-            : new Date(normalized as string);
-        const milliseconds = date.getTime();
-        return Number.isNaN(milliseconds) ? null : milliseconds;
-      };
-      const activityDates = [record.createdAt, user?.lastActivityAt]
-        .map(toMilliseconds)
-        .filter((value): value is number => value !== null);
-
-      if (activityDates.length === 0) {
-        throw new Error('No valid activity date was found');
-      }
-
-      const lastActivityAt = new Date(Math.max(...activityDates));
-      await this.firestoreService.updateUser(userId, { lastActivityAt });
+      // El máximo se calcula dentro de una transacción: dos borrados paralelos
+      // no pueden confirmar una fecha antigua después de otra más reciente.
+      await this.firestoreService.preserveLastActivityAt(
+        userId,
+        record.createdAt,
+      );
     } catch (error) {
       // Preservar la señal de actividad es defensivo; un fallo aquí no debe
       // convertir en imborrable una fila que el usuario ya decidió eliminar.
@@ -882,7 +865,10 @@ export class UsersService {
       // Devolverlo tal cual haría que reconvertir fallara con un 400 usando el
       // mismo tamaño con el que la conversión original funcionó.
       labelSize: normalizeLabelSize(record.labelSize),
-      outputFormat: record.outputFormat,
+      // El batch también guarda el formato sin validar. La normalización debe
+      // seguir su rama efectiva: solo `pdf` y `png` exactos son especiales;
+      // cualquier otro string generó JPEG.
+      outputFormat: normalizeOutputFormat(record.outputFormat),
     };
   }
 

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -367,11 +367,11 @@ export class UsersService {
   }
 
   /**
-   * Indica si el ZPL original de un registro sigue dentro de la ventana de
-   * retención del bucket. Se calcula por edad, sin tocar Storage: resolverlo
-   * fila a fila costaría una lectura de Firestore y otra de GCS por cada una.
+   * Indica si el registro sigue dentro de la ventana de retención del bucket.
+   * Se calcula por edad, sin tocar Storage: comprobar el objeto fila a fila
+   * costaría una llamada a GCS por cada una.
    */
-  private canReconvert(createdAt: Date | undefined): boolean {
+  private isWithinZplRetention(createdAt: Date | undefined): boolean {
     if (!createdAt) return false;
 
     // Firestore devuelve Date, pero los registros antiguos pueden traer la
@@ -382,6 +382,40 @@ export class UsersService {
 
     const ageMs = Date.now() - created.getTime();
     return ageMs < ZPL_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+  }
+
+  /**
+   * Marca cada fila con si admite "reconvertir". Son dos condiciones y hacen
+   * falta las dos:
+   *
+   *  - que se guardara el ZPL (una sola consulta en lote para toda la página).
+   *    No todas las filas lo tienen: hasta este cambio, el flujo batch creaba
+   *    historial sin guardar ZPL, así que esas filas nunca podrán reconvertirse.
+   *  - que el registro siga dentro de la ventana de retención, porque el doc de
+   *    metadata sobrevive al archivo que el bucket ya borró.
+   *
+   * Si la consulta en lote falla, marca todo como no reconvertible: un botón de
+   * más deshabilitado es preferible a prometer algo que devolverá 410.
+   */
+  private async marcarReconvertibles(
+    history: ConversionHistory[],
+  ): Promise<void> {
+    let jobIdsConZpl = new Set<string>();
+    try {
+      jobIdsConZpl = await this.firestoreService.getJobIdsWithSavedZpl(
+        history.map((record) => record.jobId),
+      );
+    } catch (error) {
+      this.logger.warn(
+        `Failed to resolve canReconvert flags: ${error.message}`,
+      );
+    }
+
+    for (const record of history) {
+      record.canReconvert =
+        jobIdsConZpl.has(record.jobId) &&
+        this.isWithinZplRetention(record.createdAt);
+    }
   }
 
   async getUserHistory(
@@ -397,6 +431,10 @@ export class UsersService {
       limit,
       offset,
     );
+
+    // El frontend deshabilita "reconvertir" con este flag en vez de descubrir
+    // la caducidad a base de 410s al pulsar el botón.
+    await this.marcarReconvertibles(history);
 
     // Regenerar URLs firmadas frescas para cada registro completado
     return Promise.all(
@@ -419,9 +457,6 @@ export class UsersService {
             }
           }
         }
-        // El frontend deshabilita "reconvertir" con este flag en vez de
-        // descubrir la caducidad a base de 410s al pulsar el botón.
-        record.canReconvert = this.canReconvert(record.createdAt);
         return record;
       }),
     );

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -2,6 +2,8 @@ import {
   Injectable,
   Logger,
   ForbiddenException,
+  GoneException,
+  NotFoundException,
   Inject,
   forwardRef,
 } from '@nestjs/common';
@@ -22,7 +24,9 @@ import type {
   PlanType,
   PlanLimits,
 } from '../../common/interfaces/user.interface.js';
+import { ZPL_RETENTION_DAYS } from '../../common/interfaces/conversion-history.interface.js';
 import type { ConversionHistory } from '../../common/interfaces/conversion-history.interface.js';
+import { ErrorCodes } from '../../common/constants/error-codes.js';
 import { UserProfileDto } from './dto/user-profile.dto.js';
 import { UserLimitsDto } from './dto/user-limits.dto.js';
 import { VerificationStatusDto } from './dto/verification-status.dto.js';
@@ -312,11 +316,12 @@ export class UsersService {
     };
   }
 
-  async getUserHistory(
-    userId: string,
-    page: number = 1,
-    limit: number = 50,
-  ): Promise<ConversionHistory[]> {
+  /**
+   * Gate de plan del historial, compartido por todos sus endpoints (listar,
+   * borrar, recuperar el ZPL). Vive aparte para que una acción nueva sobre el
+   * historial no pueda olvidarse de comprobarlo.
+   */
+  private async assertCanViewHistory(userId: string): Promise<void> {
     const user = await this.firestoreService.getUserById(userId);
 
     if (!user) {
@@ -336,6 +341,55 @@ export class UsersService {
         'History is only available for Pro, Pro Max and Enterprise plans',
       );
     }
+  }
+
+  /**
+   * Carga un registro de historial exigiendo que sea del usuario.
+   *
+   * Un registro ajeno se responde igual que uno inexistente (404): un 403
+   * delataría que el id existe, y el id es adivinable.
+   */
+  private async getOwnedHistoryRecord(
+    userId: string,
+    historyId: string,
+  ): Promise<ConversionHistory> {
+    const record =
+      await this.firestoreService.getConversionHistoryById(historyId);
+
+    if (!record || record.userId !== userId) {
+      throw new NotFoundException({
+        error: ErrorCodes.HISTORY_NOT_FOUND,
+        message: 'History record not found',
+      });
+    }
+
+    return record;
+  }
+
+  /**
+   * Indica si el ZPL original de un registro sigue dentro de la ventana de
+   * retención del bucket. Se calcula por edad, sin tocar Storage: resolverlo
+   * fila a fila costaría una lectura de Firestore y otra de GCS por cada una.
+   */
+  private canReconvert(createdAt: Date | undefined): boolean {
+    if (!createdAt) return false;
+
+    // Firestore devuelve Date, pero los registros antiguos pueden traer la
+    // fecha como string ISO: normalizar aquí evita un NaN silencioso.
+    const created =
+      createdAt instanceof Date ? createdAt : new Date(createdAt as string);
+    if (Number.isNaN(created.getTime())) return false;
+
+    const ageMs = Date.now() - created.getTime();
+    return ageMs < ZPL_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+  }
+
+  async getUserHistory(
+    userId: string,
+    page: number = 1,
+    limit: number = 50,
+  ): Promise<ConversionHistory[]> {
+    await this.assertCanViewHistory(userId);
 
     const offset = (page - 1) * limit;
     const history = await this.firestoreService.getUserConversionHistory(
@@ -365,9 +419,88 @@ export class UsersService {
             }
           }
         }
+        // El frontend deshabilita "reconvertir" con este flag en vez de
+        // descubrir la caducidad a base de 410s al pulsar el botón.
+        record.canReconvert = this.canReconvert(record.createdAt);
         return record;
       }),
     );
+  }
+
+  /**
+   * Elimina un registro del historial del usuario.
+   *
+   * Deliberadamente NO toca `usage`: si borrar filas descontara PDFs del
+   * período, cualquiera podría reiniciar su cuota vaciando el historial. El
+   * historial es un registro de consulta; la cuota se lleva aparte. Tampoco
+   * borra el PDF de Cloud Storage, que tiene su propio ciclo de vida.
+   */
+  async deleteHistoryEntry(
+    userId: string,
+    historyId: string,
+  ): Promise<{ id: string; deleted: true }> {
+    await this.assertCanViewHistory(userId);
+    await this.getOwnedHistoryRecord(userId, historyId);
+
+    await this.firestoreService.deleteConversionHistory(historyId);
+
+    return { id: historyId, deleted: true };
+  }
+
+  /**
+   * Devuelve el ZPL original de una conversión para que el frontend lo
+   * precargue en el conversor. La reconversión en sí pasa por el flujo normal
+   * (`POST /zpl/convert`), que es donde viven los límites de plan.
+   *
+   * El ZPL no está en Firestore — `ConversionStatus.zplContent` existe en el
+   * tipo pero nunca se escribe, y un ZPL de varios MB no cabría en un
+   * documento. La copia real está en el bucket, bajo `debug-zpl/`, indexada
+   * por jobId en `zpl_debug_files`. Ese prefijo caduca a los
+   * ZPL_RETENTION_DAYS días: pasado ese plazo la respuesta es 410, no 500.
+   */
+  async getHistoryZpl(
+    userId: string,
+    historyId: string,
+  ): Promise<{
+    zplContent: string;
+    labelSize: string;
+    outputFormat: 'pdf' | 'png' | 'jpeg';
+  }> {
+    await this.assertCanViewHistory(userId);
+    const record = await this.getOwnedHistoryRecord(userId, historyId);
+
+    const zplNoLongerAvailable = new GoneException({
+      error: ErrorCodes.ZPL_NOT_AVAILABLE,
+      message: `The original ZPL is only kept for ${ZPL_RETENTION_DAYS} days and is no longer available for this conversion`,
+      data: { retentionDays: ZPL_RETENTION_DAYS },
+    });
+
+    const debugFile = await this.firestoreService.getZplDebugFileByJobId(
+      record.jobId,
+    );
+
+    // Sin metadata no hay path que leer: el guardado del ZPL es fire-and-forget
+    // y pudo fallar en su día.
+    if (!debugFile || debugFile.userId !== userId) {
+      throw zplNoLongerAvailable;
+    }
+
+    // El doc de `zpl_debug_files` sobrevive al archivo — el lifecycle solo
+    // borra en GCS —, así que su presencia no garantiza nada: la única prueba
+    // de que el ZPL sigue ahí es leer el objeto.
+    const zplContent = await this.storageService.readTextFile(
+      debugFile.storagePath,
+    );
+
+    if (!zplContent) {
+      throw zplNoLongerAvailable;
+    }
+
+    return {
+      zplContent,
+      labelSize: record.labelSize,
+      outputFormat: record.outputFormat,
+    };
   }
 
   /**

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -73,6 +73,14 @@ export const DEFAULT_HISTORY_LIMIT = 25;
  */
 export const MAX_HISTORY_SCAN = 1000;
 
+/**
+ * Máximo que se ofrece para reconversión. Aunque el parser admite 5 MiB, el
+ * ZPL vuelve dentro de JSON y sus saltos, barras y comillas se escapan; reservar
+ * 1 MiB deja margen para que esa sobrecarga no haga que `POST /zpl/convert`
+ * rechace el body.
+ */
+export const MAX_RECONVERTIBLE_ZPL_SIZE_BYTES = 4 * 1024 * 1024;
+
 /** TTL de la caché en memoria del escaneo de historial. */
 const HISTORY_SCAN_CACHE_TTL_MS = 60_000;
 
@@ -439,14 +447,16 @@ export class UsersService {
   }
 
   /**
-   * Marca cada fila con si admite "reconvertir". Son dos condiciones y hacen
-   * falta las dos:
+   * Marca cada fila con si admite "reconvertir". Las condiciones deben cumplirse
+   * a la vez:
    *
    *  - que se guardara el ZPL (una sola consulta en lote para toda la página).
    *    No todas las filas lo tienen: hasta este cambio, el flujo batch creaba
    *    historial sin guardar ZPL, así que esas filas nunca podrán reconvertirse.
    *  - que el ZPL siga dentro de la ventana de retención, porque el doc de
    *    metadata sobrevive al archivo que el bucket ya borró.
+   *  - que el tamaño conocido quepa en el body JSON del conversor. La metadata
+   *    antigua sin `fileSize` no se bloquea porque podría ser perfectamente apta.
    *
    * La ventana se cuenta desde que se guardó el ZPL, no desde que se registró
    * la conversión: el objeto se sube al empezar y la fila del historial nace al
@@ -460,7 +470,10 @@ export class UsersService {
   private async resolverReconvertibles(
     records: ConversionHistoryRecord[],
   ): Promise<Set<string>> {
-    let zplsGuardados = new Map<string, Date | null>();
+    let zplsGuardados = new Map<
+      string,
+      { createdAt: Date | null; fileSize: number | null }
+    >();
     try {
       zplsGuardados = await this.firestoreService.getSavedZplDatesByJobId(
         records.map((record) => record.jobId),
@@ -473,13 +486,17 @@ export class UsersService {
 
     return new Set(
       records
-        .filter(
-          (record) =>
-            zplsGuardados.has(record.jobId) &&
+        .filter((record) => {
+          const zplGuardado = zplsGuardados.get(record.jobId);
+          return (
+            zplGuardado !== undefined &&
             this.isWithinZplRetention(
-              zplsGuardados.get(record.jobId) ?? record.createdAt,
-            ),
-        )
+              zplGuardado.createdAt ?? record.createdAt,
+            ) &&
+            (zplGuardado.fileSize === null ||
+              zplGuardado.fileSize <= MAX_RECONVERTIBLE_ZPL_SIZE_BYTES)
+          );
+        })
         .map((record) => record.id),
     );
   }
@@ -837,11 +854,13 @@ export class UsersService {
     );
 
     // El lifecycle puede tardar hasta 24h en borrar el objeto. Respetar la edad
-    // de la metadata evita que ese retraso amplíe la ventana contractual.
+    // de la metadata evita que ese retraso amplíe la ventana contractual. Los
+    // docs antiguos sin fecha usan la misma fecha de respaldo que el listado,
+    // para que `canReconvert` y este endpoint no discrepen.
     if (
       !debugFile ||
       debugFile.userId !== userId ||
-      !this.isWithinZplRetention(debugFile.createdAt)
+      !this.isWithinZplRetention(debugFile.createdAt ?? record.createdAt)
     ) {
       throw zplNoLongerAvailable;
     }

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -774,7 +774,25 @@ export class UsersService {
     historyId: string,
   ): Promise<{ id: string; deleted: true }> {
     await this.assertCanViewHistory(userId);
-    await this.getOwnedHistoryRecord(userId, historyId);
+    const record = await this.getOwnedHistoryRecord(userId, historyId);
+
+    // La escritura de `lastActivityAt` al convertir es fire-and-forget. Si
+    // falló, borrar esta fila eliminaría la única fecha fiable y podría hacer
+    // que un cliente recién activo pareciera inactivo desde su alta.
+    try {
+      const user = await this.firestoreService.getUserById(userId);
+      const lastActivityAt =
+        user?.lastActivityAt && user.lastActivityAt > record.createdAt
+          ? user.lastActivityAt
+          : record.createdAt;
+      await this.firestoreService.updateUser(userId, { lastActivityAt });
+    } catch (error) {
+      // Preservar la señal de actividad es defensivo; un fallo aquí no debe
+      // convertir en imborrable una fila que el usuario ya decidió eliminar.
+      this.logger.warn(
+        `Failed to preserve lastActivityAt before deleting history ${historyId}: ${error.message}`,
+      );
+    }
 
     await this.firestoreService.deleteConversionHistory(historyId);
 
@@ -817,9 +835,13 @@ export class UsersService {
       record.jobId,
     );
 
-    // Sin metadata no hay path que leer: el guardado del ZPL es fire-and-forget
-    // y pudo fallar en su día.
-    if (!debugFile || debugFile.userId !== userId) {
+    // El lifecycle puede tardar hasta 24h en borrar el objeto. Respetar la edad
+    // de la metadata evita que ese retraso amplíe la ventana contractual.
+    if (
+      !debugFile ||
+      debugFile.userId !== userId ||
+      !this.isWithinZplRetention(debugFile.createdAt)
+    ) {
       throw zplNoLongerAvailable;
     }
 

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -781,10 +781,28 @@ export class UsersService {
     // que un cliente recién activo pareciera inactivo desde su alta.
     try {
       const user = await this.firestoreService.getUserById(userId);
-      const lastActivityAt =
-        user?.lastActivityAt && user.lastActivityAt > record.createdAt
-          ? user.lastActivityAt
-          : record.createdAt;
+      // Aunque getUserById normaliza el Timestamp, esta defensa también cubre
+      // adaptadores y registros antiguos con fechas ISO. Comparar los valores
+      // crudos haría que JavaScript comparase strings según el día de la semana.
+      const toMilliseconds = (value: unknown): number | null => {
+        const normalized =
+          (value as { toDate?: () => Date })?.toDate?.() ?? value;
+        const date =
+          normalized instanceof Date
+            ? normalized
+            : new Date(normalized as string);
+        const milliseconds = date.getTime();
+        return Number.isNaN(milliseconds) ? null : milliseconds;
+      };
+      const activityDates = [record.createdAt, user?.lastActivityAt]
+        .map(toMilliseconds)
+        .filter((value): value is number => value !== null);
+
+      if (activityDates.length === 0) {
+        throw new Error('No valid activity date was found');
+      }
+
+      const lastActivityAt = new Date(Math.max(...activityDates));
       await this.firestoreService.updateUser(userId, { lastActivityAt });
     } catch (error) {
       // Preservar la señal de actividad es defensivo; un fallo aquí no debe

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -46,6 +46,7 @@ import { isBlockedEmailDomain } from '../../common/constants/blocked-email-domai
 import { GeoService } from '../admin/services/geo.service.js';
 import { EmailService } from '../email/email.service.js';
 import { StorageService } from '../storage/storage.service.js';
+import { normalizeLabelSize } from '../zpl/enums/label-size.enum.js';
 
 export interface CheckCanConvertResult {
   allowed: boolean;
@@ -835,7 +836,12 @@ export class UsersService {
 
     return {
       zplContent,
-      labelSize: record.labelSize,
+      // Normalizado, no crudo: el batch acepta el tamaño como string libre
+      // (`large`, `small`, o cualquier cosa) y así queda guardado en el
+      // historial, pero `POST /zpl/convert` lo valida con `@IsEnum(LabelSize)`.
+      // Devolverlo tal cual haría que reconvertir fallara con un 400 usando el
+      // mismo tamaño con el que la conversión original funcionó.
+      labelSize: normalizeLabelSize(record.labelSize),
       outputFormat: record.outputFormat,
     };
   }

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -391,8 +391,14 @@ export class UsersService {
    *  - que se guardara el ZPL (una sola consulta en lote para toda la página).
    *    No todas las filas lo tienen: hasta este cambio, el flujo batch creaba
    *    historial sin guardar ZPL, así que esas filas nunca podrán reconvertirse.
-   *  - que el registro siga dentro de la ventana de retención, porque el doc de
+   *  - que el ZPL siga dentro de la ventana de retención, porque el doc de
    *    metadata sobrevive al archivo que el bucket ya borró.
+   *
+   * La ventana se cuenta desde que se guardó el ZPL, no desde que se registró
+   * la conversión: el objeto se sube al empezar y la fila del historial nace al
+   * terminar, así que el lifecycle lleva ya un rato corriendo cuando aparece la
+   * fila. Solo se recurre a la fecha del historial si el doc de metadata es
+   * antiguo y no la trae.
    *
    * Si la consulta en lote falla, marca todo como no reconvertible: un botón de
    * más deshabilitado es preferible a prometer algo que devolverá 410.
@@ -400,9 +406,9 @@ export class UsersService {
   private async marcarReconvertibles(
     history: ConversionHistory[],
   ): Promise<void> {
-    let jobIdsConZpl = new Set<string>();
+    let zplsGuardados = new Map<string, Date | null>();
     try {
-      jobIdsConZpl = await this.firestoreService.getJobIdsWithSavedZpl(
+      zplsGuardados = await this.firestoreService.getSavedZplDatesByJobId(
         history.map((record) => record.jobId),
       );
     } catch (error) {
@@ -413,8 +419,10 @@ export class UsersService {
 
     for (const record of history) {
       record.canReconvert =
-        jobIdsConZpl.has(record.jobId) &&
-        this.isWithinZplRetention(record.createdAt);
+        zplsGuardados.has(record.jobId) &&
+        this.isWithinZplRetention(
+          zplsGuardados.get(record.jobId) ?? record.createdAt,
+        );
     }
   }
 

--- a/src/modules/zpl/enums/label-size.enum.ts
+++ b/src/modules/zpl/enums/label-size.enum.ts
@@ -4,3 +4,32 @@ export enum LabelSize {
   FOUR_BY_TWO = '4x2',
   FOUR_BY_SIX = '4x6',
 }
+
+/**
+ * Alias aceptados al pedir una conversión. `small` y `large` vienen de la API
+ * antigua y siguen admitiéndose.
+ */
+const LABEL_SIZE_ALIASES: Record<string, LabelSize> = {
+  small: LabelSize.TWO_BY_ONE,
+  '2x1': LabelSize.TWO_BY_ONE,
+  '2x4': LabelSize.TWO_BY_FOUR,
+  '4x2': LabelSize.FOUR_BY_TWO,
+  large: LabelSize.FOUR_BY_SIX,
+  '4x6': LabelSize.FOUR_BY_SIX,
+};
+
+/**
+ * Traduce cualquier tamaño de entrada al valor del enum con el que se convierte
+ * de verdad. Un valor desconocido cae en 2x1, igual que la conversión.
+ *
+ * Es compartida porque el historial guarda el tamaño **sin normalizar**: el
+ * batch lo acepta como string libre, mientras que `POST /zpl/convert` lo valida
+ * con `@IsEnum(LabelSize)`. Devolver el valor crudo al reconvertir haría que el
+ * frontend recibiera un 400 con el mismo tamaño con el que la conversión
+ * original funcionó.
+ */
+export function normalizeLabelSize(labelSize: string | undefined): LabelSize {
+  return (
+    LABEL_SIZE_ALIASES[labelSize?.toLowerCase() ?? ''] ?? LabelSize.TWO_BY_ONE
+  );
+}

--- a/src/modules/zpl/enums/output-format.enum.ts
+++ b/src/modules/zpl/enums/output-format.enum.ts
@@ -3,3 +3,26 @@ export enum OutputFormat {
   PNG = 'png',
   JPEG = 'jpeg',
 }
+
+/**
+ * Traduce el formato guardado por el batch al enum que acepta la reconversión.
+ *
+ * El endpoint batch deja pasar strings libres y `processBatchFiles` solo trata
+ * como PDF y PNG sus valores canónicos en minúsculas. Cualquier otro valor se
+ * procesa como JPEG; por eso incluso `PDF` debe volver como JPEG, que es el
+ * archivo que realmente produjo, mientras alias como `jpg` o `JPG` también
+ * convergen en el valor canónico `jpeg`.
+ */
+export function normalizeOutputFormat(
+  outputFormat: string | undefined,
+): OutputFormat {
+  if (outputFormat === OutputFormat.PDF) {
+    return OutputFormat.PDF;
+  }
+
+  if (outputFormat === OutputFormat.PNG) {
+    return OutputFormat.PNG;
+  }
+
+  return OutputFormat.JPEG;
+}

--- a/src/modules/zpl/zpl.service.spec.ts
+++ b/src/modules/zpl/zpl.service.spec.ts
@@ -528,4 +528,30 @@ describe('ZplService — el batch deja el ZPL disponible para reconvertir', () =
 
     expect(updateZplDebugResult).toHaveBeenCalledWith('job-batch-1', 'success');
   });
+
+  it('espera a que el ZPL esté guardado antes de marcar su resultado', async () => {
+    // updateZplDebugResult usa update() y se traga el fallo si el doc todavía no
+    // existe; el set() posterior del guardado dejaría el registro en `pending`
+    // para siempre. Con una subida más lenta que la conversión, el orden importa.
+    const { service, updateZplDebugResult } = buildBatchService();
+    let zplYaGuardado = false;
+    service.saveZplForDebug = jest.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) =>
+          setImmediate(() => {
+            zplYaGuardado = true;
+            resolve();
+          }),
+        ),
+    );
+    const observado: boolean[] = [];
+    updateZplDebugResult.mockImplementation(() => {
+      observado.push(zplYaGuardado);
+      return Promise.resolve();
+    });
+
+    await service.processBatchFiles('batch-1', [archivo], [job], '4x6', 'pdf');
+
+    expect(observado).toEqual([true]);
+  });
 });

--- a/src/modules/zpl/zpl.service.spec.ts
+++ b/src/modules/zpl/zpl.service.spec.ts
@@ -434,3 +434,98 @@ describe('ZplService — userEmail en rechazos de cuota/acceso', () => {
     );
   });
 });
+
+/**
+ * Cada archivo de un batch acaba como una fila propia en `conversion_history`,
+ * indistinguible de una conversión individual desde el historial. Si el batch
+ * no guarda su ZPL, esas filas quedan mudas: "reconvertir" devuelve 410 para
+ * siempre y el listado, que solo mira la edad del registro, las anuncia como
+ * reconvertibles durante los 15 días de retención.
+ */
+describe('ZplService — el batch deja el ZPL disponible para reconvertir', () => {
+  function buildBatchService() {
+    const saveZplForDebug = jest.fn().mockResolvedValue(undefined);
+    const recordConversion = jest.fn().mockResolvedValue(undefined);
+    const updateZplDebugResult = jest.fn().mockResolvedValue(undefined);
+
+    const service = Object.create(ZplService.prototype) as any;
+    Object.assign(service, {
+      logger: {
+        log: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+      },
+      bucket: 'test-bucket',
+      storage: {
+        bucket: () => ({
+          file: () => ({ save: jest.fn().mockResolvedValue(undefined) }),
+        }),
+      },
+      firestoreService: {
+        getBatchJob: jest.fn().mockResolvedValue({ userId: 'uid-pro' }),
+        updateZplDebugResult,
+      },
+      usersService: {
+        getUserById: jest.fn().mockResolvedValue({
+          id: 'uid-pro',
+          plan: 'pro',
+          email: 'pro@ejemplo.com',
+        }),
+        recordConversion,
+      },
+      // Ruido del bucle que estos tests no ejercitan.
+      getLabelSize: jest.fn().mockReturnValue(LabelSize.FOUR_BY_SIX),
+      countLabels: jest.fn().mockResolvedValue({ data: { totalLabels: 7 } }),
+      convertZplToPdf: jest.fn().mockResolvedValue(Buffer.from('pdf')),
+      updateBatchJobProgress: jest.fn().mockResolvedValue(undefined),
+      finalizeBatch: jest.fn().mockResolvedValue(undefined),
+      saveZplForDebug,
+    });
+
+    return { service, saveZplForDebug, recordConversion, updateZplDebugResult };
+  }
+
+  const archivo = { id: 'f1', content: '^XA^FDhola^FS^XZ', fileName: 'a.zpl' };
+  const job = {
+    jobId: 'job-batch-1',
+    fileName: 'a.zpl',
+    status: 'pending',
+    progress: 0,
+  };
+
+  it('guarda el ZPL de cada archivo bajo el jobId con el que se registra en el historial', async () => {
+    const { service, saveZplForDebug, recordConversion } = buildBatchService();
+
+    await service.processBatchFiles('batch-1', [archivo], [job], '4x6', 'pdf');
+
+    expect(saveZplForDebug).toHaveBeenCalledWith(
+      archivo.content,
+      'job-batch-1',
+      'uid-pro',
+      'pro@ejemplo.com',
+      '4x6',
+      7,
+      'pdf',
+    );
+    // El mismo jobId en ambos lados: es lo que une la fila del historial con su ZPL.
+    expect(recordConversion).toHaveBeenCalledWith(
+      'uid-pro',
+      'job-batch-1',
+      7,
+      '4x6',
+      'completed',
+      'pdf',
+      undefined,
+      undefined,
+    );
+  });
+
+  it('marca el resultado del ZPL guardado en vez de dejarlo en pending', async () => {
+    const { service, updateZplDebugResult } = buildBatchService();
+
+    await service.processBatchFiles('batch-1', [archivo], [job], '4x6', 'pdf');
+
+    expect(updateZplDebugResult).toHaveBeenCalledWith('job-batch-1', 'success');
+  });
+});

--- a/src/modules/zpl/zpl.service.ts
+++ b/src/modules/zpl/zpl.service.ts
@@ -2156,10 +2156,12 @@ export class ZplService {
 
     // Obtener el plan del usuario (batch solo disponible para pro/enterprise)
     let userPlan: UserPlan = 'pro';
+    let userEmail = 'unknown';
     if (userId) {
       try {
         const user = await this.usersService.getUserById(userId);
         userPlan = (user?.plan as UserPlan) || 'pro';
+        userEmail = user?.email || 'unknown';
       } catch {
         userPlan = 'pro'; // Default para batch
       }
@@ -2177,6 +2179,24 @@ export class ZplService {
       } catch (error) {
         this.logger.warn(
           `Error contando labels en ${file.fileName}: ${error.message}`,
+        );
+      }
+
+      // Cada archivo del batch acaba como una fila propia en el historial (ver
+      // recordConversion más abajo), así que tiene que dejar su ZPL guardado
+      // igual que una conversión individual: si no, esas filas nunca podrían
+      // reconvertirse y GET /users/history/:id/zpl devolvería siempre 410.
+      if (userId) {
+        this.saveZplForDebug(
+          file.content,
+          job.jobId,
+          userId,
+          userEmail,
+          labelSize,
+          labelCount,
+          outputFormat as OutputFormat,
+        ).catch((err) =>
+          this.logger.warn(`Failed to save ZPL for debug: ${err.message}`),
         );
       }
 
@@ -2244,6 +2264,14 @@ export class ZplService {
             undefined,
             periodInfo,
           );
+          // Update ZPL debug result
+          this.firestoreService
+            .updateZplDebugResult(job.jobId, 'success')
+            .catch((err) =>
+              this.logger.warn(
+                `Failed to update ZPL debug result: ${err.message}`,
+              ),
+            );
         }
 
         this.logger.log(
@@ -2275,6 +2303,14 @@ export class ZplService {
               `Error registrando conversión fallida: ${recordError.message}`,
             );
           }
+          // Update ZPL debug result
+          this.firestoreService
+            .updateZplDebugResult(job.jobId, 'error', error.message)
+            .catch((err) =>
+              this.logger.warn(
+                `Failed to update ZPL debug result: ${err.message}`,
+              ),
+            );
         }
       }
 

--- a/src/modules/zpl/zpl.service.ts
+++ b/src/modules/zpl/zpl.service.ts
@@ -39,13 +39,12 @@ import {
   PLAN_FEATURES,
 } from '../../common/interfaces/user.interface.js';
 import type { PlanType } from '../../common/interfaces/user.interface.js';
+import { LabelSize, normalizeLabelSize } from './enums/label-size.enum.js';
 
-export enum LabelSize {
-  TWO_BY_ONE = '2x1',
-  TWO_BY_FOUR = '2x4',
-  FOUR_BY_TWO = '4x2',
-  FOUR_BY_SIX = '4x6',
-}
+// El enum vivía duplicado aquí y en `enums/label-size.enum.ts`, con los mismos
+// valores pero como dos tipos distintos para TypeScript. Se reexporta el
+// canónico para no romper a quien lo importa desde este módulo.
+export { LabelSize };
 
 // Interfaz para el estado de conversión
 interface ConversionJob {
@@ -110,15 +109,6 @@ export class ZplService {
     '4x2': '4x2',
     large: '4x6',
     '4x6': '4x6',
-  };
-
-  private readonly LABEL_SIZE_ENUM_MAP: Record<string, LabelSize> = {
-    small: LabelSize.TWO_BY_ONE,
-    '2x1': LabelSize.TWO_BY_ONE,
-    '2x4': LabelSize.TWO_BY_FOUR,
-    '4x2': LabelSize.FOUR_BY_TWO,
-    large: LabelSize.FOUR_BY_SIX,
-    '4x6': LabelSize.FOUR_BY_SIX,
   };
 
   constructor(
@@ -1701,9 +1691,7 @@ export class ZplService {
    * @returns LabelSize enum value
    */
   private getLabelSize(labelSize: string): LabelSize {
-    return (
-      this.LABEL_SIZE_ENUM_MAP[labelSize.toLowerCase()] ?? LabelSize.TWO_BY_ONE
-    );
+    return normalizeLabelSize(labelSize);
   }
 
   /**

--- a/src/modules/zpl/zpl.service.ts
+++ b/src/modules/zpl/zpl.service.ts
@@ -2186,8 +2186,14 @@ export class ZplService {
       // recordConversion más abajo), así que tiene que dejar su ZPL guardado
       // igual que una conversión individual: si no, esas filas nunca podrían
       // reconvertirse y GET /users/history/:id/zpl devolvería siempre 410.
+      //
+      // Se lanza en paralelo con la conversión, pero la promesa se conserva: hay
+      // que esperarla antes de marcar el resultado. `updateZplDebugResult` usa
+      // update() y se traga el fallo si el doc aún no existe, de modo que un
+      // set() posterior dejaría el registro en `pending` para siempre.
+      let zplGuardado: Promise<void> = Promise.resolve();
       if (userId) {
-        this.saveZplForDebug(
+        zplGuardado = this.saveZplForDebug(
           file.content,
           job.jobId,
           userId,
@@ -2265,6 +2271,7 @@ export class ZplService {
             periodInfo,
           );
           // Update ZPL debug result
+          await zplGuardado;
           this.firestoreService
             .updateZplDebugResult(job.jobId, 'success')
             .catch((err) =>
@@ -2304,6 +2311,7 @@ export class ZplService {
             );
           }
           // Update ZPL debug result
+          await zplGuardado;
           this.firestoreService
             .updateZplDebugResult(job.jobId, 'error', error.message)
             .catch((err) =>


### PR DESCRIPTION
Cierra #90. Añade a la tabla del historial las dos acciones que pide el frontend (gustavojmarrero/zplpdf_front#220), que hasta ahora solo ofrecía "Descargar".

## Endpoints

**`DELETE /api/users/history/:id`** → `{ success: true, data: { id, deleted: true } }`

- Un registro ajeno responde **404, no 403**: el id viaja en la URL y un 403 confirmaría que existe.
- **No toca `usage`.** Si borrar filas descontara PDFs del período, cualquiera reiniciaría su cuota vaciando el historial.
- Borrado real. No revierte `daily_stats`/`global_totals`, pero sí reduce lo que leen en crudo `getTopUsers`, `getUserUsageHistory`, `getUsersWithHighUsage` y `/admin/conversions` — queda documentado en el código y en `.agent-docs/`.
- Invalida la caché de 60s del listado (la que introdujo #91): sin eso la fila borrada reaparecería en la siguiente carga.
- Antes de borrar preserva la actividad del usuario en `users.lastActivityAt`, dentro de una transacción, porque esa fila puede ser la única fecha fiable.

**`GET /api/users/history/:id/zpl`** → `{ success: true, data: { zplContent, labelSize, outputFormat } }`

- `410 ZPL_NOT_AVAILABLE` cuando el ZPL ya no está, nunca un 500.
- `labelSize` y `outputFormat` se devuelven **normalizados**: el batch los acepta como string libre (`large`, `jpg`) y así quedan en el historial, pero `POST /zpl/convert` los valida con `@IsEnum`. Devolverlos crudos hacía fallar la reconversión con un 400.
- Sin endpoint de reconversión propio: el frontend precarga el ZPL y usa `POST /zpl/convert`, que es donde ya viven los límites de plan.

**`GET /api/users/history`** añade por ítem `canReconvert: boolean` (el `id` ya lo aporta #91).

## El ZPL no estaba donde el issue suponía

`ConversionStatus.zplContent` existe en el tipo pero **no lo escribe nadie**, y un ZPL de varios MB no cabría en un documento de Firestore. La única copia vive en Cloud Storage, en `debug-zpl/{userId}/{fecha}/{jobId}.zpl`, indexada por jobId en `zpl_debug_files`.

**Y el flujo batch no la guardaba.** `processBatchFiles` creaba filas de historial sin llamar nunca a `saveZplForDebug` — su única invocación estaba en `startZplConversion`. Toda conversión batch habría dado 410, y el listado la habría anunciado como reconvertible durante 15 días. Ahora el batch guarda el ZPL de cada archivo bajo el mismo jobId con el que lo registra, y marca su resultado en vez de dejarlo en `pending`.

## Retención: 15 días

No la decide la aplicación, la impone el bucket:

```
$ gsutil lifecycle get gs://zplpdf-app-files
{"rule": [{"action": {"type": "Delete"}, "condition": {"age": 15, "matchesPrefix": ["debug-zpl/"]}}]}
```

`ZPL_RETENTION_DAYS` refleja esa regla. Firestore no tiene ninguna política TTL, así que la fila del historial sobrevive a su ZPL: se sigue viendo y descargando, solo deja de poder reconvertirse.

`canReconvert` exige las tres condiciones: que el ZPL se guardara (consulta en lote, solo los jobIds de la página), que siga dentro de la ventana —contada desde que se subió el objeto, no desde la fila, que nace al terminar la conversión— y que su tamaño conocido quepa en el body JSON del conversor.

## Efecto colateral corregido

`getProInactiveUsers` derivaba la última actividad de la fila más reciente de `conversion_history`. Con el DELETE nuevo eso deja de ser fiable: quien vaciara su historial pasaría a parecer inactivo desde su alta y `scheduleRetentionEmails` le mandaría un "te echamos de menos" al día siguiente de convertir. Ahora se toma la más reciente de las dos fuentes (`users.lastActivityAt` y el historial), consultando el historial solo para quien ya es candidato a una campaña — lo que además ahorra una query por cabeza en el resto del censo de pago.

## Verificación

- 422 tests en verde, CI incluido.
- Rebase sobre #91 (issue #89), que reescribió el mismo endpoint mientras este PR estaba abierto: `canReconvert` pasó al DTO de respuesta y se resuelve solo sobre la página ya filtrada, sin mutar los registros de la caché compartida.
- Revisado con Codex (gpt-5.6-sol) hasta agotar hallazgos accionables. Queda anotado uno no bloqueante: un ZPL patológico (casi todo barras invertidas o caracteres de control) podría superar el límite JSON al escaparse pese a pasar el filtro de tamaño; el resultado sería un 413 al reconvertir. Bajar el tope al peor caso teórico exigiría ~800 KiB y negaría la acción a ZPL válidos de varios MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)