### PR TITLE
feat: campos estructurados en upgrade pendiente de pago + search multi-campo del historial

### DIFF
--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -1,12 +1,15 @@
 // Evitar la conexión real a Stripe al cargar el módulo.
 jest.mock('stripe', () => jest.fn());
 
+import type { ArgumentsHost } from '@nestjs/common';
 import {
   BadRequestException,
   ConflictException,
   ServiceUnavailableException,
 } from '@nestjs/common';
+import type { Request, Response } from 'express';
 import { PaymentsService } from './payments.service.js';
+import { HttpExceptionFilter } from '../../common/filters/http-exception.filter.js';
 
 /**
  * Un fallo de permisos de la API key de Stripe (restricted key sin el scope
@@ -233,6 +236,35 @@ describe('PaymentsService — upgradeSubscription', () => {
 
   function claveUsada(update: jest.Mock, llamada = 0) {
     return update.mock.calls[llamada]?.[2]?.idempotencyKey;
+  }
+
+  /**
+   * Pasa una excepción por el HttpExceptionFilter global real, tal cual lo
+   * hace `main.ts` (`app.useGlobalFilters`). El filtro descarta cualquier
+   * clave suelta que no sea `data`/`errors`/`summary` (issue #97), así que
+   * comprobar solo `error.getResponse()` no basta para validar el issue #96:
+   * hay que leer lo que de verdad recibe `response.json(...)`.
+   */
+  function runThroughHttpExceptionFilter(exception: unknown) {
+    const filter = new HttpExceptionFilter();
+    const json = jest.fn();
+    const status = jest.fn().mockReturnValue({ json });
+    const response = { status, setHeader: jest.fn() } as unknown as Response;
+    const request = {
+      headers: {},
+      method: 'POST',
+      url: '/api/payments/upgrade',
+    } as unknown as Request;
+    const host = {
+      switchToHttp: () => ({
+        getResponse: () => response,
+        getRequest: () => request,
+      }),
+    } as unknown as ArgumentsHost;
+
+    filter.catch(exception, host);
+
+    return { status, body: json.mock.calls[0]?.[0] };
   }
 
   // Con precio: el upgrade falla cerrado si no puede resolver de qué plan parte,
@@ -999,6 +1031,78 @@ describe('PaymentsService — upgradeSubscription', () => {
 
     expect(error.message).toContain('has not been changed');
     expect(error.message).toContain('account settings');
+  });
+
+  /**
+   * issue #96: el frontend necesita `code`/`requiresAction`/`paymentUrl` como
+   * campos estructurados, sin dejar de poder parsear `message` (todavía lo
+   * hace en producción). Se verifica el cuerpo HTTP real DESPUÉS del
+   * HttpExceptionFilter global, no solo la excepción lanzada — es la capa
+   * donde el issue #97 documenta que estos campos se pierden si no van
+   * anidados en `data`.
+   */
+  it('#96: expone code/requiresAction/paymentUrl en el 400, sobreviviendo al HttpExceptionFilter', async () => {
+    const { service } = buildService({
+      subscription: activeSubscription,
+      updateResult: {
+        status: 'active',
+        id: 'sub_123',
+        pending_update: { expires_at: 1234567890 },
+        latest_invoice: {
+          id: 'in_123',
+          hosted_invoice_url: 'https://invoice.stripe.com/i/test',
+        },
+      },
+    });
+
+    const error = await service
+      .upgradeSubscription('uid-1', 'promax')
+      .catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(BadRequestException);
+
+    const { status, body } = runThroughHttpExceptionFilter(error);
+
+    expect(status).toHaveBeenCalledWith(400);
+    // Aditivo: el message de siempre se conserva íntegro tras el filtro.
+    expect(body.message).toContain('has not been changed');
+    expect(body.message).toContain('https://invoice.stripe.com/i/test');
+    // Campos nuevos, estructurados y estables para que el frontend los
+    // traduzca en vez de mostrar el `message` en inglés tal cual.
+    expect(body.data).toEqual({
+      code: 'UPGRADE_PAYMENT_PENDING',
+      requiresAction: true,
+      paymentUrl: 'https://invoice.stripe.com/i/test',
+    });
+  });
+
+  it('#96: paymentUrl es null (no undefined) cuando Stripe no da la factura, tras el filtro', async () => {
+    const { service } = buildService({
+      subscription: activeSubscription,
+      updateResult: {
+        status: 'active',
+        id: 'sub_123',
+        pending_update: { expires_at: 1234567890 },
+        latest_invoice: null,
+      },
+    });
+
+    const error = await service
+      .upgradeSubscription('uid-1', 'promax')
+      .catch((e: Error) => e);
+
+    const { body } = runThroughHttpExceptionFilter(error);
+
+    expect(body.data).toEqual({
+      code: 'UPGRADE_PAYMENT_PENDING',
+      requiresAction: true,
+      paymentUrl: null,
+    });
+    // JSON no distingue `undefined` de ausente, pero sí de `null`: sin el
+    // `?? null` explícito, un cliente estricto (p. ej. TS con
+    // `exactOptionalPropertyTypes`) vería la clave desaparecer en vez de ir a
+    // `null`, que es el contrato que promete el issue.
+    expect(body.data).toHaveProperty('paymentUrl', null);
   });
 
   /**

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -752,12 +752,32 @@ export class PaymentsService {
         `Plan sin cambiar. Factura: ${invoice?.id ?? 'desconocida'}.`,
     );
 
-    throw new BadRequestException(
+    const message =
       `Your plan has not been changed yet: the payment needs to be completed or authenticated. ` +
-        (payUrl
-          ? `Complete it here and the change will apply automatically: ${payUrl}`
-          : `Please check your payment method from your account settings and try again.`),
-    );
+      (payUrl
+        ? `Complete it here and the change will apply automatically: ${payUrl}`
+        : `Please check your payment method from your account settings and try again.`);
+
+    // issue #96: campos estructurados ADITIVOS junto al `message` de siempre —
+    // el frontend en producción todavía lo parsea con regex, así que no se
+    // toca. `code`/`requiresAction`/`paymentUrl` van anidados bajo `data`
+    // porque HttpExceptionFilter (común a toda la API) descarta cualquier
+    // clave suelta en el nivel superior del cuerpo de la excepción y solo
+    // copia `data` (o `errors`/`summary`) al JSON que de verdad sale por el
+    // cable — es el mismo fallo que describe el issue #97. `statusCode` y
+    // `error` replican el body que Nest arma por defecto para un
+    // BadRequestException con mensaje string, para no cambiar nada de lo que
+    // ya dependía de esa forma.
+    throw new BadRequestException({
+      statusCode: 400,
+      error: 'Bad Request',
+      message,
+      data: {
+        code: 'UPGRADE_PAYMENT_PENDING',
+        requiresAction: true,
+        paymentUrl: payUrl ?? null,
+      },
+    });
   }
 
   /**

--- a/src/modules/users/dto/get-history-query.dto.ts
+++ b/src/modules/users/dto/get-history-query.dto.ts
@@ -72,7 +72,10 @@ export class GetHistoryQueryDto {
   limit?: number = 25;
 
   @ApiPropertyOptional({
-    description: 'Free text over jobId (prefix match, case-insensitive)',
+    description:
+      'Free text, case-insensitive substring match over jobId, labelSize ' +
+      'and outputFormat; also matched against labelCount when the term is ' +
+      'numeric',
     maxLength: 100,
   })
   @IsOptional()

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -181,7 +181,9 @@ export class UsersController {
     required: false,
     type: String,
     description:
-      'Filtra por jobId (coincidencia por prefijo, case-insensitive)',
+      'Búsqueda por subcadena, case-insensitive, sobre jobId, labelSize y ' +
+      'outputFormat; también compara contra labelCount cuando el término es ' +
+      'numérico',
   })
   @ApiQuery({
     name: 'status',

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -401,7 +401,12 @@ describe('UsersService — getUserHistory', () => {
       expect(result.data.map((r: { id: string }) => r.id)).toEqual(['a']);
     });
 
-    it('busca por prefijo de jobId sin distinguir mayúsculas', async () => {
+    /**
+     * issue #94: antes era prefix-match, así que un jobId copiado a medias (el
+     * tramo final de una URL de descarga, por ejemplo) no encontraba nada. 'c'
+     * TERMINA en "abc" — con prefijo se quedaba fuera; con subcadena, no.
+     */
+    it('busca por subcadena de jobId, no solo por prefijo, sin distinguir mayúsculas', async () => {
       const { service } = buildService([
         record({ id: 'a', jobId: 'ABC-123' }),
         record({ id: 'b', jobId: 'abd-999' }),
@@ -410,7 +415,68 @@ describe('UsersService — getUserHistory', () => {
 
       const result = await service.getUserHistory('uid-1', { search: 'abc' });
 
-      expect(result.data.map((r: { id: string }) => r.id)).toEqual(['a']);
+      expect(result.data.map((r: { id: string }) => r.id)).toEqual(['a', 'c']);
+    });
+
+    /**
+     * issue #94: `search` vuelve a ser multi-campo — labelSize y outputFormat
+     * ya tenían filtros dedicados, pero el cuadro de búsqueda único debe seguir
+     * cubriéndolos sin que el usuario tenga que saber en qué desplegable vive
+     * cada cosa.
+     */
+    it('busca también por labelSize y por outputFormat', async () => {
+      const { service } = buildService([
+        record({
+          id: 'a',
+          labelSize: LabelSize.FOUR_BY_SIX,
+          outputFormat: OutputFormat.PDF,
+        }),
+        record({
+          id: 'b',
+          labelSize: LabelSize.TWO_BY_ONE,
+          outputFormat: OutputFormat.PNG,
+        }),
+      ]);
+
+      const porLabelSize = await service.getUserHistory('uid-1', {
+        search: '4x6',
+      });
+      expect(porLabelSize.data.map((r: { id: string }) => r.id)).toEqual(['a']);
+
+      const porOutputFormat = await service.getUserHistory('uid-1', {
+        search: 'png',
+      });
+      expect(porOutputFormat.data.map((r: { id: string }) => r.id)).toEqual([
+        'b',
+      ]);
+    });
+
+    /**
+     * issue #94: labelCount entra en el barrido solo cuando el término es
+     * numérico, para que "50" encuentre tanto un jobId que lo contenga como
+     * una fila con 50 o 150 etiquetas.
+     */
+    it('busca por labelCount cuando el término es numérico', async () => {
+      const { service } = buildService([
+        record({ id: 'a', labelCount: 50, jobId: 'job-a' }),
+        record({ id: 'b', labelCount: 150, jobId: 'job-b' }),
+        record({ id: 'c', labelCount: 7, jobId: 'job-c' }),
+      ]);
+
+      const result = await service.getUserHistory('uid-1', { search: '50' });
+
+      expect(result.data.map((r: { id: string }) => r.id)).toEqual(['a', 'b']);
+    });
+
+    it('un término que no aparece en ningún campo cubierto no devuelve nada', async () => {
+      const { service } = buildService(mixed);
+
+      const result = await service.getUserHistory('uid-1', {
+        search: 'no-existe-en-nada',
+      });
+
+      expect(result.data).toHaveLength(0);
+      expect(result.pagination.total).toBe(0);
     });
 
     it('total refleja los filtros, no el total absoluto', async () => {

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -655,7 +655,7 @@ export class UsersService {
       }
       if (query.labelSize && record.labelSize !== query.labelSize) return false;
 
-      if (search && !record.jobId?.toLowerCase().startsWith(search)) {
+      if (search && !this.matchesSearch(record, search)) {
         return false;
       }
 
@@ -668,6 +668,43 @@ export class UsersService {
 
       return true;
     });
+  }
+
+  /**
+   * issue #94: `search` era prefix-match solo sobre `jobId`, justo el único
+   * campo visible en el historial que el buscador no cubría — `labelSize`,
+   * `outputFormat` y `status` ya tienen filtros dedicados. Pasa a subcadena
+   * (no prefijo: un usuario que pega el tramo final de un jobId copiado de una
+   * URL de descarga antes no encontraba nada) y a multi-campo, para que un
+   * único cuadro de búsqueda vuelva a cubrir lo que el filtrado en cliente
+   * ofrecía antes de que el historial se paginara en servidor.
+   *
+   * Sigue siendo en memoria sobre el bloque ya escaneado (`getScannedHistory`),
+   * así que no exige índices nuevos en Firestore.
+   *
+   * `search` ya llega en minúsculas (recortado en `filterHistory`).
+   */
+  private matchesSearch(
+    record: ConversionHistoryRecord,
+    search: string,
+  ): boolean {
+    if (record.jobId?.toLowerCase().includes(search)) return true;
+    if (record.labelSize?.toLowerCase().includes(search)) return true;
+    if (record.outputFormat?.toLowerCase().includes(search)) return true;
+
+    // labelCount es numérico: compararlo como subcadena de texto contra un
+    // término no numérico ("png", "4x6"...) no podría dar falso positivo —
+    // ninguna cifra contiene letras—, pero limitar la comparación a términos
+    // numéricos deja explícito que este campo solo entra en juego cuando el
+    // usuario busca por cantidad de etiquetas.
+    if (
+      /^\d+$/.test(search) &&
+      String(record.labelCount ?? '').includes(search)
+    ) {
+      return true;
+    }
+
+    return false;
   }
 
   private sortHistory(


### PR DESCRIPTION
## Qué resuelve

### #96 — campos estructurados en el 400 de upgrade pendiente de pago (`payments`)

`throwPendingPaymentError` (cuando un upgrade queda en `pending_update` por
3DS/SCA) solo devolvía un `message` en inglés. El frontend lo parseaba con dos
regex frágiles (URL de pago, y reconocer el caso frente a cualquier otro 400
del endpoint); si el texto cambiaba, dejaba de reconocerlo en silencio y volvía
a aconsejar reintentar — justo lo que anula la factura abierta del cliente.

Se añaden, **aditivos** junto al `message` de siempre (que se conserva
intacto, porque el frontend en producción todavía lo parsea):
- `code`: `"UPGRADE_PAYMENT_PENDING"`
- `requiresAction`: `true`
- `paymentUrl`: `string | null` (`hosted_invoice_url` de `latest_invoice`, o `null`)

**Confirmación de que sobreviven al `HttpExceptionFilter` global (después del
filtro, no solo en la excepción lanzada):** el filtro descarta cualquier clave
suelta en el nivel superior del cuerpo de la excepción y solo copia `data` (o
`errors`/`summary`) al JSON que de verdad sale por el cable — es el mismo
fallo que describe el issue #97. Por eso `code`/`requiresAction`/`paymentUrl`
van anidados en `data`. El test nuevo instancia el `HttpExceptionFilter` real
con un `ArgumentsHost` simulado, llama a `.catch()` y lee lo que se pasó a
`response.json(...)`:

```json
{
  "success": false,
  "error": "Bad Request",
  "message": "Your plan has not been changed yet: ... https://invoice.stripe.com/i/test",
  "data": {
    "code": "UPGRADE_PAYMENT_PENDING",
    "requiresAction": true,
    "paymentUrl": "https://invoice.stripe.com/i/test"
  },
  "requestId": "req_..."
}
```

### #94 — ampliar el `search` del historial más allá del prefijo de jobId (`users`)

`search` en `GET /users/history` era *prefix-match* solo sobre `jobId`: el
único campo que el buscador anterior (en cliente) no cubría, mientras que
`labelSize`, `outputFormat` y `status` ya tienen filtros dedicados.

Semántica nueva de `filterHistory` (mismo parámetro `search`, sin alias ni
parámetros nuevos):
- Pasa de prefijo a **subcadena**, case-insensitive — un jobId pegado a medias
  (p. ej. el tramo final copiado de una URL de descarga) ahora sí se encuentra.
- Amplía el barrido a **`labelSize`** y **`outputFormat`**.
- Compara también contra **`labelCount`**, pero solo cuando el término es
  numérico (`"50"` encuentra tanto un jobId que lo contenga como una fila con
  50 o 150 etiquetas).

Sigue siendo en memoria sobre el bloque ya escaneado (`getScannedHistory`), así
que no requiere índices nuevos en Firestore. Se documenta la nueva semántica en
el `@ApiQuery('search')` del controller y en el `@ApiPropertyOptional` del DTO,
que hoy solo mencionaban `jobId`.

## Gates

- `npm run typecheck` — limpio.
- `npm test` — 427/427 (16/16 suites).
- `npm run lint:ci` — 0 errores, 0 warnings.

Closes #96
Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)
