### PR TITLE
feat(zpl): soportar etiquetas de 50x80mm (Phomemo M110) y arreglar timestamp truncado

### DIFF
--- a/src/modules/zpl/dto/batch.dto.ts
+++ b/src/modules/zpl/dto/batch.dto.ts
@@ -39,7 +39,15 @@ export class BatchConvertDto {
   @Type(() => BatchFileDto)
   files: BatchFileDto[];
 
-  @ApiProperty({ description: 'Label size (e.g., 4x6, 4x4)' })
+  // NOTA: este DTO documenta la forma del endpoint en Swagger, pero
+  // `POST /zpl/batch` no lo usa como `@Body()` (recibe multipart/form-data vía
+  // `@UploadedFiles()` + un tipo ad-hoc en el controller, no esta clase), así
+  // que `class-validator` nunca corre sobre este campo. La validación real de
+  // labelSize (incluida contra valores no reconocidos, issue #101) vive en
+  // `ZplService.startBatchConversion`, que sigue aceptando string libre a
+  // propósito: el batch históricamente guarda el tamaño sin normalizar
+  // (`large`, `small`, …) en conversion_history.
+  @ApiProperty({ description: 'Label size (e.g., 4x6, 50x80mm)' })
   @IsString()
   @IsNotEmpty()
   labelSize: string;

--- a/src/modules/zpl/dto/convert-zpl.dto.ts
+++ b/src/modules/zpl/dto/convert-zpl.dto.ts
@@ -15,7 +15,9 @@ export class ConvertZplDto {
   zplContent?: string;
 
   @ApiProperty({
-    description: 'Tamaño de la etiqueta (2x1, 2x4, 4x2 o 4x6 pulgadas)',
+    description:
+      'Tamaño de la etiqueta: 2x1, 2x4, 4x2, 4x6 (impresoras de escritorio) o ' +
+      '50x80mm (impresoras portátiles tipo Phomemo M110)',
     example: LabelSize.TWO_BY_ONE,
     enum: LabelSize,
     default: LabelSize.TWO_BY_ONE,

--- a/src/modules/zpl/enums/label-size.enum.spec.ts
+++ b/src/modules/zpl/enums/label-size.enum.spec.ts
@@ -4,6 +4,7 @@ import {
   LABEL_SIZE_DIMENSIONS,
   isKnownLabelSize,
   normalizeLabelSize,
+  resolveLabelSizeAlias,
 } from './label-size.enum.js';
 
 /**
@@ -67,6 +68,22 @@ describe('label-size.enum — isKnownLabelSize', () => {
       expect(isKnownLabelSize(value)).toBe(false);
     },
   );
+
+  /**
+   * Regresión (review de Codex, PR #104): `constructor` y `__proto__` ya
+   * están en minúsculas, así que `.toLowerCase()` no los cambia, y un lookup
+   * ingenuo (`LABEL_SIZE_ALIASES[key]`) encuentra la propiedad HEREDADA de
+   * Object.prototype en vez de `undefined`. Antes de este fix, ambos valores
+   * "colaban" como tamaño reconocido y `normalizeLabelSize` devolvía, en
+   * tiempo de ejecución, el constructor `Object` en vez de un `LabelSize`
+   * real — la URL de Labelary terminaba con dimensiones `undefined`.
+   */
+  it.each(['constructor', 'CONSTRUCTOR', '__proto__'])(
+    'no confunde la propiedad heredada "%s" con un tamaño válido',
+    (value) => {
+      expect(isKnownLabelSize(value)).toBe(false);
+    },
+  );
 });
 
 describe('label-size.enum — normalizeLabelSize', () => {
@@ -95,10 +112,33 @@ describe('label-size.enum — normalizeLabelSize', () => {
     expect(normalizeLabelSize('4x4')).toBe(LabelSize.TWO_BY_ONE);
     expect(normalizeLabelSize(undefined)).toBe(LabelSize.TWO_BY_ONE);
   });
+
+  // Misma regresión que en isKnownLabelSize: sin el guard de propiedad propia,
+  // esto devolvía en runtime el constructor `Object`, no un `LabelSize`.
+  it.each(['constructor', '__proto__'])(
+    'cae en 2x1 para la propiedad heredada "%s" en vez de devolverla',
+    (value) => {
+      expect(normalizeLabelSize(value)).toBe(LabelSize.TWO_BY_ONE);
+    },
+  );
 });
 
 describe('label-size.enum — LABEL_SIZE_ALIASES', () => {
   it('incluye el alias del tamaño nuevo, para no mantener un segundo mapa duplicado en zpl.service.ts', () => {
     expect(LABEL_SIZE_ALIASES['50x80mm']).toBe(LabelSize.FIFTY_BY_EIGHTY_MM);
   });
+});
+
+describe('label-size.enum — resolveLabelSizeAlias (lookup seguro, sin herencia de Object.prototype)', () => {
+  it('resuelve alias válidos igual que un acceso directo', () => {
+    expect(resolveLabelSizeAlias('4x6')).toBe(LabelSize.FOUR_BY_SIX);
+    expect(resolveLabelSizeAlias('large')).toBe(LabelSize.FOUR_BY_SIX);
+  });
+
+  it.each(['constructor', '__proto__', '4x4', undefined])(
+    'devuelve undefined (no una propiedad heredada) para "%s"',
+    (value) => {
+      expect(resolveLabelSizeAlias(value)).toBeUndefined();
+    },
+  );
 });

--- a/src/modules/zpl/enums/label-size.enum.spec.ts
+++ b/src/modules/zpl/enums/label-size.enum.spec.ts
@@ -1,0 +1,104 @@
+import {
+  LabelSize,
+  LABEL_SIZE_ALIASES,
+  LABEL_SIZE_DIMENSIONS,
+  isKnownLabelSize,
+  normalizeLabelSize,
+} from './label-size.enum.js';
+
+/**
+ * issue #101 (50x80mm, Phomemo M110): el id que viaja por la API pública
+ * (`LabelSize`) y la dimensión que entiende Labelary son cosas separadas a
+ * propósito (opción B). Este mapeo es el contrato con Labelary: si alguien lo
+ * toca sin querer, el PDF sale con el tamaño equivocado sin que ningún tipo lo
+ * detecte (la clave es un string).
+ */
+describe('label-size.enum — LABEL_SIZE_DIMENSIONS', () => {
+  it('fija el mapeo completo id -> dimensión de Labelary', () => {
+    expect(LABEL_SIZE_DIMENSIONS).toEqual({
+      [LabelSize.TWO_BY_ONE]: '2x1',
+      [LabelSize.TWO_BY_FOUR]: '2x4',
+      [LabelSize.FOUR_BY_TWO]: '4x2',
+      [LabelSize.FOUR_BY_SIX]: '4x6',
+      [LabelSize.FIFTY_BY_EIGHTY_MM]: '1.9705x3.1528',
+    });
+  });
+
+  it('usa 1.9705x3.1528 para 50x80mm: 400x640 dots exactos a 8dpmm, no la conversión ingenua mm/25.4 (1.9685x3.1496)', () => {
+    expect(LABEL_SIZE_DIMENSIONS[LabelSize.FIFTY_BY_EIGHTY_MM]).toBe(
+      '1.9705x3.1528',
+    );
+  });
+
+  it('para los cuatro tamaños de catálogo original, el id y la dimensión coinciden', () => {
+    expect(LABEL_SIZE_DIMENSIONS[LabelSize.TWO_BY_ONE]).toBe(
+      LabelSize.TWO_BY_ONE,
+    );
+    expect(LABEL_SIZE_DIMENSIONS[LabelSize.TWO_BY_FOUR]).toBe(
+      LabelSize.TWO_BY_FOUR,
+    );
+    expect(LABEL_SIZE_DIMENSIONS[LabelSize.FOUR_BY_TWO]).toBe(
+      LabelSize.FOUR_BY_TWO,
+    );
+    expect(LABEL_SIZE_DIMENSIONS[LabelSize.FOUR_BY_SIX]).toBe(
+      LabelSize.FOUR_BY_SIX,
+    );
+  });
+});
+
+describe('label-size.enum — isKnownLabelSize', () => {
+  it.each([
+    '2x1',
+    '2x4',
+    '4x2',
+    '4x6',
+    '50x80mm',
+    'small',
+    'large',
+    'SMALL',
+    '50X80MM',
+  ])('reconoce "%s" como tamaño o alias válido', (value) => {
+    expect(isKnownLabelSize(value)).toBe(true);
+  });
+
+  it.each([undefined, '', '4x4', 'sdfsdf', 'toString'])(
+    'no reconoce "%s" (protege el batch de valores no soportados)',
+    (value) => {
+      expect(isKnownLabelSize(value)).toBe(false);
+    },
+  );
+});
+
+describe('label-size.enum — normalizeLabelSize', () => {
+  it('resuelve el nuevo alias 50x80mm al enum correspondiente', () => {
+    expect(normalizeLabelSize('50x80mm')).toBe(LabelSize.FIFTY_BY_EIGHTY_MM);
+  });
+
+  it('sigue resolviendo los alias existentes sin romper la API pública ni el historial', () => {
+    expect(normalizeLabelSize('small')).toBe(LabelSize.TWO_BY_ONE);
+    expect(normalizeLabelSize('2x1')).toBe(LabelSize.TWO_BY_ONE);
+    expect(normalizeLabelSize('2x4')).toBe(LabelSize.TWO_BY_FOUR);
+    expect(normalizeLabelSize('4x2')).toBe(LabelSize.FOUR_BY_TWO);
+    expect(normalizeLabelSize('large')).toBe(LabelSize.FOUR_BY_SIX);
+    expect(normalizeLabelSize('4x6')).toBe(LabelSize.FOUR_BY_SIX);
+  });
+
+  it('es case-insensitive', () => {
+    expect(normalizeLabelSize('50X80MM')).toBe(LabelSize.FIFTY_BY_EIGHTY_MM);
+    expect(normalizeLabelSize('LARGE')).toBe(LabelSize.FOUR_BY_SIX);
+  });
+
+  // Contrato bloqueado también por users.service.spec.ts (getHistoryZpl): el
+  // fallback a 2x1 para valores no reconocidos no puede cambiar de valor de
+  // retorno, solo dejar de ser silencioso (se registra con logger.warn).
+  it('cae en 2x1 para un valor no reconocido, sin lanzar', () => {
+    expect(normalizeLabelSize('4x4')).toBe(LabelSize.TWO_BY_ONE);
+    expect(normalizeLabelSize(undefined)).toBe(LabelSize.TWO_BY_ONE);
+  });
+});
+
+describe('label-size.enum — LABEL_SIZE_ALIASES', () => {
+  it('incluye el alias del tamaño nuevo, para no mantener un segundo mapa duplicado en zpl.service.ts', () => {
+    expect(LABEL_SIZE_ALIASES['50x80mm']).toBe(LabelSize.FIFTY_BY_EIGHTY_MM);
+  });
+});

--- a/src/modules/zpl/enums/label-size.enum.ts
+++ b/src/modules/zpl/enums/label-size.enum.ts
@@ -1,22 +1,81 @@
+import { Logger } from '@nestjs/common';
+
+const logger = new Logger('LabelSize');
+
 export enum LabelSize {
   TWO_BY_ONE = '2x1',
   TWO_BY_FOUR = '2x4',
   FOUR_BY_TWO = '4x2',
   FOUR_BY_SIX = '4x6',
+  // Rollo de catálogo de las impresoras térmicas portátiles Phomemo M110 (y
+  // compatibles M120/M150/M200/M220/M221). El id es legible a propósito
+  // (issue #101, opción B): es lo que viaja por la API pública y se guarda en
+  // conversion_history. La dimensión real que entiende Labelary vive en
+  // `LABEL_SIZE_DIMENSIONS`, no aquí.
+  FIFTY_BY_EIGHTY_MM = '50x80mm',
 }
 
 /**
  * Alias aceptados al pedir una conversión. `small` y `large` vienen de la API
  * antigua y siguen admitiéndose.
+ *
+ * Exportado (a diferencia del resto de tablas internas) porque `zpl.service.ts`
+ * lo reutiliza para el segmento de tamaño del nombre de descarga: antes existía
+ * un segundo mapa (`LABEL_SIZE_NORMALIZE_MAP`) con las mismas entradas que este,
+ * y mantenerlos en sincronía a mano es exactamente el tipo de duplicación que
+ * se olvida actualizar al añadir un tamaño nuevo.
  */
-const LABEL_SIZE_ALIASES: Record<string, LabelSize> = {
+export const LABEL_SIZE_ALIASES: Record<string, LabelSize> = {
   small: LabelSize.TWO_BY_ONE,
   '2x1': LabelSize.TWO_BY_ONE,
   '2x4': LabelSize.TWO_BY_FOUR,
   '4x2': LabelSize.FOUR_BY_TWO,
   large: LabelSize.FOUR_BY_SIX,
   '4x6': LabelSize.FOUR_BY_SIX,
+  '50x80mm': LabelSize.FIFTY_BY_EIGHTY_MM,
 };
+
+/**
+ * Traduce cada id de `LabelSize` al fragmento de dimensiones que entiende la
+ * URL de Labelary (`.../printers/8dpmm/labels/{dimensiones}/...`).
+ *
+ * Separado del enum a propósito (issue #101, opción B): antes el valor del
+ * enum SE INTERPOLABA tal cual en la URL, así que el id público y la
+ * dimensión eran la misma cosa. Eso funcionaba mientras todos los tamaños
+ * fueran pulgadas exactas, pero deja de servir en cuanto el id es legible
+ * (`50x80mm`) y la dimensión real que hay que mandarle a Labelary es decimal.
+ *
+ * Para los cuatro tamaños de catálogo original, id y dimensión coinciden (ya
+ * eran pulgadas legibles). Para el resto del catálogo métrico que se vaya
+ * añadiendo, no tienen por qué coincidir nunca más.
+ *
+ * El valor de 50×80mm es `1.9705x3.1528`, no la conversión ingenua
+ * `50/25.4 x 80/25.4` (`1.9685x3.1496`): Labelary trunca a dots usando 203 dpi
+ * (8 dots/mm), y solo `1.9705x3.1528` cae exacto en la rejilla 400×640 dots,
+ * que es sobre la que está diseñado el ZPL de estas etiquetas. La conversión
+ * ingenua pierde el último dot de cada eje y recorta cualquier `^FO` pegado al
+ * borde derecho o inferior. Medido contra la API real de Labelary — ver
+ * issue #101.
+ */
+export const LABEL_SIZE_DIMENSIONS: Record<LabelSize, string> = {
+  [LabelSize.TWO_BY_ONE]: '2x1',
+  [LabelSize.TWO_BY_FOUR]: '2x4',
+  [LabelSize.FOUR_BY_TWO]: '4x2',
+  [LabelSize.FOUR_BY_SIX]: '4x6',
+  [LabelSize.FIFTY_BY_EIGHTY_MM]: '1.9705x3.1528',
+};
+
+/**
+ * true si el valor (case-insensitive) es un tamaño o alias reconocido, es
+ * decir si `normalizeLabelSize` lo resolvería sin caer en el fallback.
+ *
+ * Pensado para validar ANTES de aceptar una entrada (p. ej. el batch, que no
+ * tiene `@IsEnum` porque históricamente acepta alias libres). El chequeo en sí
+ * no registra nada: quien lo llama decide cómo rechazar el valor inválido.
+ */
+export function isKnownLabelSize(labelSize: string | undefined): boolean {
+  return LABEL_SIZE_ALIASES[labelSize?.toLowerCase() ?? ''] !== undefined;
+}
 
 /**
  * Traduce cualquier tamaño de entrada al valor del enum con el que se convierte
@@ -27,9 +86,22 @@ const LABEL_SIZE_ALIASES: Record<string, LabelSize> = {
  * con `@IsEnum(LabelSize)`. Devolver el valor crudo al reconvertir haría que el
  * frontend recibiera un 400 con el mismo tamaño con el que la conversión
  * original funcionó.
+ *
+ * El fallback a 2x1 se queda (no lanza): romperlo dejaría sin reconvertir
+ * cualquier registro histórico con un tamaño ya no reconocido. Pero deja de
+ * ser silencioso — se registra en el logger para poder detectar en producción
+ * un frontend desplegado antes que el backend (issue #101). Quien pueda
+ * permitirse rechazar la entrada en vez de absorberla (p. ej. el batch, antes
+ * de aceptar la conversión) debe validar con `isKnownLabelSize` primero en
+ * lugar de confiar en este fallback.
  */
 export function normalizeLabelSize(labelSize: string | undefined): LabelSize {
-  return (
-    LABEL_SIZE_ALIASES[labelSize?.toLowerCase() ?? ''] ?? LabelSize.TWO_BY_ONE
-  );
+  const resolved = LABEL_SIZE_ALIASES[labelSize?.toLowerCase() ?? ''];
+  if (resolved === undefined) {
+    logger.warn(
+      `Tamaño de etiqueta no reconocido ("${labelSize}"), usando 2x1 por defecto`,
+    );
+    return LabelSize.TWO_BY_ONE;
+  }
+  return resolved;
 }

--- a/src/modules/zpl/enums/label-size.enum.ts
+++ b/src/modules/zpl/enums/label-size.enum.ts
@@ -66,6 +66,30 @@ export const LABEL_SIZE_DIMENSIONS: Record<LabelSize, string> = {
 };
 
 /**
+ * Lookup seguro en `LABEL_SIZE_ALIASES`. `constructor` y `__proto__` ya están
+ * en minúsculas, así que `.toLowerCase()` no los cambia, y un acceso directo
+ * por corchete (`LABEL_SIZE_ALIASES['constructor']`) encuentra la propiedad
+ * HEREDADA de `Object.prototype` en vez de `undefined` — cualquiera de los
+ * dos "cuela" como tamaño reconocido y `normalizeLabelSize` acabaría
+ * devolviendo, en tiempo de ejecución, el constructor `Object` en vez de un
+ * `LabelSize`. `Object.prototype.hasOwnProperty.call` descarta esa herencia
+ * (no se usa `Object.hasOwn`: el `target` de tsconfig es ES2021, anterior a
+ * su tipado). Hallazgo del review de Codex en el PR #104.
+ *
+ * Exportado para que cualquier otro lookup directo sobre `LABEL_SIZE_ALIASES`
+ * (p. ej. el segmento de tamaño del nombre de descarga en `zpl.service.ts`)
+ * pase por el mismo guard en vez de reintroducir el bug con un acceso crudo.
+ */
+export function resolveLabelSizeAlias(
+  labelSize: string | undefined,
+): LabelSize | undefined {
+  const key = labelSize?.toLowerCase() ?? '';
+  return Object.prototype.hasOwnProperty.call(LABEL_SIZE_ALIASES, key)
+    ? LABEL_SIZE_ALIASES[key]
+    : undefined;
+}
+
+/**
  * true si el valor (case-insensitive) es un tamaño o alias reconocido, es
  * decir si `normalizeLabelSize` lo resolvería sin caer en el fallback.
  *
@@ -74,7 +98,7 @@ export const LABEL_SIZE_DIMENSIONS: Record<LabelSize, string> = {
  * no registra nada: quien lo llama decide cómo rechazar el valor inválido.
  */
 export function isKnownLabelSize(labelSize: string | undefined): boolean {
-  return LABEL_SIZE_ALIASES[labelSize?.toLowerCase() ?? ''] !== undefined;
+  return resolveLabelSizeAlias(labelSize) !== undefined;
 }
 
 /**
@@ -96,7 +120,7 @@ export function isKnownLabelSize(labelSize: string | undefined): boolean {
  * lugar de confiar en este fallback.
  */
 export function normalizeLabelSize(labelSize: string | undefined): LabelSize {
-  const resolved = LABEL_SIZE_ALIASES[labelSize?.toLowerCase() ?? ''];
+  const resolved = resolveLabelSizeAlias(labelSize);
   if (resolved === undefined) {
     logger.warn(
       `Tamaño de etiqueta no reconocido ("${labelSize}"), usando 2x1 por defecto`,

--- a/src/modules/zpl/services/labelary-queue.service.spec.ts
+++ b/src/modules/zpl/services/labelary-queue.service.spec.ts
@@ -1,0 +1,80 @@
+jest.mock('axios');
+
+import axios from 'axios';
+import { LabelaryQueueService } from './labelary-queue.service.js';
+import { LabelSize } from '../enums/label-size.enum.js';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+/**
+ * issue #101 (50x80mm, Phomemo M110): el id de `LabelSize` que circula por la
+ * app (`50x80mm`) no es lo que entiende la URL de Labelary. Antes el enum SE
+ * INTERPOLABA tal cual porque id y dimensión eran la misma cosa; con la
+ * opción B dejan de serlo. Este spec fija que la llamada HTTP real sale con
+ * la dimensión traducida, no con el id — es la regresión más directa si
+ * alguien revierte alguno de los dos puntos de interpolación.
+ */
+describe('LabelaryQueueService — traducción de LabelSize a dimensiones de Labelary', () => {
+  function buildService(): LabelaryQueueService {
+    const labelaryAnalyticsService: any = {
+      trackSuccess: jest.fn().mockResolvedValue(undefined),
+      trackRateLimit: jest.fn().mockResolvedValue(undefined),
+      trackError: jest.fn().mockResolvedValue(undefined),
+    };
+    return new LabelaryQueueService(labelaryAnalyticsService);
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('enqueuePngDirect (preview)', () => {
+    it('usa la dimensión decimal para 50x80mm, no el id legible', async () => {
+      mockedAxios.post.mockResolvedValue({ data: Buffer.from('png') });
+      const service = buildService();
+
+      await service.enqueuePngDirect('^XA^XZ', LabelSize.FIFTY_BY_EIGHTY_MM);
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'http://api.labelary.com/v1/printers/8dpmm/labels/1.9705x3.1528/0/',
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('sigue mandando la dimensión de los tamaños de catálogo original sin cambios', async () => {
+      mockedAxios.post.mockResolvedValue({ data: Buffer.from('png') });
+      const service = buildService();
+
+      await service.enqueuePngDirect('^XA^XZ', LabelSize.FOUR_BY_SIX);
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'http://api.labelary.com/v1/printers/8dpmm/labels/4x6/0/',
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('enqueue (conversión PDF)', () => {
+    it('usa la dimensión decimal para 50x80mm, no el id legible', async () => {
+      mockedAxios.post.mockResolvedValue({ data: Buffer.from('pdf') });
+      const service = buildService();
+
+      await service.enqueue(
+        'job-1',
+        'user-1',
+        'free',
+        '^XA^XZ',
+        LabelSize.FIFTY_BY_EIGHTY_MM,
+        1,
+      );
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'http://api.labelary.com/v1/printers/8dpmm/labels/1.9705x3.1528',
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/src/modules/zpl/services/labelary-queue.service.ts
+++ b/src/modules/zpl/services/labelary-queue.service.ts
@@ -10,7 +10,7 @@ import {
   QUEUE_CONFIG,
 } from '../interfaces/queue.interface.js';
 import { LabelaryAnalyticsService } from './labelary-analytics.service.js';
-import { LabelSize } from '../enums/label-size.enum.js';
+import { LabelSize, LABEL_SIZE_DIMENSIONS } from '../enums/label-size.enum.js';
 import { PLAN_FEATURES } from '../../../common/interfaces/user.interface.js';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -315,7 +315,10 @@ export class LabelaryQueueService {
    * Llamada HTTP a Labelary API
    */
   private async callLabelaryInternal(item: QueueItem): Promise<Buffer> {
-    const url = `http://api.labelary.com/v1/printers/8dpmm/labels/${item.labelSize}`;
+    // El id de LabelSize (p. ej. `50x80mm`) no es lo que Labelary entiende en
+    // la URL: hay que traducirlo a sus dimensiones (issue #101, opción B).
+    const dimensions = LABEL_SIZE_DIMENSIONS[item.labelSize];
+    const url = `http://api.labelary.com/v1/printers/8dpmm/labels/${dimensions}`;
 
     const response = await axios.post(url, item.zplBatch, {
       headers: {
@@ -433,7 +436,8 @@ export class LabelaryQueueService {
       // Respetar rate limit global
       await this.waitForRateLimit();
 
-      const url = `http://api.labelary.com/v1/printers/8dpmm/labels/${labelSize}/0/`;
+      const dimensions = LABEL_SIZE_DIMENSIONS[labelSize];
+      const url = `http://api.labelary.com/v1/printers/8dpmm/labels/${dimensions}/0/`;
 
       const response = await axios.post(url, zplContent, {
         headers: {

--- a/src/modules/zpl/zpl.controller.ts
+++ b/src/modules/zpl/zpl.controller.ts
@@ -91,9 +91,12 @@ export class ZplController {
             LabelSize.TWO_BY_FOUR,
             LabelSize.FOUR_BY_TWO,
             LabelSize.FOUR_BY_SIX,
+            LabelSize.FIFTY_BY_EIGHTY_MM,
           ],
           default: LabelSize.TWO_BY_ONE,
-          description: 'Tamano de la etiqueta (2x1, 2x4, 4x2 o 4x6 pulgadas)',
+          description:
+            'Tamano de la etiqueta: 2x1, 2x4, 4x2, 4x6 (impresoras de escritorio) ' +
+            'o 50x80mm (impresoras portatiles tipo Phomemo M110)',
         },
         language: {
           type: 'string',
@@ -524,9 +527,12 @@ export class ZplController {
             LabelSize.TWO_BY_FOUR,
             LabelSize.FOUR_BY_TWO,
             LabelSize.FOUR_BY_SIX,
+            LabelSize.FIFTY_BY_EIGHTY_MM,
           ],
           default: LabelSize.TWO_BY_ONE,
-          description: 'Tamano de la etiqueta (2x1, 2x4, 4x2 o 4x6 pulgadas)',
+          description:
+            'Tamano de la etiqueta: 2x1, 2x4, 4x2, 4x6 (impresoras de escritorio) ' +
+            'o 50x80mm (impresoras portatiles tipo Phomemo M110)',
         },
       },
     },
@@ -780,7 +786,8 @@ export class ZplController {
         labelSize: {
           type: 'string',
           example: '4x6',
-          description: 'Tamano de etiqueta',
+          description:
+            'Tamano de etiqueta: 2x1, 2x4, 4x2, 4x6 o 50x80mm (Phomemo M110)',
         },
         outputFormat: {
           type: 'string',

--- a/src/modules/zpl/zpl.service.spec.ts
+++ b/src/modules/zpl/zpl.service.spec.ts
@@ -279,6 +279,32 @@ describe('ZplService — validación de labelSize en el batch (issue #101)', () 
     );
   });
 
+  /**
+   * Regresión (review de Codex, PR #104): `constructor` ya está en minúsculas,
+   * así que un lookup ingenuo sobre el mapa de alias encuentra la propiedad
+   * heredada de Object.prototype en vez de `undefined` y el gate lo deja pasar
+   * como si fuera un tamaño válido. Cubre el camino completo, no solo el
+   * helper del enum.
+   */
+  it('rechaza "constructor" en vez de dejarlo colar como propiedad heredada del mapa de alias', async () => {
+    const saveErrorLog = jest
+      .fn()
+      .mockResolvedValue({ id: 'x', errorId: 'ERR-9' });
+    const service = buildBatchService(saveErrorLog);
+
+    await expect(
+      service.startBatchConversion(
+        'uid-b',
+        [{ id: 'f1', fileName: 'a.zpl', content: SIMPLE_ZPL }],
+        'constructor',
+      ),
+    ).rejects.toThrow();
+
+    expect(saveErrorLog).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'INVALID_LABEL_SIZE' }),
+    );
+  });
+
   it('acepta 50x80mm: pasa el gate de labelSize y llega hasta guardar el batch', async () => {
     const saveErrorLog = jest
       .fn()

--- a/src/modules/zpl/zpl.service.spec.ts
+++ b/src/modules/zpl/zpl.service.spec.ts
@@ -138,6 +138,187 @@ describe('ZplService — bloques de configuración sin contenido', () => {
     it('mapea 4x6 al enum correcto', () => {
       expect((service as any).getLabelSize('4x6')).toBe(LabelSize.FOUR_BY_SIX);
     });
+
+    it('mapea 50x80mm (Phomemo M110) al enum correcto (issue #101)', () => {
+      expect((service as any).getLabelSize('50x80mm')).toBe(
+        LabelSize.FIFTY_BY_EIGHTY_MM,
+      );
+    });
+  });
+});
+
+/**
+ * issue #100: el nombre de descarga para free/lite (`zplpdf_size_timestamp`)
+ * salía con la hora cortada a la mitad y en UTC. `generateFilenames` arma
+ * ahora el timestamp explícitamente en GMT-6 en vez de recortar un ISO a
+ * ciegas.
+ */
+describe('ZplService — generateFilenames (issue #100: timestamp truncado)', () => {
+  function buildService(): ZplService {
+    const configService: any = { get: jest.fn(() => 'test-bucket') };
+    return new ZplService(configService, {} as any, {} as any, {}, {} as any);
+  }
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('genera fecha y hora completas en GMT-6 (minutos incluidos), no un ISO recortado', () => {
+    // 21:42:16.123Z UTC = 15:42 GMT-6 (Mérida)
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-19T21:42:16.123Z'));
+    const service = buildService();
+
+    const { downloadFilename } = (service as any).generateFilenames(
+      'job-1',
+      '4x2',
+    );
+
+    expect(downloadFilename).toBe('zplpdf_4x2_20260819T1542.pdf');
+  });
+
+  it('dos conversiones separadas por menos de 10 minutos producen nombres distintos', () => {
+    const service = buildService();
+
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-19T21:40:00.000Z'));
+    const first = (service as any).generateFilenames('job-1', '4x2');
+
+    jest.setSystemTime(new Date('2026-08-19T21:45:00.000Z'));
+    const second = (service as any).generateFilenames('job-2', '4x2');
+
+    expect(first.downloadFilename).not.toBe(second.downloadFilename);
+  });
+
+  it('usa GMT-6 y no UTC: una conversión nocturna en México no salta al día siguiente', () => {
+    // 19:00 hora local (Mérida) = 01:00 UTC del día siguiente
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-20T01:00:00.000Z'));
+    const service = buildService();
+
+    const { downloadFilename } = (service as any).generateFilenames(
+      'job-1',
+      '4x2',
+    );
+
+    expect(downloadFilename).toBe('zplpdf_4x2_20260819T1900.pdf');
+  });
+
+  it('sigue traduciendo los alias (large -> 4x6) igual que antes de unificar los mapas de tamaño', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-19T21:42:00.000Z'));
+    const service = buildService();
+
+    const { downloadFilename } = (service as any).generateFilenames(
+      'job-1',
+      'large',
+    );
+
+    expect(downloadFilename).toBe('zplpdf_4x6_20260819T1542.pdf');
+  });
+
+  it('el tamaño nuevo (50x80mm) sale legible en el nombre de descarga', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-19T21:42:00.000Z'));
+    const service = buildService();
+
+    const { downloadFilename } = (service as any).generateFilenames(
+      'job-1',
+      '50x80mm',
+    );
+
+    expect(downloadFilename).toBe('zplpdf_50x80mm_20260819T1542.pdf');
+  });
+});
+
+/**
+ * issue #101, riesgo 2: el batch no tiene `@IsEnum` (acepta string libre a
+ * propósito para no romper el historial), así que un tamaño no reconocido
+ * debe rechazarse explícitamente en vez de convertirse en 2x1 en silencio.
+ */
+describe('ZplService — validación de labelSize en el batch (issue #101)', () => {
+  const SIMPLE_ZPL = '^XA^FO50,50^A0,30^FDtest^FS^XZ';
+
+  function buildBatchService(saveErrorLog: jest.Mock) {
+    const configService: any = { get: jest.fn(() => 'test-bucket') };
+    const usersService: any = {
+      getUserById: jest.fn().mockResolvedValue({
+        id: 'uid-b',
+        email: 'batch@ejemplo.com',
+        plan: 'pro',
+      }),
+      getEffectivePlan: jest.fn().mockReturnValue('pro'),
+      checkCanConvert: jest
+        .fn()
+        .mockResolvedValue({ allowed: true, userEmail: 'batch@ejemplo.com' }),
+    };
+    return new ZplService(
+      configService,
+      { saveErrorLog } as any,
+      usersService,
+      {} as any,
+      {} as any,
+    );
+  }
+
+  it('rechaza un tamaño no reconocido con INVALID_LABEL_SIZE en vez de convertirlo en 2x1', async () => {
+    const saveErrorLog = jest
+      .fn()
+      .mockResolvedValue({ id: 'x', errorId: 'ERR-7' });
+    const service = buildBatchService(saveErrorLog);
+
+    await expect(
+      service.startBatchConversion(
+        'uid-b',
+        [{ id: 'f1', fileName: 'a.zpl', content: SIMPLE_ZPL }],
+        'tamano-inventado',
+      ),
+    ).rejects.toThrow();
+
+    expect(saveErrorLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'INVALID_LABEL_SIZE',
+        userId: 'uid-b',
+        userEmail: 'batch@ejemplo.com',
+      }),
+    );
+  });
+
+  it('acepta 50x80mm: pasa el gate de labelSize y llega hasta guardar el batch', async () => {
+    const saveErrorLog = jest
+      .fn()
+      .mockResolvedValue({ id: 'x', errorId: 'ERR-8' });
+    const configService: any = { get: jest.fn(() => 'test-bucket') };
+    const usersService: any = {
+      getUserById: jest.fn().mockResolvedValue({
+        id: 'uid-b',
+        email: 'batch@ejemplo.com',
+        plan: 'pro',
+      }),
+      getEffectivePlan: jest.fn().mockReturnValue('pro'),
+      checkCanConvert: jest
+        .fn()
+        .mockResolvedValue({ allowed: true, userEmail: 'batch@ejemplo.com' }),
+    };
+    // saveBatchJob corta el flujo justo después del gate de labelSize, sin
+    // necesidad de simular processBatchFiles (que sigue en segundo plano sin
+    // await) al completo.
+    const saveBatchJob = jest.fn().mockRejectedValue(new Error('stop-here'));
+    const service = new ZplService(
+      configService,
+      { saveErrorLog, saveBatchJob } as any,
+      usersService,
+      {} as any,
+      {} as any,
+    );
+
+    await expect(
+      service.startBatchConversion(
+        'uid-b',
+        [{ id: 'f1', fileName: 'a.zpl', content: SIMPLE_ZPL }],
+        '50x80mm',
+      ),
+    ).rejects.toThrow();
+
+    expect(saveBatchJob).toHaveBeenCalled();
+    expect(saveErrorLog).not.toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'INVALID_LABEL_SIZE' }),
+    );
   });
 });
 

--- a/src/modules/zpl/zpl.service.ts
+++ b/src/modules/zpl/zpl.service.ts
@@ -41,7 +41,7 @@ import {
 import type { PlanType } from '../../common/interfaces/user.interface.js';
 import {
   LabelSize,
-  LABEL_SIZE_ALIASES,
+  resolveLabelSizeAlias,
   normalizeLabelSize,
   isKnownLabelSize,
 } from './enums/label-size.enum.js';
@@ -1638,7 +1638,7 @@ export class ZplService {
     }
 
     // Para usuarios Free, usar formato estándar zplpdf_size_timestamp
-    const size = LABEL_SIZE_ALIASES[labelSize.toLowerCase()] ?? labelSize;
+    const size = resolveLabelSizeAlias(labelSize) ?? labelSize;
     // Timestamp compacto y explícito en GMT-6 (Mérida), no un slice() a ciegas
     // sobre un ISO en UTC: ese slice(0, 14) se comía la hora a la mitad porque
     // el replace solo quitaba ":" y "." pero dejaba los "-" de la fecha

--- a/src/modules/zpl/zpl.service.ts
+++ b/src/modules/zpl/zpl.service.ts
@@ -39,7 +39,16 @@ import {
   PLAN_FEATURES,
 } from '../../common/interfaces/user.interface.js';
 import type { PlanType } from '../../common/interfaces/user.interface.js';
-import { LabelSize, normalizeLabelSize } from './enums/label-size.enum.js';
+import {
+  LabelSize,
+  LABEL_SIZE_ALIASES,
+  normalizeLabelSize,
+  isKnownLabelSize,
+} from './enums/label-size.enum.js';
+import {
+  getDateStringInTimezone,
+  getTimeStringInTimezone,
+} from '../../utils/timezone.util.js';
 
 // El enum vivía duplicado aquí y en `enums/label-size.enum.ts`, con los mismos
 // valores pero como dos tipos distintos para TypeScript. Se reexporta el
@@ -100,16 +109,6 @@ export class ZplService {
   private readonly bucket: string;
   private readonly storageBasePath: string;
   private readonly URL_EXPIRATION_TIME = 15 * 60 * 1000; // 15 minutos en milisegundos
-
-  // Mapas de conversión para tamaños de etiqueta
-  private readonly LABEL_SIZE_NORMALIZE_MAP: Record<string, string> = {
-    small: '2x1',
-    '2x1': '2x1',
-    '2x4': '2x4',
-    '4x2': '4x2',
-    large: '4x6',
-    '4x6': '4x6',
-  };
 
   constructor(
     private configService: ConfigService,
@@ -1639,12 +1638,14 @@ export class ZplService {
     }
 
     // Para usuarios Free, usar formato estándar zplpdf_size_timestamp
-    const size =
-      this.LABEL_SIZE_NORMALIZE_MAP[labelSize.toLowerCase()] ?? labelSize;
-    const timestamp = new Date()
-      .toISOString()
-      .replace(/[:.]/g, '')
-      .slice(0, 14);
+    const size = LABEL_SIZE_ALIASES[labelSize.toLowerCase()] ?? labelSize;
+    // Timestamp compacto y explícito en GMT-6 (Mérida), no un slice() a ciegas
+    // sobre un ISO en UTC: ese slice(0, 14) se comía la hora a la mitad porque
+    // el replace solo quitaba ":" y "." pero dejaba los "-" de la fecha
+    // (issue #100). Se construye a partir de un único `now` para que fecha y
+    // hora salgan siempre del mismo instante.
+    const now = new Date();
+    const timestamp = `${getDateStringInTimezone(now).replace(/-/g, '')}T${getTimeStringInTimezone(now)}`;
     const formatSuffix =
       outputFormat !== OutputFormat.PDF ? `_${outputFormat}` : '';
     return {
@@ -1983,6 +1984,28 @@ export class ZplService {
           },
           HttpStatus.FORBIDDEN,
           { plan: effectivePlan, fileCount: files.length },
+        );
+      }
+
+      // El batch no tiene `@IsEnum` en su DTO (acepta string libre a propósito,
+      // ver `batch.dto.ts`): sin este gate, un tamaño no reconocido llegaba
+      // silencioso hasta `processBatchFiles` → `getLabelSize` →
+      // `normalizeLabelSize`, que lo convertía en 2x1 sin avisar a nadie
+      // (issue #101, riesgo 2). Se rechaza aquí, antes de gastar cuota o
+      // contar labels, en vez de dejar que la conversión "funcione" con un
+      // tamaño distinto al pedido.
+      if (!isKnownLabelSize(labelSize)) {
+        throw await this.batchRejection(
+          userId,
+          userEmail,
+          ErrorCodes.INVALID_LABEL_SIZE,
+          {
+            error: ErrorCodes.INVALID_LABEL_SIZE,
+            message: 'El tamaño de etiqueta no es válido',
+            data: { labelSize },
+          },
+          HttpStatus.BAD_REQUEST,
+          { plan: effectivePlan },
         );
       }
 

--- a/src/scripts/generate-font-previews.ts
+++ b/src/scripts/generate-font-previews.ts
@@ -11,6 +11,10 @@ import * as dotenv from 'dotenv';
 import * as fs from 'fs';
 import * as path from 'path';
 import sharp from 'sharp';
+import {
+  LabelSize,
+  LABEL_SIZE_DIMENSIONS,
+} from '../modules/zpl/enums/label-size.enum.js';
 
 dotenv.config({ path: ['.env.local', '.env'] });
 
@@ -39,7 +43,9 @@ const ZPL_FONTS = [
   'V',
 ] as const;
 
-const LABEL_SIZE = '4x2';
+// Id de LabelSize, no la dimensión cruda: se traduce vía LABEL_SIZE_DIMENSIONS
+// para no duplicar el mapeo id -> dimensión de Labelary (issue #101).
+const LABEL_SIZE = LabelSize.FOUR_BY_TWO;
 const SAMPLE_TEXT = 'ABCDabcd 12345';
 const GCS_BUCKET_OVERRIDE = 'zplpdf-public-assets';
 const GCS_FOLDER = 'font-previews';
@@ -119,7 +125,7 @@ async function main() {
       console.log(`Processing font ${fontCode}...`);
 
       // Call Labelary API for PNG
-      const url = `http://api.labelary.com/v1/printers/8dpmm/labels/${LABEL_SIZE}/0/`;
+      const url = `http://api.labelary.com/v1/printers/8dpmm/labels/${LABEL_SIZE_DIMENSIONS[LABEL_SIZE]}/0/`;
       const response = await axios.post(url, zpl, {
         headers: {
           Accept: 'image/png',

--- a/src/utils/timezone.util.spec.ts
+++ b/src/utils/timezone.util.spec.ts
@@ -1,6 +1,8 @@
 import {
   getStartOfDateInTimezone,
   getEndOfDateInTimezone,
+  getDateStringInTimezone,
+  getTimeStringInTimezone,
 } from './timezone.util.js';
 
 /**
@@ -47,5 +49,45 @@ describe('timezone.util — límites de día en GMT-6', () => {
     const start = getStartOfDateInTimezone('2026-06-11');
     const end = getEndOfDateInTimezone('2026-06-11');
     expect(end.getTime() - start.getTime()).toBe(24 * 60 * 60 * 1000 - 1);
+  });
+});
+
+/**
+ * issue #100: `generateFilenames` armaba el timestamp del nombre de descarga
+ * recortando un ISO en UTC a ciegas (`slice(0, 14)`), lo que dejaba la hora
+ * cortada a la mitad y encima en UTC en vez de GMT-6. `getTimeStringInTimezone`
+ * es la mitad "hora" del reemplazo explícito: se combina con
+ * `getDateStringInTimezone` para armar `YYYYMMDDTHHmm`.
+ */
+describe('timezone.util — getTimeStringInTimezone', () => {
+  it('resta el offset sin tocar los minutos (offset de horas completas)', () => {
+    // 21:42 UTC - 6h = 15:42 GMT-6
+    expect(getTimeStringInTimezone(new Date('2026-08-19T21:42:16.123Z'))).toBe(
+      '1542',
+    );
+  });
+
+  it('hace acarreo circular de hora cuando UTC cae en la madrugada', () => {
+    // 03:15 UTC - 6h = 21:15 GMT-6 del día anterior (el día no importa aquí)
+    expect(getTimeStringInTimezone(new Date('2026-08-19T03:15:00.000Z'))).toBe(
+      '2115',
+    );
+  });
+
+  it('rellena con ceros horas y minutos de un dígito', () => {
+    expect(getTimeStringInTimezone(new Date('2026-08-19T06:05:00.000Z'))).toBe(
+      '0005',
+    );
+  });
+
+  it('combinado con getDateStringInTimezone reproduce GMT-6 y no UTC (issue #100)', () => {
+    // A las 19:00 hora local (01:00 UTC del día siguiente) el nombre debe
+    // fechar el día de Mérida, no el de UTC.
+    const localEvening = new Date('2026-08-20T01:00:00.000Z'); // 19:00 GMT-6 del 19
+    const compact =
+      getDateStringInTimezone(localEvening).replace(/-/g, '') +
+      'T' +
+      getTimeStringInTimezone(localEvening);
+    expect(compact).toBe('20260819T1900');
   });
 });

--- a/src/utils/timezone.util.ts
+++ b/src/utils/timezone.util.ts
@@ -71,6 +71,20 @@ export function getDateStringInTimezone(date: Date = new Date()): string {
 }
 
 /**
+ * Convierte una fecha UTC a hora compacta en GMT-6 (HHmm), para timestamps
+ * legibles de nombre de archivo. El offset de Mérida es de horas completas,
+ * así que los minutos no cambian entre UTC y GMT-6: solo se recalcula la hora
+ * (con acarreo circular; a diferencia de `getDateStringInTimezone` no importa
+ * si el acarreo cruza de día, porque este resultado no incluye la fecha).
+ */
+export function getTimeStringInTimezone(date: Date = new Date()): string {
+  const localHours = (date.getUTCHours() - GMT_OFFSET_HOURS + 24) % 24;
+  const hoursStr = String(localHours).padStart(2, '0');
+  const minutesStr = String(date.getUTCMinutes()).padStart(2, '0');
+  return `${hoursStr}${minutesStr}`;
+}
+
+/**
  * Convierte un string de fecha (YYYY-MM-DD, o ISO con hora) al instante de
  * inicio de ese día en GMT-6.
  * Ej: "2026-06-11" → 2026-06-11T06:00:00.000Z (= 00:00:00 GMT-6)


### PR DESCRIPTION
## Resumen

Implementa dos issues que tocan líneas contiguas de `zpl.service.ts`:

- **#101** — soporta etiquetas de **50 × 80 mm** (Phomemo M110 y compatibles M120/M150/M200/M220/M221).
- **#100** — el timestamp del nombre de descarga (plan free/lite) salía truncado a mitad de hora y en UTC en vez de GMT-6.

## #101 — 50×80mm (Phomemo M110)

Implementa la **opción B** del issue (recomendada): separa el **id público** de `LabelSize` (legible, viaja por la API y se guarda en `conversion_history`) de la **dimensión** que Labelary espera en la URL.

- `LabelSize.FIFTY_BY_EIGHTY_MM = '50x80mm'` — el id.
- `LABEL_SIZE_DIMENSIONS` — tabla nueva que traduce cada id a su fragmento de Labelary. Para los 4 tamaños de catálogo original, id y dimensión coinciden (ya eran pulgadas legibles); para el nuevo, no.
- Valor usado para 50×80mm: **`1.9705x3.1528`** (400×640 dots exactos a 8dpmm), no la conversión ingenua `50/25.4 x 80/25.4` (`1.9685x3.1496`), que pierde el último dot de cada eje — medido y justificado en el issue.

Se actualizan los tres puntos que antes interpolaban el enum crudo en la URL de Labelary: `labelary-queue.service.ts` (PDF y preview PNG) y el script `generate-font-previews.ts`. Swagger de `convert`/`preview`/`batch` actualizado; la descripción ya no afirma que todos los tamaños son en pulgadas.

**Los dos mapas duplicados se unificaron**: `LABEL_SIZE_ALIASES` (antes privado en el enum) ahora se exporta y `zpl.service.ts` lo reutiliza para el nombre de descarga, en vez de mantener `LABEL_SIZE_NORMALIZE_MAP` como copia separada.

### Los dos riesgos del issue

1. **Fallback silencioso de `normalizeLabelSize()` a `2x1`.** Se mantiene el valor de retorno (no lanza) porque `getHistoryZpl` depende de que nunca falle al reconvertir un registro histórico con un tamaño ya no reconocido — ese contrato está bloqueado por un test existente en `users.service.spec.ts`. Lo que cambia es que deja de ser *silencioso*: ahora registra un `logger.warn` con el valor recibido, para poder detectar en producción un frontend desplegado antes que el backend.

2. **`batch.dto.ts` sin `@IsEnum`.** Investigando el flujo real encontré que ese DTO **no está conectado** al controller (`POST /zpl/batch` usa `@UploadedFiles()` + un tipo ad-hoc en el `@Body()`, no esta clase) — `class-validator` nunca corre sobre `labelSize` ahí. La validación real se añadió donde sí importa: `ZplService.startBatchConversion` ahora rechaza con `400 INVALID_LABEL_SIZE` (vía el helper `batchRejection` ya existente, con log a `error_logs`) cualquier tamaño no reconocido, **antes** de gastar cuota o contar labels. Se dejó `batch.dto.ts` con `@IsString()` libre a propósito (sigue aceptando alias históricos como `large`/`small` que ya están en `conversion_history`) pero con un comentario explicando por qué no lleva `@IsEnum` y dónde vive la validación real.

Los alias existentes (`small`, `large`, `2x1`, `2x4`, `4x2`, `4x6`) no cambian de comportamiento.

## #100 — timestamp truncado

`generateFilenames` recortaba un ISO en UTC a ciegas (`slice(0, 14)` sobre un string al que solo se le habían quitado `:` y `.`, dejando los `-` de la fecha) — el resultado cortaba la hora a la mitad y encima en UTC, no en GMT-6 (Mérida). Se reemplaza por `getDateStringInTimezone` + una función nueva `getTimeStringInTimezone` (en `timezone.util.ts`), ambas invocadas sobre un único `now` para que fecha y hora salgan del mismo instante.

## Gates

```
npm run typecheck   -> OK
npm run lint:ci      -> OK (0 errores, 0 warnings)
npm test -- --maxWorkers=2  -> OK (18 suites, 459 tests)
```

## Tests añadidos

- `src/modules/zpl/enums/label-size.enum.spec.ts` (nuevo): mapeo `LABEL_SIZE_DIMENSIONS`, `isKnownLabelSize`, `normalizeLabelSize` (incluye el contrato de fallback a 2x1).
- `src/modules/zpl/services/labelary-queue.service.spec.ts` (nuevo): la llamada HTTP real a Labelary usa la dimensión traducida, no el id.
- `src/modules/zpl/zpl.service.spec.ts`: `getLabelSize('50x80mm')`, `generateFilenames` (formato GMT-6, colisión evitada, alias), rechazo de `labelSize` no reconocido en el batch.
- `src/utils/timezone.util.spec.ts`: `getTimeStringInTimezone`.

Closes #101
Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)
