### PR TITLE
release: promover development a main (#102, #103, #104, #105)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,8 @@
     "typescript": "^5.1.3"
   },
   "jest": {
+    "maxWorkers": 2,
+    "workerIdleMemoryLimit": "1500MB",
     "moduleFileExtensions": [
       "js",
       "json",

--- a/src/modules/billing/billing.controller.spec.ts
+++ b/src/modules/billing/billing.controller.spec.ts
@@ -1,0 +1,161 @@
+import { Test } from '@nestjs/testing';
+import type { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { BillingController } from './billing.controller.js';
+import { BillingService } from './billing.service.js';
+import { FirebaseAuthGuard } from '../../common/guards/firebase-auth.guard.js';
+import { HttpExceptionFilter } from '../../common/filters/http-exception.filter.js';
+
+/**
+ * Verifica el contrato HTTP del módulo de facturación: que los query params
+ * llegan al servicio con el nombre y tipo correctos, y que lo que el cliente
+ * recibe de verdad —después del `HttpExceptionFilter` global— conserva lo que
+ * el servicio puso en `data`.
+ *
+ * El servicio va mockeado a propósito: su lógica (validación del cursor,
+ * anidado de cfdiError) se prueba en billing.service.spec.ts. Lo que aquí
+ * puede romperse es el cableado del controller y el filtro.
+ */
+describe('BillingController — HTTP', () => {
+  const UID = 'uid-propietario';
+
+  let app: INestApplication;
+  let billingService: {
+    getInvoices: jest.Mock;
+    retryCfdi: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    billingService = {
+      getInvoices: jest
+        .fn()
+        .mockResolvedValue({ invoices: [], hasMore: false }),
+      retryCfdi: jest.fn().mockResolvedValue({
+        status: 'stamped',
+        uuid: 'UUID-1',
+        pdfUrl: null,
+        xmlUrl: null,
+        stampedAt: null,
+        error: null,
+      }),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [BillingController],
+      providers: [{ provide: BillingService, useValue: billingService }],
+    })
+      .overrideGuard(FirebaseAuthGuard)
+      .useValue({
+        canActivate: (context) => {
+          context.switchToHttp().getRequest().user = { uid: UID };
+          return true;
+        },
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalFilters(new HttpExceptionFilter());
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('GET /billing/invoices', () => {
+    it('usa el default de limit=10 y no manda starting_after si no llega', async () => {
+      await request(app.getHttpServer()).get('/billing/invoices').expect(200);
+
+      expect(billingService.getInvoices).toHaveBeenCalledWith(
+        UID,
+        10,
+        undefined,
+      );
+    });
+
+    it('pasa limit y starting_after tal cual llegan en el query', async () => {
+      await request(app.getHttpServer())
+        .get('/billing/invoices')
+        .query({ limit: '5', starting_after: 'in_abc' })
+        .expect(200);
+
+      expect(billingService.getInvoices).toHaveBeenCalledWith(UID, 5, 'in_abc');
+    });
+
+    it('propaga el 403 cuando el cursor no pertenece al usuario', async () => {
+      const { ForbiddenException } = await import('@nestjs/common');
+      billingService.getInvoices.mockRejectedValue(
+        new ForbiddenException('Invoice cursor does not belong to this user'),
+      );
+
+      const response = await request(app.getHttpServer())
+        .get('/billing/invoices')
+        .query({ starting_after: 'in_ajena' })
+        .expect(403);
+
+      expect(response.body.success).toBe(false);
+    });
+  });
+
+  describe('POST /billing/invoices/:invoiceId/cfdi/retry', () => {
+    /**
+     * Este es el test central del issue #97: reproduce, vía HTTP real
+     * (supertest) y el `HttpExceptionFilter` real (no un doble), los tres
+     * rechazos de `retryCfdi` y comprueba que `data.cfdiError.code` llega
+     * intacto al cliente. Es la capa que un test que solo mire
+     * `error.getResponse()` en el servicio no puede cubrir.
+     */
+    it.each([
+      ['400 — cobro no efectivo', 400, 'BadRequestException'],
+      ['400 — perfil fiscal incompleto', 400, 'BadRequestException'],
+      ['422 — rechazo del PAC', 422, 'UnprocessableEntityException'],
+    ])(
+      '%s: propaga cfdiError dentro de data',
+      async (_label, status, exceptionName) => {
+        const nestCommon = await import('@nestjs/common');
+        const ExceptionCtor = nestCommon[exceptionName] as new (
+          body: unknown,
+        ) => Error;
+
+        billingService.retryCfdi.mockRejectedValue(
+          new ExceptionCtor({
+            error: 'INVALID_INPUT',
+            message: 'detalle interno',
+            data: {
+              cfdiError: { code: 'rfc_not_found', message: 'RFC no inscrito' },
+            },
+          }),
+        );
+
+        const response = await request(app.getHttpServer())
+          .post('/billing/invoices/in_123/cfdi/retry')
+          .expect(status);
+
+        expect(response.body.success).toBe(false);
+        expect(response.body.data).toEqual({
+          cfdiError: { code: 'rfc_not_found', message: 'RFC no inscrito' },
+        });
+      },
+    );
+
+    it('responde con el cfdi cuando el timbrado funciona', async () => {
+      // Nest responde 201 por defecto en @Post sin @HttpCode explícito.
+      const response = await request(app.getHttpServer())
+        .post('/billing/invoices/in_123/cfdi/retry')
+        .expect(201);
+
+      expect(billingService.retryCfdi).toHaveBeenCalledWith(UID, 'in_123');
+      expect(response.body).toEqual({
+        success: true,
+        cfdi: {
+          status: 'stamped',
+          uuid: 'UUID-1',
+          pdfUrl: null,
+          xmlUrl: null,
+          stampedAt: null,
+          error: null,
+        },
+      });
+    });
+  });
+});

--- a/src/modules/billing/billing.controller.ts
+++ b/src/modules/billing/billing.controller.ts
@@ -45,17 +45,33 @@ export class BillingController {
     type: Number,
     description: 'Max invoices to return (default: 10)',
   })
+  @ApiQuery({
+    name: 'starting_after',
+    required: false,
+    type: String,
+    description:
+      'Cursor de paginación: ID de la última factura de la página anterior. Debe pertenecer al customer del usuario autenticado.',
+  })
   @ApiResponse({
     status: 200,
     description: 'List of invoices',
     type: InvoicesResponseDto,
   })
+  @ApiResponse({
+    status: 403,
+    description: 'El cursor `starting_after` no pertenece a este usuario',
+  })
   async getInvoices(
     @CurrentUser() user: FirebaseUser,
     @Query('limit') limit?: string,
+    @Query('starting_after') startingAfter?: string,
   ): Promise<InvoicesResponseDto> {
     const parsedLimit = limit ? parseInt(limit, 10) : 10;
-    return this.billingService.getInvoices(user.uid, parsedLimit);
+    return this.billingService.getInvoices(
+      user.uid,
+      parsedLimit,
+      startingAfter,
+    );
   }
 
   @Get('payment-methods')

--- a/src/modules/billing/billing.service.spec.ts
+++ b/src/modules/billing/billing.service.spec.ts
@@ -6,11 +6,14 @@ import {
   ForbiddenException,
   NotFoundException,
   UnprocessableEntityException,
+  type ArgumentsHost,
+  type HttpException,
 } from '@nestjs/common';
 import { BillingService } from './billing.service.js';
 import type { UpdateTaxProfileDto } from './dto/tax-profile.dto.js';
 import { CfdiErrorCodes } from '../facturama/facturama.constants.js';
 import { FacturamaError } from '../facturama/interfaces/facturama.interface.js';
+import { HttpExceptionFilter } from '../../common/filters/http-exception.filter.js';
 
 /**
  * El perfil fiscal es la entrada de datos que después se timbra ante el SAT.
@@ -756,18 +759,29 @@ describe('BillingService — perfil fiscal', () => {
       );
     });
 
-    it('400, no 422, si el perfil fiscal está incompleto', async () => {
+    it('400, no 422, si el perfil fiscal está incompleto, con el cfdiError anidado en data', async () => {
       const service = buildRetryService({
         cfdi: { status: 'failed' },
         profile: null,
       });
 
-      // Es una precondición que el usuario no ha cumplido, no un rechazo del
-      // PAC: un 422 le diría que su RFC está mal cuando lo que falta es
-      // cargarlo.
-      await expect(service.retryCfdi('uid-1', 'in_123')).rejects.toBeInstanceOf(
-        BadRequestException,
-      );
+      try {
+        // Es una precondición que el usuario no ha cumplido, no un rechazo del
+        // PAC: un 422 le diría que su RFC está mal cuando lo que falta es
+        // cargarlo.
+        await service.retryCfdi('uid-1', 'in_123');
+        throw new Error('Se esperaba un BadRequestException');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BadRequestException);
+        const body = (error as BadRequestException).getResponse() as {
+          data: { cfdiError: { code: string } };
+        };
+        // Anidado en `data`: es la única clave que el HttpExceptionFilter
+        // copia al body de respuesta.
+        expect(body.data.cfdiError.code).toBe(
+          CfdiErrorCodes.INVOICE_NOT_STAMPABLE,
+        );
+      }
     });
 
     it('422 con el mismo código estable cuando el PAC vuelve a rechazar', async () => {
@@ -786,11 +800,11 @@ describe('BillingService — perfil fiscal', () => {
       } catch (error) {
         expect(error).toBeInstanceOf(UnprocessableEntityException);
         const body = (error as UnprocessableEntityException).getResponse() as {
-          cfdiError: { code: string };
+          data: { cfdiError: { code: string } };
         };
         // El reintento fallido se explica con el mismo diccionario que el fallo
-        // original.
-        expect(body.cfdiError.code).toBe(CfdiErrorCodes.RFC_NOT_FOUND);
+        // original. Anidado en `data`: ver comentario del test anterior.
+        expect(body.data.cfdiError.code).toBe(CfdiErrorCodes.RFC_NOT_FOUND);
       }
     });
 
@@ -817,7 +831,7 @@ describe('BillingService — perfil fiscal', () => {
       );
     });
 
-    it('rechaza una factura que no está pagada', async () => {
+    it('rechaza una factura que no está pagada, con el cfdiError anidado en data', async () => {
       const claim = jest.fn();
       const service = buildRetryService({
         invoice: {
@@ -829,11 +843,20 @@ describe('BillingService — perfil fiscal', () => {
         claim,
       });
 
-      // La factura la elige el cliente: sin esta comprobación podría mandar al
-      // PAC una factura suya abierta y timbrar un ingreso que no existió.
-      await expect(service.retryCfdi('uid-1', 'in_123')).rejects.toBeInstanceOf(
-        BadRequestException,
-      );
+      try {
+        // La factura la elige el cliente: sin esta comprobación podría mandar
+        // al PAC una factura suya abierta y timbrar un ingreso que no existió.
+        await service.retryCfdi('uid-1', 'in_123');
+        throw new Error('Se esperaba un BadRequestException');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BadRequestException);
+        const body = (error as BadRequestException).getResponse() as {
+          data: { cfdiError: { code: string } };
+        };
+        expect(body.data.cfdiError.code).toBe(
+          CfdiErrorCodes.INVOICE_NOT_STAMPABLE,
+        );
+      }
       expect(claim).not.toHaveBeenCalled();
     });
 
@@ -912,6 +935,89 @@ describe('BillingService — perfil fiscal', () => {
       // legítimo.
       expect(claim).not.toHaveBeenCalled();
     });
+
+    /**
+     * Los tests de arriba comprueban `cfdiError` en la capa donde el servicio
+     * lanza la excepción — que es donde el dato todavía existe, pero no es lo
+     * que recibe el frontend. El `HttpExceptionFilter` global reconstruye el
+     * body de la respuesta HTTP copiando solo `responseObj.data` (ver
+     * `common/filters/http-exception.filter.ts`): un `cfdiError` en el nivel
+     * superior del objeto de la excepción se pierde ahí, aunque el test de
+     * arriba siguiera en verde. Este test pasa la excepción real por el
+     * filtro real y comprueba el JSON que de verdad sale por el cable.
+     */
+    it('el cfdiError sobrevive al HttpExceptionFilter en los tres rechazos', async () => {
+      const filter = new HttpExceptionFilter();
+
+      // Simula el ciclo request/response de Express que consume el filtro,
+      // y devuelve el objeto exacto que se habría serializado con res.json().
+      function bodyAfterFilter(exception: HttpException) {
+        const json = jest.fn();
+        const response = {
+          status: jest.fn().mockReturnValue({ json }),
+          setHeader: jest.fn(),
+        };
+        const request = {
+          headers: {},
+          method: 'POST',
+          url: '/api/billing/invoices/in_123/cfdi/retry',
+          ip: '127.0.0.1',
+        };
+        const host = {
+          switchToHttp: () => ({
+            getResponse: () => response,
+            getRequest: () => request,
+          }),
+        } as unknown as ArgumentsHost;
+
+        filter.catch(exception, host);
+        return json.mock.calls[0][0];
+      }
+
+      // 1. Cobro no efectivo (400).
+      const notPayableService = buildRetryService({
+        invoice: {
+          id: 'in_123',
+          customer: 'cus_123',
+          status: 'open',
+          amount_paid: 0,
+        },
+      });
+      const notPayableError = await notPayableService
+        .retryCfdi('uid-1', 'in_123')
+        .catch((error) => error);
+      expect(bodyAfterFilter(notPayableError).data.cfdiError.code).toBe(
+        CfdiErrorCodes.INVOICE_NOT_STAMPABLE,
+      );
+
+      // 2. Perfil fiscal incompleto (400).
+      const incompleteProfileService = buildRetryService({
+        cfdi: { status: 'failed' },
+        profile: null,
+      });
+      const incompleteProfileError = await incompleteProfileService
+        .retryCfdi('uid-1', 'in_123')
+        .catch((error) => error);
+      expect(bodyAfterFilter(incompleteProfileError).data.cfdiError.code).toBe(
+        CfdiErrorCodes.INVOICE_NOT_STAMPABLE,
+      );
+
+      // 3. Rechazo del PAC (422).
+      const pacRejectedService = buildRetryService({
+        cfdi: { status: 'failed' },
+        retry: jest
+          .fn()
+          .mockRejectedValue(
+            new FacturamaError(CfdiErrorCodes.RFC_NOT_FOUND, 'RFC no inscrito'),
+          ),
+      });
+      const pacRejectedError = await pacRejectedService
+        .retryCfdi('uid-1', 'in_123')
+        .catch((error) => error);
+      expect(bodyAfterFilter(pacRejectedError).data.cfdiError.code).toBe(
+        CfdiErrorCodes.RFC_NOT_FOUND,
+      );
+    });
   });
 
   /**
@@ -919,20 +1025,28 @@ describe('BillingService — perfil fiscal', () => {
    * factura o no, así que el estado que devuelve tiene que distinguir «no te
    * toca» de «falló».
    */
-  describe('getInvoices — bloque cfdi', () => {
+  describe('getInvoices', () => {
     function buildInvoicesService(overrides: {
       country?: string;
       cfdis?: Map<string, unknown>;
+      list?: jest.Mock;
+      retrieve?: jest.Mock;
     }) {
       const service = Object.create(BillingService.prototype) as BillingService;
       Object.assign(service, {
         logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
         stripe: {
           invoices: {
-            list: jest.fn().mockResolvedValue({
-              data: [{ id: 'in_1' }, { id: 'in_2' }],
-              has_more: false,
-            }),
+            list:
+              overrides.list ??
+              jest.fn().mockResolvedValue({
+                data: [{ id: 'in_1' }, { id: 'in_2' }],
+                has_more: false,
+              }),
+            // Usado solo cuando se valida un cursor `starting_after`.
+            retrieve:
+              overrides.retrieve ??
+              jest.fn().mockResolvedValue({ id: 'in_0', customer: 'cus_123' }),
           },
         },
         firestoreService: {
@@ -955,102 +1069,184 @@ describe('BillingService — perfil fiscal', () => {
       return service;
     }
 
-    it('devuelve cfdi null para un usuario no mexicano', async () => {
-      const service = buildInvoicesService({ country: 'ES' });
+    describe('bloque cfdi', () => {
+      it('devuelve cfdi null para un usuario no mexicano', async () => {
+        const service = buildInvoicesService({ country: 'ES' });
 
-      const { invoices } = await service.getInvoices('uid-1');
+        const { invoices } = await service.getInvoices('uid-1');
 
-      // Es como el frontend sabe que no debe pintar la columna.
-      expect(invoices.every((invoice) => invoice.cfdi === null)).toBe(true);
+        // Es como el frontend sabe que no debe pintar la columna.
+        expect(invoices.every((invoice) => invoice.cfdi === null)).toBe(true);
+      });
+
+      it('conserva los CFDI emitidos aunque el usuario cambie de país', async () => {
+        const service = buildInvoicesService({
+          country: 'ES',
+          cfdis: new Map([
+            [
+              'in_1',
+              {
+                status: 'stamped',
+                uuid: 'UUID-1',
+                pdfPath: 'cfdis/uid-1/in_1.pdf',
+              },
+            ],
+          ]),
+        });
+
+        const { invoices } = await service.getInvoices('uid-1');
+
+        // Un comprobante fiscal se conserva cinco años y esta es la única vía de
+        // descarga: mudarse de país no puede dejar al usuario sin sus facturas.
+        expect(invoices[0].cfdi).toMatchObject({
+          status: 'stamped',
+          uuid: 'UUID-1',
+          pdfUrl: 'https://signed.example/file',
+        });
+        // Las facturas sin CFDI sí siguen el país actual.
+        expect(invoices[1].cfdi).toBeNull();
+      });
+
+      it('marca not_applicable una factura mexicana sin registro', async () => {
+        const service = buildInvoicesService({ country: 'MX' });
+
+        const { invoices } = await service.getInvoices('uid-1');
+
+        // Típicamente una factura anterior a que cargara su perfil fiscal.
+        expect(invoices[0].cfdi.status).toBe('not_applicable');
+        expect(invoices[0].cfdi.uuid).toBeNull();
+      });
+
+      it('expone el estado real y las descargas de un CFDI timbrado', async () => {
+        const service = buildInvoicesService({
+          country: 'MX',
+          cfdis: new Map([
+            [
+              'in_1',
+              {
+                status: 'stamped',
+                uuid: 'UUID-1',
+                stampedAt: new Date('2026-08-04T12:00:00.000Z'),
+                pdfPath: 'cfdis/uid-1/in_1.pdf',
+                xmlPath: 'cfdis/uid-1/in_1.xml',
+              },
+            ],
+          ]),
+        });
+
+        const { invoices } = await service.getInvoices('uid-1');
+
+        expect(invoices[0].cfdi).toMatchObject({
+          status: 'stamped',
+          uuid: 'UUID-1',
+          stampedAt: '2026-08-04T12:00:00.000Z',
+          pdfUrl: 'https://signed.example/file',
+        });
+        // La segunda factura no tiene CFDI y no debe heredar el de la primera.
+        expect(invoices[1].cfdi.status).toBe('not_applicable');
+      });
+
+      it('expone el código de error de un CFDI fallido', async () => {
+        const service = buildInvoicesService({
+          country: 'MX',
+          cfdis: new Map([
+            [
+              'in_1',
+              {
+                status: 'failed',
+                error: { code: 'rfc_not_found', message: 'RFC no inscrito' },
+              },
+            ],
+          ]),
+        });
+
+        const { invoices } = await service.getInvoices('uid-1');
+
+        expect(invoices[0].cfdi).toMatchObject({
+          status: 'failed',
+          error: { code: 'rfc_not_found' },
+          pdfUrl: null,
+        });
+      });
     });
 
-    it('conserva los CFDI emitidos aunque el usuario cambie de país', async () => {
-      const service = buildInvoicesService({
-        country: 'ES',
-        cfdis: new Map([
-          [
-            'in_1',
-            {
-              status: 'stamped',
-              uuid: 'UUID-1',
-              pdfPath: 'cfdis/uid-1/in_1.pdf',
-            },
-          ],
-        ]),
+    /**
+     * `starting_after` es el cursor que usa "Cargar más" del historial: sin
+     * pasarlo a Stripe, el frontend recibe otra vez la primera página y nunca
+     * avanza. Se valida contra el customer del usuario antes de reenviarlo:
+     * es un ID que pone el cliente, y `customer` + `starting_after`
+     * combinados en Stripe no son, por sí solos, un control de acceso en el
+     * que convenga confiar.
+     */
+    describe('paginación (starting_after)', () => {
+      it('no manda starting_after a Stripe cuando no hay cursor', async () => {
+        const list = jest.fn().mockResolvedValue({ data: [], has_more: false });
+        const service = buildInvoicesService({ list });
+
+        await service.getInvoices('uid-1');
+
+        const params = list.mock.calls[0][0];
+        expect(params).not.toHaveProperty('starting_after');
       });
 
-      const { invoices } = await service.getInvoices('uid-1');
+      it('pasa starting_after a Stripe cuando el cursor es del propio customer', async () => {
+        const list = jest.fn().mockResolvedValue({ data: [], has_more: false });
+        const retrieve = jest
+          .fn()
+          .mockResolvedValue({ id: 'in_0', customer: 'cus_123' });
+        const service = buildInvoicesService({ list, retrieve });
 
-      // Un comprobante fiscal se conserva cinco años y esta es la única vía de
-      // descarga: mudarse de país no puede dejar al usuario sin sus facturas.
-      expect(invoices[0].cfdi).toMatchObject({
-        status: 'stamped',
-        uuid: 'UUID-1',
-        pdfUrl: 'https://signed.example/file',
-      });
-      // Las facturas sin CFDI sí siguen el país actual.
-      expect(invoices[1].cfdi).toBeNull();
-    });
+        await service.getInvoices('uid-1', 10, 'in_0');
 
-    it('marca not_applicable una factura mexicana sin registro', async () => {
-      const service = buildInvoicesService({ country: 'MX' });
-
-      const { invoices } = await service.getInvoices('uid-1');
-
-      // Típicamente una factura anterior a que cargara su perfil fiscal.
-      expect(invoices[0].cfdi.status).toBe('not_applicable');
-      expect(invoices[0].cfdi.uuid).toBeNull();
-    });
-
-    it('expone el estado real y las descargas de un CFDI timbrado', async () => {
-      const service = buildInvoicesService({
-        country: 'MX',
-        cfdis: new Map([
-          [
-            'in_1',
-            {
-              status: 'stamped',
-              uuid: 'UUID-1',
-              stampedAt: new Date('2026-08-04T12:00:00.000Z'),
-              pdfPath: 'cfdis/uid-1/in_1.pdf',
-              xmlPath: 'cfdis/uid-1/in_1.xml',
-            },
-          ],
-        ]),
+        expect(retrieve).toHaveBeenCalledWith('in_0');
+        expect(list).toHaveBeenCalledWith(
+          expect.objectContaining({ starting_after: 'in_0', limit: 10 }),
+        );
       });
 
-      const { invoices } = await service.getInvoices('uid-1');
+      it('rechaza con 403 un cursor que pertenece a otro customer', async () => {
+        const list = jest.fn();
+        const retrieve = jest
+          .fn()
+          .mockResolvedValue({ id: 'in_ajena', customer: 'cus_de_otro' });
+        const service = buildInvoicesService({ list, retrieve });
 
-      expect(invoices[0].cfdi).toMatchObject({
-        status: 'stamped',
-        uuid: 'UUID-1',
-        stampedAt: '2026-08-04T12:00:00.000Z',
-        pdfUrl: 'https://signed.example/file',
-      });
-      // La segunda factura no tiene CFDI y no debe heredar el de la primera.
-      expect(invoices[1].cfdi.status).toBe('not_applicable');
-    });
-
-    it('expone el código de error de un CFDI fallido', async () => {
-      const service = buildInvoicesService({
-        country: 'MX',
-        cfdis: new Map([
-          [
-            'in_1',
-            {
-              status: 'failed',
-              error: { code: 'rfc_not_found', message: 'RFC no inscrito' },
-            },
-          ],
-        ]),
+        await expect(
+          service.getInvoices('uid-1', 10, 'in_ajena'),
+        ).rejects.toBeInstanceOf(ForbiddenException);
+        // No debe alcanzar a Stripe con un cursor ajeno: la validación va
+        // antes del listado.
+        expect(list).not.toHaveBeenCalled();
       });
 
-      const { invoices } = await service.getInvoices('uid-1');
+      it('rechaza con 403 un cursor que no existe en Stripe', async () => {
+        const list = jest.fn();
+        const retrieve = jest
+          .fn()
+          .mockRejectedValue({ code: 'resource_missing' });
+        const service = buildInvoicesService({ list, retrieve });
 
-      expect(invoices[0].cfdi).toMatchObject({
-        status: 'failed',
-        error: { code: 'rfc_not_found' },
-        pdfUrl: null,
+        await expect(
+          service.getInvoices('uid-1', 10, 'in_fantasma'),
+        ).rejects.toBeInstanceOf(ForbiddenException);
+        expect(list).not.toHaveBeenCalled();
+      });
+
+      it('convierte en 400, no en 500, un fallo de Stripe al validar el cursor que no es "no existe"', async () => {
+        // Rate limit, red, credenciales: cualquier fallo de Stripe que no sea
+        // resource_missing debe caer en el mismo 400 genérico que un fallo al
+        // listar, no escapar sin manejar hacia un 500.
+        const list = jest.fn();
+        const retrieve = jest.fn().mockRejectedValue({
+          code: 'rate_limit_error',
+          message: 'Too many requests',
+        });
+        const service = buildInvoicesService({ list, retrieve });
+
+        await expect(
+          service.getInvoices('uid-1', 10, 'in_0'),
+        ).rejects.toBeInstanceOf(BadRequestException);
+        expect(list).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/modules/billing/billing.service.ts
+++ b/src/modules/billing/billing.service.ts
@@ -88,7 +88,11 @@ export class BillingService {
     this.stripe = new Stripe(stripeSecretKey);
   }
 
-  async getInvoices(userId: string, limit = 10): Promise<InvoicesResponseDto> {
+  async getInvoices(
+    userId: string,
+    limit = 10,
+    startingAfter?: string,
+  ): Promise<InvoicesResponseDto> {
     if (!this.stripe) {
       throw new BadRequestException('Billing system not configured');
     }
@@ -100,9 +104,23 @@ export class BillingService {
     }
 
     try {
+      // El cursor es un ID de factura que llega tal cual desde el cliente:
+      // se valida contra el customer antes de reenviarlo a Stripe. Dentro del
+      // try para que un fallo de Stripe al validar (rate limit, red, etc.)
+      // caiga en el mismo 400 genérico que un fallo al listar, en vez de
+      // escapar sin manejar como 500 — el catch de abajo relanza el 403
+      // propio y no lo tapa.
+      if (startingAfter) {
+        await this.assertInvoiceBelongsToCustomer(
+          startingAfter,
+          user.stripeCustomerId,
+        );
+      }
+
       const invoices = await this.stripe.invoices.list({
         customer: user.stripeCustomerId,
         limit,
+        ...(startingAfter && { starting_after: startingAfter }),
       });
 
       const cfdis = await this.resolveCfdis(user, invoices.data);
@@ -126,10 +144,51 @@ export class BillingService {
         hasMore: invoices.has_more,
       };
     } catch (error) {
+      // El cursor ajeno o inexistente ya trae su propio 403: no lo tapamos
+      // con el 400 genérico de abajo.
+      if (error instanceof ForbiddenException) {
+        throw error;
+      }
+
       this.logger.error(
         `Error fetching invoices for user ${userId}: ${error.message}`,
       );
       throw new BadRequestException('Failed to fetch invoices');
+    }
+  }
+
+  /**
+   * Comprueba que el cursor de paginación (`starting_after`) sea una factura
+   * de este customer antes de reenviarlo a Stripe.
+   *
+   * `stripe.invoices.list` ya filtra por `customer`, pero eso no es motivo
+   * para confiar en su combinación con `starting_after` como control de
+   * acceso: es un ID que pone el cliente, y sin esta comprobación serviría
+   * como oráculo para sondear si una factura ajena existe. Solo lanza
+   * `ForbiddenException` (cursor ajeno o inexistente); cualquier otro fallo
+   * de Stripe (rate limit, red) se relanza tal cual para que el catch de
+   * `getInvoices` lo trate igual que un fallo al listar.
+   */
+  private async assertInvoiceBelongsToCustomer(
+    invoiceId: string,
+    customerId: string,
+  ): Promise<void> {
+    let invoice: Stripe.Invoice;
+    try {
+      invoice = await this.stripe.invoices.retrieve(invoiceId);
+    } catch (error) {
+      if (error?.code === 'resource_missing') {
+        throw new ForbiddenException(
+          'Invoice cursor does not belong to this user',
+        );
+      }
+      throw error;
+    }
+
+    if ((invoice.customer as string) !== customerId) {
+      throw new ForbiddenException(
+        'Invoice cursor does not belong to this user',
+      );
     }
   }
 
@@ -259,9 +318,15 @@ export class BillingService {
       throw new BadRequestException({
         error: ErrorCodes.INVALID_INPUT,
         message: `Invoice is not payable for CFDI (status: ${invoice.status}, amount_paid: ${invoice.amount_paid ?? 0})`,
-        cfdiError: {
-          code: CfdiErrorCodes.INVOICE_NOT_STAMPABLE,
-          message: 'La factura no corresponde a un cobro efectivo',
+        // Anidado en `data`: es la única clave que el HttpExceptionFilter
+        // copia al body de respuesta (ver `catch()` del filtro). En el nivel
+        // superior del objeto de la excepción, el filtro nunca lo lee y el
+        // frontend se queda sin el código estable para traducir.
+        data: {
+          cfdiError: {
+            code: CfdiErrorCodes.INVOICE_NOT_STAMPABLE,
+            message: 'La factura no corresponde a un cobro efectivo',
+          },
         },
       });
     }
@@ -275,9 +340,12 @@ export class BillingService {
       throw new BadRequestException({
         error: ErrorCodes.INVALID_INPUT,
         message: 'Tax profile is incomplete',
-        cfdiError: {
-          code: CfdiErrorCodes.INVOICE_NOT_STAMPABLE,
-          message: 'Tax profile is incomplete',
+        // Mismo motivo que arriba: sin `data`, el filtro descarta cfdiError.
+        data: {
+          cfdiError: {
+            code: CfdiErrorCodes.INVOICE_NOT_STAMPABLE,
+            message: 'Tax profile is incomplete',
+          },
         },
       });
     }
@@ -319,9 +387,12 @@ export class BillingService {
       throw new UnprocessableEntityException({
         error: ErrorCodes.INVALID_INPUT,
         message: error?.message ?? 'CFDI stamping failed',
-        cfdiError: {
-          code,
-          message: error?.message ?? 'CFDI stamping failed',
+        // Mismo motivo que arriba: sin `data`, el filtro descarta cfdiError.
+        data: {
+          cfdiError: {
+            code,
+            message: error?.message ?? 'CFDI stamping failed',
+          },
         },
       });
     }

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -1,12 +1,15 @@
 // Evitar la conexión real a Stripe al cargar el módulo.
 jest.mock('stripe', () => jest.fn());
 
+import type { ArgumentsHost } from '@nestjs/common';
 import {
   BadRequestException,
   ConflictException,
   ServiceUnavailableException,
 } from '@nestjs/common';
+import type { Request, Response } from 'express';
 import { PaymentsService } from './payments.service.js';
+import { HttpExceptionFilter } from '../../common/filters/http-exception.filter.js';
 
 /**
  * Un fallo de permisos de la API key de Stripe (restricted key sin el scope
@@ -233,6 +236,35 @@ describe('PaymentsService — upgradeSubscription', () => {
 
   function claveUsada(update: jest.Mock, llamada = 0) {
     return update.mock.calls[llamada]?.[2]?.idempotencyKey;
+  }
+
+  /**
+   * Pasa una excepción por el HttpExceptionFilter global real, tal cual lo
+   * hace `main.ts` (`app.useGlobalFilters`). El filtro descarta cualquier
+   * clave suelta que no sea `data`/`errors`/`summary` (issue #97), así que
+   * comprobar solo `error.getResponse()` no basta para validar el issue #96:
+   * hay que leer lo que de verdad recibe `response.json(...)`.
+   */
+  function runThroughHttpExceptionFilter(exception: unknown) {
+    const filter = new HttpExceptionFilter();
+    const json = jest.fn();
+    const status = jest.fn().mockReturnValue({ json });
+    const response = { status, setHeader: jest.fn() } as unknown as Response;
+    const request = {
+      headers: {},
+      method: 'POST',
+      url: '/api/payments/upgrade',
+    } as unknown as Request;
+    const host = {
+      switchToHttp: () => ({
+        getResponse: () => response,
+        getRequest: () => request,
+      }),
+    } as unknown as ArgumentsHost;
+
+    filter.catch(exception, host);
+
+    return { status, body: json.mock.calls[0]?.[0] };
   }
 
   // Con precio: el upgrade falla cerrado si no puede resolver de qué plan parte,
@@ -999,6 +1031,78 @@ describe('PaymentsService — upgradeSubscription', () => {
 
     expect(error.message).toContain('has not been changed');
     expect(error.message).toContain('account settings');
+  });
+
+  /**
+   * issue #96: el frontend necesita `code`/`requiresAction`/`paymentUrl` como
+   * campos estructurados, sin dejar de poder parsear `message` (todavía lo
+   * hace en producción). Se verifica el cuerpo HTTP real DESPUÉS del
+   * HttpExceptionFilter global, no solo la excepción lanzada — es la capa
+   * donde el issue #97 documenta que estos campos se pierden si no van
+   * anidados en `data`.
+   */
+  it('#96: expone code/requiresAction/paymentUrl en el 400, sobreviviendo al HttpExceptionFilter', async () => {
+    const { service } = buildService({
+      subscription: activeSubscription,
+      updateResult: {
+        status: 'active',
+        id: 'sub_123',
+        pending_update: { expires_at: 1234567890 },
+        latest_invoice: {
+          id: 'in_123',
+          hosted_invoice_url: 'https://invoice.stripe.com/i/test',
+        },
+      },
+    });
+
+    const error = await service
+      .upgradeSubscription('uid-1', 'promax')
+      .catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(BadRequestException);
+
+    const { status, body } = runThroughHttpExceptionFilter(error);
+
+    expect(status).toHaveBeenCalledWith(400);
+    // Aditivo: el message de siempre se conserva íntegro tras el filtro.
+    expect(body.message).toContain('has not been changed');
+    expect(body.message).toContain('https://invoice.stripe.com/i/test');
+    // Campos nuevos, estructurados y estables para que el frontend los
+    // traduzca en vez de mostrar el `message` en inglés tal cual.
+    expect(body.data).toEqual({
+      code: 'UPGRADE_PAYMENT_PENDING',
+      requiresAction: true,
+      paymentUrl: 'https://invoice.stripe.com/i/test',
+    });
+  });
+
+  it('#96: paymentUrl es null (no undefined) cuando Stripe no da la factura, tras el filtro', async () => {
+    const { service } = buildService({
+      subscription: activeSubscription,
+      updateResult: {
+        status: 'active',
+        id: 'sub_123',
+        pending_update: { expires_at: 1234567890 },
+        latest_invoice: null,
+      },
+    });
+
+    const error = await service
+      .upgradeSubscription('uid-1', 'promax')
+      .catch((e: Error) => e);
+
+    const { body } = runThroughHttpExceptionFilter(error);
+
+    expect(body.data).toEqual({
+      code: 'UPGRADE_PAYMENT_PENDING',
+      requiresAction: true,
+      paymentUrl: null,
+    });
+    // JSON no distingue `undefined` de ausente, pero sí de `null`: sin el
+    // `?? null` explícito, un cliente estricto (p. ej. TS con
+    // `exactOptionalPropertyTypes`) vería la clave desaparecer en vez de ir a
+    // `null`, que es el contrato que promete el issue.
+    expect(body.data).toHaveProperty('paymentUrl', null);
   });
 
   /**

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -752,12 +752,32 @@ export class PaymentsService {
         `Plan sin cambiar. Factura: ${invoice?.id ?? 'desconocida'}.`,
     );
 
-    throw new BadRequestException(
+    const message =
       `Your plan has not been changed yet: the payment needs to be completed or authenticated. ` +
-        (payUrl
-          ? `Complete it here and the change will apply automatically: ${payUrl}`
-          : `Please check your payment method from your account settings and try again.`),
-    );
+      (payUrl
+        ? `Complete it here and the change will apply automatically: ${payUrl}`
+        : `Please check your payment method from your account settings and try again.`);
+
+    // issue #96: campos estructurados ADITIVOS junto al `message` de siempre —
+    // el frontend en producción todavía lo parsea con regex, así que no se
+    // toca. `code`/`requiresAction`/`paymentUrl` van anidados bajo `data`
+    // porque HttpExceptionFilter (común a toda la API) descarta cualquier
+    // clave suelta en el nivel superior del cuerpo de la excepción y solo
+    // copia `data` (o `errors`/`summary`) al JSON que de verdad sale por el
+    // cable — es el mismo fallo que describe el issue #97. `statusCode` y
+    // `error` replican el body que Nest arma por defecto para un
+    // BadRequestException con mensaje string, para no cambiar nada de lo que
+    // ya dependía de esa forma.
+    throw new BadRequestException({
+      statusCode: 400,
+      error: 'Bad Request',
+      message,
+      data: {
+        code: 'UPGRADE_PAYMENT_PENDING',
+        requiresAction: true,
+        paymentUrl: payUrl ?? null,
+      },
+    });
   }
 
   /**

--- a/src/modules/users/dto/get-history-query.dto.ts
+++ b/src/modules/users/dto/get-history-query.dto.ts
@@ -72,7 +72,10 @@ export class GetHistoryQueryDto {
   limit?: number = 25;
 
   @ApiPropertyOptional({
-    description: 'Free text over jobId (prefix match, case-insensitive)',
+    description:
+      'Free text, case-insensitive substring match over jobId, labelSize ' +
+      'and outputFormat; also matched against labelCount when the term is ' +
+      'numeric',
     maxLength: 100,
   })
   @IsOptional()

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -181,7 +181,9 @@ export class UsersController {
     required: false,
     type: String,
     description:
-      'Filtra por jobId (coincidencia por prefijo, case-insensitive)',
+      'Búsqueda por subcadena, case-insensitive, sobre jobId, labelSize y ' +
+      'outputFormat; también compara contra labelCount cuando el término es ' +
+      'numérico',
   })
   @ApiQuery({
     name: 'status',

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -401,7 +401,12 @@ describe('UsersService — getUserHistory', () => {
       expect(result.data.map((r: { id: string }) => r.id)).toEqual(['a']);
     });
 
-    it('busca por prefijo de jobId sin distinguir mayúsculas', async () => {
+    /**
+     * issue #94: antes era prefix-match, así que un jobId copiado a medias (el
+     * tramo final de una URL de descarga, por ejemplo) no encontraba nada. 'c'
+     * TERMINA en "abc" — con prefijo se quedaba fuera; con subcadena, no.
+     */
+    it('busca por subcadena de jobId, no solo por prefijo, sin distinguir mayúsculas', async () => {
       const { service } = buildService([
         record({ id: 'a', jobId: 'ABC-123' }),
         record({ id: 'b', jobId: 'abd-999' }),
@@ -410,7 +415,68 @@ describe('UsersService — getUserHistory', () => {
 
       const result = await service.getUserHistory('uid-1', { search: 'abc' });
 
-      expect(result.data.map((r: { id: string }) => r.id)).toEqual(['a']);
+      expect(result.data.map((r: { id: string }) => r.id)).toEqual(['a', 'c']);
+    });
+
+    /**
+     * issue #94: `search` vuelve a ser multi-campo — labelSize y outputFormat
+     * ya tenían filtros dedicados, pero el cuadro de búsqueda único debe seguir
+     * cubriéndolos sin que el usuario tenga que saber en qué desplegable vive
+     * cada cosa.
+     */
+    it('busca también por labelSize y por outputFormat', async () => {
+      const { service } = buildService([
+        record({
+          id: 'a',
+          labelSize: LabelSize.FOUR_BY_SIX,
+          outputFormat: OutputFormat.PDF,
+        }),
+        record({
+          id: 'b',
+          labelSize: LabelSize.TWO_BY_ONE,
+          outputFormat: OutputFormat.PNG,
+        }),
+      ]);
+
+      const porLabelSize = await service.getUserHistory('uid-1', {
+        search: '4x6',
+      });
+      expect(porLabelSize.data.map((r: { id: string }) => r.id)).toEqual(['a']);
+
+      const porOutputFormat = await service.getUserHistory('uid-1', {
+        search: 'png',
+      });
+      expect(porOutputFormat.data.map((r: { id: string }) => r.id)).toEqual([
+        'b',
+      ]);
+    });
+
+    /**
+     * issue #94: labelCount entra en el barrido solo cuando el término es
+     * numérico, para que "50" encuentre tanto un jobId que lo contenga como
+     * una fila con 50 o 150 etiquetas.
+     */
+    it('busca por labelCount cuando el término es numérico', async () => {
+      const { service } = buildService([
+        record({ id: 'a', labelCount: 50, jobId: 'job-a' }),
+        record({ id: 'b', labelCount: 150, jobId: 'job-b' }),
+        record({ id: 'c', labelCount: 7, jobId: 'job-c' }),
+      ]);
+
+      const result = await service.getUserHistory('uid-1', { search: '50' });
+
+      expect(result.data.map((r: { id: string }) => r.id)).toEqual(['a', 'b']);
+    });
+
+    it('un término que no aparece en ningún campo cubierto no devuelve nada', async () => {
+      const { service } = buildService(mixed);
+
+      const result = await service.getUserHistory('uid-1', {
+        search: 'no-existe-en-nada',
+      });
+
+      expect(result.data).toHaveLength(0);
+      expect(result.pagination.total).toBe(0);
     });
 
     it('total refleja los filtros, no el total absoluto', async () => {

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -655,7 +655,7 @@ export class UsersService {
       }
       if (query.labelSize && record.labelSize !== query.labelSize) return false;
 
-      if (search && !record.jobId?.toLowerCase().startsWith(search)) {
+      if (search && !this.matchesSearch(record, search)) {
         return false;
       }
 
@@ -668,6 +668,43 @@ export class UsersService {
 
       return true;
     });
+  }
+
+  /**
+   * issue #94: `search` era prefix-match solo sobre `jobId`, justo el único
+   * campo visible en el historial que el buscador no cubría — `labelSize`,
+   * `outputFormat` y `status` ya tienen filtros dedicados. Pasa a subcadena
+   * (no prefijo: un usuario que pega el tramo final de un jobId copiado de una
+   * URL de descarga antes no encontraba nada) y a multi-campo, para que un
+   * único cuadro de búsqueda vuelva a cubrir lo que el filtrado en cliente
+   * ofrecía antes de que el historial se paginara en servidor.
+   *
+   * Sigue siendo en memoria sobre el bloque ya escaneado (`getScannedHistory`),
+   * así que no exige índices nuevos en Firestore.
+   *
+   * `search` ya llega en minúsculas (recortado en `filterHistory`).
+   */
+  private matchesSearch(
+    record: ConversionHistoryRecord,
+    search: string,
+  ): boolean {
+    if (record.jobId?.toLowerCase().includes(search)) return true;
+    if (record.labelSize?.toLowerCase().includes(search)) return true;
+    if (record.outputFormat?.toLowerCase().includes(search)) return true;
+
+    // labelCount es numérico: compararlo como subcadena de texto contra un
+    // término no numérico ("png", "4x6"...) no podría dar falso positivo —
+    // ninguna cifra contiene letras—, pero limitar la comparación a términos
+    // numéricos deja explícito que este campo solo entra en juego cuando el
+    // usuario busca por cantidad de etiquetas.
+    if (
+      /^\d+$/.test(search) &&
+      String(record.labelCount ?? '').includes(search)
+    ) {
+      return true;
+    }
+
+    return false;
   }
 
   private sortHistory(

--- a/src/modules/zpl/dto/batch.dto.ts
+++ b/src/modules/zpl/dto/batch.dto.ts
@@ -39,7 +39,15 @@ export class BatchConvertDto {
   @Type(() => BatchFileDto)
   files: BatchFileDto[];
 
-  @ApiProperty({ description: 'Label size (e.g., 4x6, 4x4)' })
+  // NOTA: este DTO documenta la forma del endpoint en Swagger, pero
+  // `POST /zpl/batch` no lo usa como `@Body()` (recibe multipart/form-data vía
+  // `@UploadedFiles()` + un tipo ad-hoc en el controller, no esta clase), así
+  // que `class-validator` nunca corre sobre este campo. La validación real de
+  // labelSize (incluida contra valores no reconocidos, issue #101) vive en
+  // `ZplService.startBatchConversion`, que sigue aceptando string libre a
+  // propósito: el batch históricamente guarda el tamaño sin normalizar
+  // (`large`, `small`, …) en conversion_history.
+  @ApiProperty({ description: 'Label size (e.g., 4x6, 50x80mm)' })
   @IsString()
   @IsNotEmpty()
   labelSize: string;

--- a/src/modules/zpl/dto/convert-zpl.dto.ts
+++ b/src/modules/zpl/dto/convert-zpl.dto.ts
@@ -15,7 +15,9 @@ export class ConvertZplDto {
   zplContent?: string;
 
   @ApiProperty({
-    description: 'Tamaño de la etiqueta (2x1, 2x4, 4x2 o 4x6 pulgadas)',
+    description:
+      'Tamaño de la etiqueta: 2x1, 2x4, 4x2, 4x6 (impresoras de escritorio) o ' +
+      '50x80mm (impresoras portátiles tipo Phomemo M110)',
     example: LabelSize.TWO_BY_ONE,
     enum: LabelSize,
     default: LabelSize.TWO_BY_ONE,

--- a/src/modules/zpl/enums/label-size.enum.spec.ts
+++ b/src/modules/zpl/enums/label-size.enum.spec.ts
@@ -1,0 +1,144 @@
+import {
+  LabelSize,
+  LABEL_SIZE_ALIASES,
+  LABEL_SIZE_DIMENSIONS,
+  isKnownLabelSize,
+  normalizeLabelSize,
+  resolveLabelSizeAlias,
+} from './label-size.enum.js';
+
+/**
+ * issue #101 (50x80mm, Phomemo M110): el id que viaja por la API pública
+ * (`LabelSize`) y la dimensión que entiende Labelary son cosas separadas a
+ * propósito (opción B). Este mapeo es el contrato con Labelary: si alguien lo
+ * toca sin querer, el PDF sale con el tamaño equivocado sin que ningún tipo lo
+ * detecte (la clave es un string).
+ */
+describe('label-size.enum — LABEL_SIZE_DIMENSIONS', () => {
+  it('fija el mapeo completo id -> dimensión de Labelary', () => {
+    expect(LABEL_SIZE_DIMENSIONS).toEqual({
+      [LabelSize.TWO_BY_ONE]: '2x1',
+      [LabelSize.TWO_BY_FOUR]: '2x4',
+      [LabelSize.FOUR_BY_TWO]: '4x2',
+      [LabelSize.FOUR_BY_SIX]: '4x6',
+      [LabelSize.FIFTY_BY_EIGHTY_MM]: '1.9705x3.1528',
+    });
+  });
+
+  it('usa 1.9705x3.1528 para 50x80mm: 400x640 dots exactos a 8dpmm, no la conversión ingenua mm/25.4 (1.9685x3.1496)', () => {
+    expect(LABEL_SIZE_DIMENSIONS[LabelSize.FIFTY_BY_EIGHTY_MM]).toBe(
+      '1.9705x3.1528',
+    );
+  });
+
+  it('para los cuatro tamaños de catálogo original, el id y la dimensión coinciden', () => {
+    expect(LABEL_SIZE_DIMENSIONS[LabelSize.TWO_BY_ONE]).toBe(
+      LabelSize.TWO_BY_ONE,
+    );
+    expect(LABEL_SIZE_DIMENSIONS[LabelSize.TWO_BY_FOUR]).toBe(
+      LabelSize.TWO_BY_FOUR,
+    );
+    expect(LABEL_SIZE_DIMENSIONS[LabelSize.FOUR_BY_TWO]).toBe(
+      LabelSize.FOUR_BY_TWO,
+    );
+    expect(LABEL_SIZE_DIMENSIONS[LabelSize.FOUR_BY_SIX]).toBe(
+      LabelSize.FOUR_BY_SIX,
+    );
+  });
+});
+
+describe('label-size.enum — isKnownLabelSize', () => {
+  it.each([
+    '2x1',
+    '2x4',
+    '4x2',
+    '4x6',
+    '50x80mm',
+    'small',
+    'large',
+    'SMALL',
+    '50X80MM',
+  ])('reconoce "%s" como tamaño o alias válido', (value) => {
+    expect(isKnownLabelSize(value)).toBe(true);
+  });
+
+  it.each([undefined, '', '4x4', 'sdfsdf', 'toString'])(
+    'no reconoce "%s" (protege el batch de valores no soportados)',
+    (value) => {
+      expect(isKnownLabelSize(value)).toBe(false);
+    },
+  );
+
+  /**
+   * Regresión (review de Codex, PR #104): `constructor` y `__proto__` ya
+   * están en minúsculas, así que `.toLowerCase()` no los cambia, y un lookup
+   * ingenuo (`LABEL_SIZE_ALIASES[key]`) encuentra la propiedad HEREDADA de
+   * Object.prototype en vez de `undefined`. Antes de este fix, ambos valores
+   * "colaban" como tamaño reconocido y `normalizeLabelSize` devolvía, en
+   * tiempo de ejecución, el constructor `Object` en vez de un `LabelSize`
+   * real — la URL de Labelary terminaba con dimensiones `undefined`.
+   */
+  it.each(['constructor', 'CONSTRUCTOR', '__proto__'])(
+    'no confunde la propiedad heredada "%s" con un tamaño válido',
+    (value) => {
+      expect(isKnownLabelSize(value)).toBe(false);
+    },
+  );
+});
+
+describe('label-size.enum — normalizeLabelSize', () => {
+  it('resuelve el nuevo alias 50x80mm al enum correspondiente', () => {
+    expect(normalizeLabelSize('50x80mm')).toBe(LabelSize.FIFTY_BY_EIGHTY_MM);
+  });
+
+  it('sigue resolviendo los alias existentes sin romper la API pública ni el historial', () => {
+    expect(normalizeLabelSize('small')).toBe(LabelSize.TWO_BY_ONE);
+    expect(normalizeLabelSize('2x1')).toBe(LabelSize.TWO_BY_ONE);
+    expect(normalizeLabelSize('2x4')).toBe(LabelSize.TWO_BY_FOUR);
+    expect(normalizeLabelSize('4x2')).toBe(LabelSize.FOUR_BY_TWO);
+    expect(normalizeLabelSize('large')).toBe(LabelSize.FOUR_BY_SIX);
+    expect(normalizeLabelSize('4x6')).toBe(LabelSize.FOUR_BY_SIX);
+  });
+
+  it('es case-insensitive', () => {
+    expect(normalizeLabelSize('50X80MM')).toBe(LabelSize.FIFTY_BY_EIGHTY_MM);
+    expect(normalizeLabelSize('LARGE')).toBe(LabelSize.FOUR_BY_SIX);
+  });
+
+  // Contrato bloqueado también por users.service.spec.ts (getHistoryZpl): el
+  // fallback a 2x1 para valores no reconocidos no puede cambiar de valor de
+  // retorno, solo dejar de ser silencioso (se registra con logger.warn).
+  it('cae en 2x1 para un valor no reconocido, sin lanzar', () => {
+    expect(normalizeLabelSize('4x4')).toBe(LabelSize.TWO_BY_ONE);
+    expect(normalizeLabelSize(undefined)).toBe(LabelSize.TWO_BY_ONE);
+  });
+
+  // Misma regresión que en isKnownLabelSize: sin el guard de propiedad propia,
+  // esto devolvía en runtime el constructor `Object`, no un `LabelSize`.
+  it.each(['constructor', '__proto__'])(
+    'cae en 2x1 para la propiedad heredada "%s" en vez de devolverla',
+    (value) => {
+      expect(normalizeLabelSize(value)).toBe(LabelSize.TWO_BY_ONE);
+    },
+  );
+});
+
+describe('label-size.enum — LABEL_SIZE_ALIASES', () => {
+  it('incluye el alias del tamaño nuevo, para no mantener un segundo mapa duplicado en zpl.service.ts', () => {
+    expect(LABEL_SIZE_ALIASES['50x80mm']).toBe(LabelSize.FIFTY_BY_EIGHTY_MM);
+  });
+});
+
+describe('label-size.enum — resolveLabelSizeAlias (lookup seguro, sin herencia de Object.prototype)', () => {
+  it('resuelve alias válidos igual que un acceso directo', () => {
+    expect(resolveLabelSizeAlias('4x6')).toBe(LabelSize.FOUR_BY_SIX);
+    expect(resolveLabelSizeAlias('large')).toBe(LabelSize.FOUR_BY_SIX);
+  });
+
+  it.each(['constructor', '__proto__', '4x4', undefined])(
+    'devuelve undefined (no una propiedad heredada) para "%s"',
+    (value) => {
+      expect(resolveLabelSizeAlias(value)).toBeUndefined();
+    },
+  );
+});

--- a/src/modules/zpl/enums/label-size.enum.ts
+++ b/src/modules/zpl/enums/label-size.enum.ts
@@ -1,22 +1,105 @@
+import { Logger } from '@nestjs/common';
+
+const logger = new Logger('LabelSize');
+
 export enum LabelSize {
   TWO_BY_ONE = '2x1',
   TWO_BY_FOUR = '2x4',
   FOUR_BY_TWO = '4x2',
   FOUR_BY_SIX = '4x6',
+  // Rollo de catálogo de las impresoras térmicas portátiles Phomemo M110 (y
+  // compatibles M120/M150/M200/M220/M221). El id es legible a propósito
+  // (issue #101, opción B): es lo que viaja por la API pública y se guarda en
+  // conversion_history. La dimensión real que entiende Labelary vive en
+  // `LABEL_SIZE_DIMENSIONS`, no aquí.
+  FIFTY_BY_EIGHTY_MM = '50x80mm',
 }
 
 /**
  * Alias aceptados al pedir una conversión. `small` y `large` vienen de la API
  * antigua y siguen admitiéndose.
+ *
+ * Exportado (a diferencia del resto de tablas internas) porque `zpl.service.ts`
+ * lo reutiliza para el segmento de tamaño del nombre de descarga: antes existía
+ * un segundo mapa (`LABEL_SIZE_NORMALIZE_MAP`) con las mismas entradas que este,
+ * y mantenerlos en sincronía a mano es exactamente el tipo de duplicación que
+ * se olvida actualizar al añadir un tamaño nuevo.
  */
-const LABEL_SIZE_ALIASES: Record<string, LabelSize> = {
+export const LABEL_SIZE_ALIASES: Record<string, LabelSize> = {
   small: LabelSize.TWO_BY_ONE,
   '2x1': LabelSize.TWO_BY_ONE,
   '2x4': LabelSize.TWO_BY_FOUR,
   '4x2': LabelSize.FOUR_BY_TWO,
   large: LabelSize.FOUR_BY_SIX,
   '4x6': LabelSize.FOUR_BY_SIX,
+  '50x80mm': LabelSize.FIFTY_BY_EIGHTY_MM,
 };
+
+/**
+ * Traduce cada id de `LabelSize` al fragmento de dimensiones que entiende la
+ * URL de Labelary (`.../printers/8dpmm/labels/{dimensiones}/...`).
+ *
+ * Separado del enum a propósito (issue #101, opción B): antes el valor del
+ * enum SE INTERPOLABA tal cual en la URL, así que el id público y la
+ * dimensión eran la misma cosa. Eso funcionaba mientras todos los tamaños
+ * fueran pulgadas exactas, pero deja de servir en cuanto el id es legible
+ * (`50x80mm`) y la dimensión real que hay que mandarle a Labelary es decimal.
+ *
+ * Para los cuatro tamaños de catálogo original, id y dimensión coinciden (ya
+ * eran pulgadas legibles). Para el resto del catálogo métrico que se vaya
+ * añadiendo, no tienen por qué coincidir nunca más.
+ *
+ * El valor de 50×80mm es `1.9705x3.1528`, no la conversión ingenua
+ * `50/25.4 x 80/25.4` (`1.9685x3.1496`): Labelary trunca a dots usando 203 dpi
+ * (8 dots/mm), y solo `1.9705x3.1528` cae exacto en la rejilla 400×640 dots,
+ * que es sobre la que está diseñado el ZPL de estas etiquetas. La conversión
+ * ingenua pierde el último dot de cada eje y recorta cualquier `^FO` pegado al
+ * borde derecho o inferior. Medido contra la API real de Labelary — ver
+ * issue #101.
+ */
+export const LABEL_SIZE_DIMENSIONS: Record<LabelSize, string> = {
+  [LabelSize.TWO_BY_ONE]: '2x1',
+  [LabelSize.TWO_BY_FOUR]: '2x4',
+  [LabelSize.FOUR_BY_TWO]: '4x2',
+  [LabelSize.FOUR_BY_SIX]: '4x6',
+  [LabelSize.FIFTY_BY_EIGHTY_MM]: '1.9705x3.1528',
+};
+
+/**
+ * Lookup seguro en `LABEL_SIZE_ALIASES`. `constructor` y `__proto__` ya están
+ * en minúsculas, así que `.toLowerCase()` no los cambia, y un acceso directo
+ * por corchete (`LABEL_SIZE_ALIASES['constructor']`) encuentra la propiedad
+ * HEREDADA de `Object.prototype` en vez de `undefined` — cualquiera de los
+ * dos "cuela" como tamaño reconocido y `normalizeLabelSize` acabaría
+ * devolviendo, en tiempo de ejecución, el constructor `Object` en vez de un
+ * `LabelSize`. `Object.prototype.hasOwnProperty.call` descarta esa herencia
+ * (no se usa `Object.hasOwn`: el `target` de tsconfig es ES2021, anterior a
+ * su tipado). Hallazgo del review de Codex en el PR #104.
+ *
+ * Exportado para que cualquier otro lookup directo sobre `LABEL_SIZE_ALIASES`
+ * (p. ej. el segmento de tamaño del nombre de descarga en `zpl.service.ts`)
+ * pase por el mismo guard en vez de reintroducir el bug con un acceso crudo.
+ */
+export function resolveLabelSizeAlias(
+  labelSize: string | undefined,
+): LabelSize | undefined {
+  const key = labelSize?.toLowerCase() ?? '';
+  return Object.prototype.hasOwnProperty.call(LABEL_SIZE_ALIASES, key)
+    ? LABEL_SIZE_ALIASES[key]
+    : undefined;
+}
+
+/**
+ * true si el valor (case-insensitive) es un tamaño o alias reconocido, es
+ * decir si `normalizeLabelSize` lo resolvería sin caer en el fallback.
+ *
+ * Pensado para validar ANTES de aceptar una entrada (p. ej. el batch, que no
+ * tiene `@IsEnum` porque históricamente acepta alias libres). El chequeo en sí
+ * no registra nada: quien lo llama decide cómo rechazar el valor inválido.
+ */
+export function isKnownLabelSize(labelSize: string | undefined): boolean {
+  return resolveLabelSizeAlias(labelSize) !== undefined;
+}
 
 /**
  * Traduce cualquier tamaño de entrada al valor del enum con el que se convierte
@@ -27,9 +110,22 @@ const LABEL_SIZE_ALIASES: Record<string, LabelSize> = {
  * con `@IsEnum(LabelSize)`. Devolver el valor crudo al reconvertir haría que el
  * frontend recibiera un 400 con el mismo tamaño con el que la conversión
  * original funcionó.
+ *
+ * El fallback a 2x1 se queda (no lanza): romperlo dejaría sin reconvertir
+ * cualquier registro histórico con un tamaño ya no reconocido. Pero deja de
+ * ser silencioso — se registra en el logger para poder detectar en producción
+ * un frontend desplegado antes que el backend (issue #101). Quien pueda
+ * permitirse rechazar la entrada en vez de absorberla (p. ej. el batch, antes
+ * de aceptar la conversión) debe validar con `isKnownLabelSize` primero en
+ * lugar de confiar en este fallback.
  */
 export function normalizeLabelSize(labelSize: string | undefined): LabelSize {
-  return (
-    LABEL_SIZE_ALIASES[labelSize?.toLowerCase() ?? ''] ?? LabelSize.TWO_BY_ONE
-  );
+  const resolved = resolveLabelSizeAlias(labelSize);
+  if (resolved === undefined) {
+    logger.warn(
+      `Tamaño de etiqueta no reconocido ("${labelSize}"), usando 2x1 por defecto`,
+    );
+    return LabelSize.TWO_BY_ONE;
+  }
+  return resolved;
 }

--- a/src/modules/zpl/services/labelary-queue.service.spec.ts
+++ b/src/modules/zpl/services/labelary-queue.service.spec.ts
@@ -1,0 +1,80 @@
+jest.mock('axios');
+
+import axios from 'axios';
+import { LabelaryQueueService } from './labelary-queue.service.js';
+import { LabelSize } from '../enums/label-size.enum.js';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+/**
+ * issue #101 (50x80mm, Phomemo M110): el id de `LabelSize` que circula por la
+ * app (`50x80mm`) no es lo que entiende la URL de Labelary. Antes el enum SE
+ * INTERPOLABA tal cual porque id y dimensión eran la misma cosa; con la
+ * opción B dejan de serlo. Este spec fija que la llamada HTTP real sale con
+ * la dimensión traducida, no con el id — es la regresión más directa si
+ * alguien revierte alguno de los dos puntos de interpolación.
+ */
+describe('LabelaryQueueService — traducción de LabelSize a dimensiones de Labelary', () => {
+  function buildService(): LabelaryQueueService {
+    const labelaryAnalyticsService: any = {
+      trackSuccess: jest.fn().mockResolvedValue(undefined),
+      trackRateLimit: jest.fn().mockResolvedValue(undefined),
+      trackError: jest.fn().mockResolvedValue(undefined),
+    };
+    return new LabelaryQueueService(labelaryAnalyticsService);
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('enqueuePngDirect (preview)', () => {
+    it('usa la dimensión decimal para 50x80mm, no el id legible', async () => {
+      mockedAxios.post.mockResolvedValue({ data: Buffer.from('png') });
+      const service = buildService();
+
+      await service.enqueuePngDirect('^XA^XZ', LabelSize.FIFTY_BY_EIGHTY_MM);
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'http://api.labelary.com/v1/printers/8dpmm/labels/1.9705x3.1528/0/',
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('sigue mandando la dimensión de los tamaños de catálogo original sin cambios', async () => {
+      mockedAxios.post.mockResolvedValue({ data: Buffer.from('png') });
+      const service = buildService();
+
+      await service.enqueuePngDirect('^XA^XZ', LabelSize.FOUR_BY_SIX);
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'http://api.labelary.com/v1/printers/8dpmm/labels/4x6/0/',
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('enqueue (conversión PDF)', () => {
+    it('usa la dimensión decimal para 50x80mm, no el id legible', async () => {
+      mockedAxios.post.mockResolvedValue({ data: Buffer.from('pdf') });
+      const service = buildService();
+
+      await service.enqueue(
+        'job-1',
+        'user-1',
+        'free',
+        '^XA^XZ',
+        LabelSize.FIFTY_BY_EIGHTY_MM,
+        1,
+      );
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'http://api.labelary.com/v1/printers/8dpmm/labels/1.9705x3.1528',
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/src/modules/zpl/services/labelary-queue.service.ts
+++ b/src/modules/zpl/services/labelary-queue.service.ts
@@ -10,7 +10,7 @@ import {
   QUEUE_CONFIG,
 } from '../interfaces/queue.interface.js';
 import { LabelaryAnalyticsService } from './labelary-analytics.service.js';
-import { LabelSize } from '../enums/label-size.enum.js';
+import { LabelSize, LABEL_SIZE_DIMENSIONS } from '../enums/label-size.enum.js';
 import { PLAN_FEATURES } from '../../../common/interfaces/user.interface.js';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -315,7 +315,10 @@ export class LabelaryQueueService {
    * Llamada HTTP a Labelary API
    */
   private async callLabelaryInternal(item: QueueItem): Promise<Buffer> {
-    const url = `http://api.labelary.com/v1/printers/8dpmm/labels/${item.labelSize}`;
+    // El id de LabelSize (p. ej. `50x80mm`) no es lo que Labelary entiende en
+    // la URL: hay que traducirlo a sus dimensiones (issue #101, opción B).
+    const dimensions = LABEL_SIZE_DIMENSIONS[item.labelSize];
+    const url = `http://api.labelary.com/v1/printers/8dpmm/labels/${dimensions}`;
 
     const response = await axios.post(url, item.zplBatch, {
       headers: {
@@ -433,7 +436,8 @@ export class LabelaryQueueService {
       // Respetar rate limit global
       await this.waitForRateLimit();
 
-      const url = `http://api.labelary.com/v1/printers/8dpmm/labels/${labelSize}/0/`;
+      const dimensions = LABEL_SIZE_DIMENSIONS[labelSize];
+      const url = `http://api.labelary.com/v1/printers/8dpmm/labels/${dimensions}/0/`;
 
       const response = await axios.post(url, zplContent, {
         headers: {

--- a/src/modules/zpl/zpl.controller.ts
+++ b/src/modules/zpl/zpl.controller.ts
@@ -91,9 +91,12 @@ export class ZplController {
             LabelSize.TWO_BY_FOUR,
             LabelSize.FOUR_BY_TWO,
             LabelSize.FOUR_BY_SIX,
+            LabelSize.FIFTY_BY_EIGHTY_MM,
           ],
           default: LabelSize.TWO_BY_ONE,
-          description: 'Tamano de la etiqueta (2x1, 2x4, 4x2 o 4x6 pulgadas)',
+          description:
+            'Tamano de la etiqueta: 2x1, 2x4, 4x2, 4x6 (impresoras de escritorio) ' +
+            'o 50x80mm (impresoras portatiles tipo Phomemo M110)',
         },
         language: {
           type: 'string',
@@ -524,9 +527,12 @@ export class ZplController {
             LabelSize.TWO_BY_FOUR,
             LabelSize.FOUR_BY_TWO,
             LabelSize.FOUR_BY_SIX,
+            LabelSize.FIFTY_BY_EIGHTY_MM,
           ],
           default: LabelSize.TWO_BY_ONE,
-          description: 'Tamano de la etiqueta (2x1, 2x4, 4x2 o 4x6 pulgadas)',
+          description:
+            'Tamano de la etiqueta: 2x1, 2x4, 4x2, 4x6 (impresoras de escritorio) ' +
+            'o 50x80mm (impresoras portatiles tipo Phomemo M110)',
         },
       },
     },
@@ -780,7 +786,8 @@ export class ZplController {
         labelSize: {
           type: 'string',
           example: '4x6',
-          description: 'Tamano de etiqueta',
+          description:
+            'Tamano de etiqueta: 2x1, 2x4, 4x2, 4x6 o 50x80mm (Phomemo M110)',
         },
         outputFormat: {
           type: 'string',

--- a/src/modules/zpl/zpl.service.spec.ts
+++ b/src/modules/zpl/zpl.service.spec.ts
@@ -138,6 +138,213 @@ describe('ZplService — bloques de configuración sin contenido', () => {
     it('mapea 4x6 al enum correcto', () => {
       expect((service as any).getLabelSize('4x6')).toBe(LabelSize.FOUR_BY_SIX);
     });
+
+    it('mapea 50x80mm (Phomemo M110) al enum correcto (issue #101)', () => {
+      expect((service as any).getLabelSize('50x80mm')).toBe(
+        LabelSize.FIFTY_BY_EIGHTY_MM,
+      );
+    });
+  });
+});
+
+/**
+ * issue #100: el nombre de descarga para free/lite (`zplpdf_size_timestamp`)
+ * salía con la hora cortada a la mitad y en UTC. `generateFilenames` arma
+ * ahora el timestamp explícitamente en GMT-6 en vez de recortar un ISO a
+ * ciegas.
+ */
+describe('ZplService — generateFilenames (issue #100: timestamp truncado)', () => {
+  function buildService(): ZplService {
+    const configService: any = { get: jest.fn(() => 'test-bucket') };
+    return new ZplService(configService, {} as any, {} as any, {}, {} as any);
+  }
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('genera fecha y hora completas en GMT-6 (minutos incluidos), no un ISO recortado', () => {
+    // 21:42:16.123Z UTC = 15:42 GMT-6 (Mérida)
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-19T21:42:16.123Z'));
+    const service = buildService();
+
+    const { downloadFilename } = (service as any).generateFilenames(
+      'job-1',
+      '4x2',
+    );
+
+    expect(downloadFilename).toBe('zplpdf_4x2_20260819T1542.pdf');
+  });
+
+  it('dos conversiones separadas por menos de 10 minutos producen nombres distintos', () => {
+    const service = buildService();
+
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-19T21:40:00.000Z'));
+    const first = (service as any).generateFilenames('job-1', '4x2');
+
+    jest.setSystemTime(new Date('2026-08-19T21:45:00.000Z'));
+    const second = (service as any).generateFilenames('job-2', '4x2');
+
+    expect(first.downloadFilename).not.toBe(second.downloadFilename);
+  });
+
+  it('usa GMT-6 y no UTC: una conversión nocturna en México no salta al día siguiente', () => {
+    // 19:00 hora local (Mérida) = 01:00 UTC del día siguiente
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-20T01:00:00.000Z'));
+    const service = buildService();
+
+    const { downloadFilename } = (service as any).generateFilenames(
+      'job-1',
+      '4x2',
+    );
+
+    expect(downloadFilename).toBe('zplpdf_4x2_20260819T1900.pdf');
+  });
+
+  it('sigue traduciendo los alias (large -> 4x6) igual que antes de unificar los mapas de tamaño', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-19T21:42:00.000Z'));
+    const service = buildService();
+
+    const { downloadFilename } = (service as any).generateFilenames(
+      'job-1',
+      'large',
+    );
+
+    expect(downloadFilename).toBe('zplpdf_4x6_20260819T1542.pdf');
+  });
+
+  it('el tamaño nuevo (50x80mm) sale legible en el nombre de descarga', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-19T21:42:00.000Z'));
+    const service = buildService();
+
+    const { downloadFilename } = (service as any).generateFilenames(
+      'job-1',
+      '50x80mm',
+    );
+
+    expect(downloadFilename).toBe('zplpdf_50x80mm_20260819T1542.pdf');
+  });
+});
+
+/**
+ * issue #101, riesgo 2: el batch no tiene `@IsEnum` (acepta string libre a
+ * propósito para no romper el historial), así que un tamaño no reconocido
+ * debe rechazarse explícitamente en vez de convertirse en 2x1 en silencio.
+ */
+describe('ZplService — validación de labelSize en el batch (issue #101)', () => {
+  const SIMPLE_ZPL = '^XA^FO50,50^A0,30^FDtest^FS^XZ';
+
+  function buildBatchService(saveErrorLog: jest.Mock) {
+    const configService: any = { get: jest.fn(() => 'test-bucket') };
+    const usersService: any = {
+      getUserById: jest.fn().mockResolvedValue({
+        id: 'uid-b',
+        email: 'batch@ejemplo.com',
+        plan: 'pro',
+      }),
+      getEffectivePlan: jest.fn().mockReturnValue('pro'),
+      checkCanConvert: jest
+        .fn()
+        .mockResolvedValue({ allowed: true, userEmail: 'batch@ejemplo.com' }),
+    };
+    return new ZplService(
+      configService,
+      { saveErrorLog } as any,
+      usersService,
+      {} as any,
+      {} as any,
+    );
+  }
+
+  it('rechaza un tamaño no reconocido con INVALID_LABEL_SIZE en vez de convertirlo en 2x1', async () => {
+    const saveErrorLog = jest
+      .fn()
+      .mockResolvedValue({ id: 'x', errorId: 'ERR-7' });
+    const service = buildBatchService(saveErrorLog);
+
+    await expect(
+      service.startBatchConversion(
+        'uid-b',
+        [{ id: 'f1', fileName: 'a.zpl', content: SIMPLE_ZPL }],
+        'tamano-inventado',
+      ),
+    ).rejects.toThrow();
+
+    expect(saveErrorLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'INVALID_LABEL_SIZE',
+        userId: 'uid-b',
+        userEmail: 'batch@ejemplo.com',
+      }),
+    );
+  });
+
+  /**
+   * Regresión (review de Codex, PR #104): `constructor` ya está en minúsculas,
+   * así que un lookup ingenuo sobre el mapa de alias encuentra la propiedad
+   * heredada de Object.prototype en vez de `undefined` y el gate lo deja pasar
+   * como si fuera un tamaño válido. Cubre el camino completo, no solo el
+   * helper del enum.
+   */
+  it('rechaza "constructor" en vez de dejarlo colar como propiedad heredada del mapa de alias', async () => {
+    const saveErrorLog = jest
+      .fn()
+      .mockResolvedValue({ id: 'x', errorId: 'ERR-9' });
+    const service = buildBatchService(saveErrorLog);
+
+    await expect(
+      service.startBatchConversion(
+        'uid-b',
+        [{ id: 'f1', fileName: 'a.zpl', content: SIMPLE_ZPL }],
+        'constructor',
+      ),
+    ).rejects.toThrow();
+
+    expect(saveErrorLog).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'INVALID_LABEL_SIZE' }),
+    );
+  });
+
+  it('acepta 50x80mm: pasa el gate de labelSize y llega hasta guardar el batch', async () => {
+    const saveErrorLog = jest
+      .fn()
+      .mockResolvedValue({ id: 'x', errorId: 'ERR-8' });
+    const configService: any = { get: jest.fn(() => 'test-bucket') };
+    const usersService: any = {
+      getUserById: jest.fn().mockResolvedValue({
+        id: 'uid-b',
+        email: 'batch@ejemplo.com',
+        plan: 'pro',
+      }),
+      getEffectivePlan: jest.fn().mockReturnValue('pro'),
+      checkCanConvert: jest
+        .fn()
+        .mockResolvedValue({ allowed: true, userEmail: 'batch@ejemplo.com' }),
+    };
+    // saveBatchJob corta el flujo justo después del gate de labelSize, sin
+    // necesidad de simular processBatchFiles (que sigue en segundo plano sin
+    // await) al completo.
+    const saveBatchJob = jest.fn().mockRejectedValue(new Error('stop-here'));
+    const service = new ZplService(
+      configService,
+      { saveErrorLog, saveBatchJob } as any,
+      usersService,
+      {} as any,
+      {} as any,
+    );
+
+    await expect(
+      service.startBatchConversion(
+        'uid-b',
+        [{ id: 'f1', fileName: 'a.zpl', content: SIMPLE_ZPL }],
+        '50x80mm',
+      ),
+    ).rejects.toThrow();
+
+    expect(saveBatchJob).toHaveBeenCalled();
+    expect(saveErrorLog).not.toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'INVALID_LABEL_SIZE' }),
+    );
   });
 });
 

--- a/src/modules/zpl/zpl.service.ts
+++ b/src/modules/zpl/zpl.service.ts
@@ -39,7 +39,16 @@ import {
   PLAN_FEATURES,
 } from '../../common/interfaces/user.interface.js';
 import type { PlanType } from '../../common/interfaces/user.interface.js';
-import { LabelSize, normalizeLabelSize } from './enums/label-size.enum.js';
+import {
+  LabelSize,
+  resolveLabelSizeAlias,
+  normalizeLabelSize,
+  isKnownLabelSize,
+} from './enums/label-size.enum.js';
+import {
+  getDateStringInTimezone,
+  getTimeStringInTimezone,
+} from '../../utils/timezone.util.js';
 
 // El enum vivía duplicado aquí y en `enums/label-size.enum.ts`, con los mismos
 // valores pero como dos tipos distintos para TypeScript. Se reexporta el
@@ -100,16 +109,6 @@ export class ZplService {
   private readonly bucket: string;
   private readonly storageBasePath: string;
   private readonly URL_EXPIRATION_TIME = 15 * 60 * 1000; // 15 minutos en milisegundos
-
-  // Mapas de conversión para tamaños de etiqueta
-  private readonly LABEL_SIZE_NORMALIZE_MAP: Record<string, string> = {
-    small: '2x1',
-    '2x1': '2x1',
-    '2x4': '2x4',
-    '4x2': '4x2',
-    large: '4x6',
-    '4x6': '4x6',
-  };
 
   constructor(
     private configService: ConfigService,
@@ -1639,12 +1638,14 @@ export class ZplService {
     }
 
     // Para usuarios Free, usar formato estándar zplpdf_size_timestamp
-    const size =
-      this.LABEL_SIZE_NORMALIZE_MAP[labelSize.toLowerCase()] ?? labelSize;
-    const timestamp = new Date()
-      .toISOString()
-      .replace(/[:.]/g, '')
-      .slice(0, 14);
+    const size = resolveLabelSizeAlias(labelSize) ?? labelSize;
+    // Timestamp compacto y explícito en GMT-6 (Mérida), no un slice() a ciegas
+    // sobre un ISO en UTC: ese slice(0, 14) se comía la hora a la mitad porque
+    // el replace solo quitaba ":" y "." pero dejaba los "-" de la fecha
+    // (issue #100). Se construye a partir de un único `now` para que fecha y
+    // hora salgan siempre del mismo instante.
+    const now = new Date();
+    const timestamp = `${getDateStringInTimezone(now).replace(/-/g, '')}T${getTimeStringInTimezone(now)}`;
     const formatSuffix =
       outputFormat !== OutputFormat.PDF ? `_${outputFormat}` : '';
     return {
@@ -1983,6 +1984,28 @@ export class ZplService {
           },
           HttpStatus.FORBIDDEN,
           { plan: effectivePlan, fileCount: files.length },
+        );
+      }
+
+      // El batch no tiene `@IsEnum` en su DTO (acepta string libre a propósito,
+      // ver `batch.dto.ts`): sin este gate, un tamaño no reconocido llegaba
+      // silencioso hasta `processBatchFiles` → `getLabelSize` →
+      // `normalizeLabelSize`, que lo convertía en 2x1 sin avisar a nadie
+      // (issue #101, riesgo 2). Se rechaza aquí, antes de gastar cuota o
+      // contar labels, en vez de dejar que la conversión "funcione" con un
+      // tamaño distinto al pedido.
+      if (!isKnownLabelSize(labelSize)) {
+        throw await this.batchRejection(
+          userId,
+          userEmail,
+          ErrorCodes.INVALID_LABEL_SIZE,
+          {
+            error: ErrorCodes.INVALID_LABEL_SIZE,
+            message: 'El tamaño de etiqueta no es válido',
+            data: { labelSize },
+          },
+          HttpStatus.BAD_REQUEST,
+          { plan: effectivePlan },
         );
       }
 

--- a/src/scripts/generate-font-previews.ts
+++ b/src/scripts/generate-font-previews.ts
@@ -11,6 +11,10 @@ import * as dotenv from 'dotenv';
 import * as fs from 'fs';
 import * as path from 'path';
 import sharp from 'sharp';
+import {
+  LabelSize,
+  LABEL_SIZE_DIMENSIONS,
+} from '../modules/zpl/enums/label-size.enum.js';
 
 dotenv.config({ path: ['.env.local', '.env'] });
 
@@ -39,7 +43,9 @@ const ZPL_FONTS = [
   'V',
 ] as const;
 
-const LABEL_SIZE = '4x2';
+// Id de LabelSize, no la dimensión cruda: se traduce vía LABEL_SIZE_DIMENSIONS
+// para no duplicar el mapeo id -> dimensión de Labelary (issue #101).
+const LABEL_SIZE = LabelSize.FOUR_BY_TWO;
 const SAMPLE_TEXT = 'ABCDabcd 12345';
 const GCS_BUCKET_OVERRIDE = 'zplpdf-public-assets';
 const GCS_FOLDER = 'font-previews';
@@ -119,7 +125,7 @@ async function main() {
       console.log(`Processing font ${fontCode}...`);
 
       // Call Labelary API for PNG
-      const url = `http://api.labelary.com/v1/printers/8dpmm/labels/${LABEL_SIZE}/0/`;
+      const url = `http://api.labelary.com/v1/printers/8dpmm/labels/${LABEL_SIZE_DIMENSIONS[LABEL_SIZE]}/0/`;
       const response = await axios.post(url, zpl, {
         headers: {
           Accept: 'image/png',

--- a/src/utils/timezone.util.spec.ts
+++ b/src/utils/timezone.util.spec.ts
@@ -1,6 +1,8 @@
 import {
   getStartOfDateInTimezone,
   getEndOfDateInTimezone,
+  getDateStringInTimezone,
+  getTimeStringInTimezone,
 } from './timezone.util.js';
 
 /**
@@ -47,5 +49,45 @@ describe('timezone.util — límites de día en GMT-6', () => {
     const start = getStartOfDateInTimezone('2026-06-11');
     const end = getEndOfDateInTimezone('2026-06-11');
     expect(end.getTime() - start.getTime()).toBe(24 * 60 * 60 * 1000 - 1);
+  });
+});
+
+/**
+ * issue #100: `generateFilenames` armaba el timestamp del nombre de descarga
+ * recortando un ISO en UTC a ciegas (`slice(0, 14)`), lo que dejaba la hora
+ * cortada a la mitad y encima en UTC en vez de GMT-6. `getTimeStringInTimezone`
+ * es la mitad "hora" del reemplazo explícito: se combina con
+ * `getDateStringInTimezone` para armar `YYYYMMDDTHHmm`.
+ */
+describe('timezone.util — getTimeStringInTimezone', () => {
+  it('resta el offset sin tocar los minutos (offset de horas completas)', () => {
+    // 21:42 UTC - 6h = 15:42 GMT-6
+    expect(getTimeStringInTimezone(new Date('2026-08-19T21:42:16.123Z'))).toBe(
+      '1542',
+    );
+  });
+
+  it('hace acarreo circular de hora cuando UTC cae en la madrugada', () => {
+    // 03:15 UTC - 6h = 21:15 GMT-6 del día anterior (el día no importa aquí)
+    expect(getTimeStringInTimezone(new Date('2026-08-19T03:15:00.000Z'))).toBe(
+      '2115',
+    );
+  });
+
+  it('rellena con ceros horas y minutos de un dígito', () => {
+    expect(getTimeStringInTimezone(new Date('2026-08-19T06:05:00.000Z'))).toBe(
+      '0005',
+    );
+  });
+
+  it('combinado con getDateStringInTimezone reproduce GMT-6 y no UTC (issue #100)', () => {
+    // A las 19:00 hora local (01:00 UTC del día siguiente) el nombre debe
+    // fechar el día de Mérida, no el de UTC.
+    const localEvening = new Date('2026-08-20T01:00:00.000Z'); // 19:00 GMT-6 del 19
+    const compact =
+      getDateStringInTimezone(localEvening).replace(/-/g, '') +
+      'T' +
+      getTimeStringInTimezone(localEvening);
+    expect(compact).toBe('20260819T1900');
   });
 });

--- a/src/utils/timezone.util.ts
+++ b/src/utils/timezone.util.ts
@@ -71,6 +71,20 @@ export function getDateStringInTimezone(date: Date = new Date()): string {
 }
 
 /**
+ * Convierte una fecha UTC a hora compacta en GMT-6 (HHmm), para timestamps
+ * legibles de nombre de archivo. El offset de Mérida es de horas completas,
+ * así que los minutos no cambian entre UTC y GMT-6: solo se recalcula la hora
+ * (con acarreo circular; a diferencia de `getDateStringInTimezone` no importa
+ * si el acarreo cruza de día, porque este resultado no incluye la fecha).
+ */
+export function getTimeStringInTimezone(date: Date = new Date()): string {
+  const localHours = (date.getUTCHours() - GMT_OFFSET_HOURS + 24) % 24;
+  const hoursStr = String(localHours).padStart(2, '0');
+  const minutesStr = String(date.getUTCMinutes()).padStart(2, '0');
+  return `${hoursStr}${minutesStr}`;
+}
+
+/**
  * Convierte un string de fecha (YYYY-MM-DD, o ISO con hora) al instante de
  * inicio de ese día en GMT-6.
  * Ej: "2026-06-11" → 2026-06-11T06:00:00.000Z (= 00:00:00 GMT-6)


### PR DESCRIPTION
Promoción de `development` a `main`. Cuatro commits, todos ya revisados y mergeados en `development` con el CI en verde.

## Contenido

| PR | Issues | Qué entra |
|---|---|---|
| #104 | #101, #100 | Tamaño de etiqueta **50 × 80 mm** (Phomemo M110) y arreglo del timestamp truncado en el nombre de descarga |
| #103 | #97, #98 | `cfdiError` deja de perderse en el `HttpExceptionFilter`; `GET /billing/invoices` acepta `starting_after` |
| #102 | #96, #94 | Campos estructurados en el 400 de upgrade pendiente; búsqueda multi-campo del historial |
| #105 | — | `maxWorkers: 2` en la config de jest |

## Notas

- **#104** introduce `LabelSize.FIFTY_BY_EIGHTY_MM = '50x80mm'` como id público, separado de la tabla que traduce a las dimensiones que espera Labelary (`1.9705x3.1528`, 400 × 640 dots exactos a 8 dpmm). El frontend no puede ofrecer el tamaño hasta que esto esté desplegado — ver gustavojmarrero/zplpdf_front#256.
- **#103** y **#102** desbloquean trabajo pendiente del frontend (zplpdf_front#239).
- El review de Codex encontró dos defectos reales durante el proceso, ambos corregidos antes del merge: un `try/catch` mal delimitado en la validación del cursor de Stripe, y un lookup por corchete en el mapa de alias que dejaba pasar `constructor` y `__proto__` como tamaños válidos.

Al mergear se cierran los issues #94, #96, #97, #98, #100 y #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)