### PR TITLE
chore(jest): limitar los workers a 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,8 @@
     "typescript": "^5.1.3"
   },
   "jest": {
+    "maxWorkers": 2,
+    "workerIdleMemoryLimit": "1500MB",
     "moduleFileExtensions": [
       "js",
       "json",


### PR DESCRIPTION
## Qué

Fija `maxWorkers: 2` y `workerIdleMemoryLimit: 1500MB` en la configuración de jest del `package.json`.

## Por qué

Jest sin `maxWorkers` arranca con `cpus - 1` workers — 11 en la máquina de desarrollo. Cuando se reparten issues entre varios worktrees y cada uno corre `npm test`, eso son decenas de procesos de ts-jest compitiendo por 12 CPUs. Hoy pasó: el load llegó a **61** y la máquina dejó de responder.

El ajuste ya existía como modificación local sin commitear, así que **ningún worktree lo heredaba** — que es justo donde hace falta, porque un worktree nuevo sale del HEAD de `development`.

`workerIdleMemoryLimit` acompaña al límite porque ts-jest acumula memoria entre suites; durante el incidente la máquina se quedó en 0,2 GB libres.

## Efecto

Ninguno sobre el código ni sobre los tests: solo acota los recursos que consume la suite. En CI el runner tiene menos cores, así que el límite no cambia nada allí.

🤖 Generated with [Claude Code](https://claude.com/claude-code)