### PR TITLE
feat(zpl): endpoint publico de vista previa con rate limit por IP y tope de etiquetas

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -35,6 +35,18 @@ import { GoogleAuthProvider } from './config/google-auth.provider.js';
         ttl: 60000,
         limit: 100,
       },
+      // Ventana horaria. Existe para que las rutas publicas puedan overridearla
+      // con @Throttle: un tope por minuto no impide sostener el consumo durante
+      // horas, y el render publico va contra el plan free de Labelary (1 req/s
+      // para toda la plataforma). El limite global es deliberadamente
+      // inalcanzable — con 'default' en 100 req/min el techo real ya es 6.000/h
+      // — para no meterle un rate limit nuevo a quien esta autenticado, que
+      // ademas comparte IP con sus companeros detras de cualquier NAT.
+      {
+        name: 'hourly',
+        ttl: 3600000,
+        limit: 100000,
+      },
     ]),
     AuthModule,
     UsersModule,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -47,6 +47,20 @@ import { GoogleAuthProvider } from './config/google-auth.provider.js';
         ttl: 3600000,
         limit: 100000,
       },
+      // Ventanas por IP de origen real (el salto que no se puede falsificar).
+      // Mismo motivo y mismo limite inerte que 'hourly': solo existen para que
+      // las rutas publicas puedan bajarlas con @Throttle, ya que el guard solo
+      // evalua los throttlers declarados aqui.
+      {
+        name: 'peerMinute',
+        ttl: 60000,
+        limit: 100000,
+      },
+      {
+        name: 'peerHourly',
+        ttl: 3600000,
+        limit: 100000,
+      },
     ]),
     AuthModule,
     UsersModule,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -30,8 +30,8 @@ import { GoogleAuthProvider } from './config/google-auth.provider.js';
     // Rate limiting: 100 req/min por defecto. Endpoints especificos
     // overridean limit/ttl con @Throttle inline. Las ventanas del endpoint
     // publico de vista previa NO viven aqui a proposito (ver
-    // PublicPreviewThrottlerGuard): el guard global evalua todo lo declarado en
-    // esta lista para TODAS las rutas.
+    // PublicPreviewThrottlerGuard): la ruta publica omite este guard global con
+    // @SkipThrottle y conserva su guard propio con storage acotado.
     ThrottlerModule.forRoot([
       {
         name: 'default',

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -28,38 +28,15 @@ import { GoogleAuthProvider } from './config/google-auth.provider.js';
       envFilePath: ['.env.local', '.env'],
     }),
     // Rate limiting: 100 req/min por defecto. Endpoints especificos
-    // overridean limit/ttl con @Throttle inline.
+    // overridean limit/ttl con @Throttle inline. Las ventanas del endpoint
+    // publico de vista previa NO viven aqui a proposito (ver
+    // PublicPreviewThrottlerGuard): el guard global evalua todo lo declarado en
+    // esta lista para TODAS las rutas.
     ThrottlerModule.forRoot([
       {
         name: 'default',
         ttl: 60000,
         limit: 100,
-      },
-      // Ventana horaria. Existe para que las rutas publicas puedan overridearla
-      // con @Throttle: un tope por minuto no impide sostener el consumo durante
-      // horas, y el render publico va contra el plan free de Labelary (1 req/s
-      // para toda la plataforma). El limite global es deliberadamente
-      // inalcanzable — con 'default' en 100 req/min el techo real ya es 6.000/h
-      // — para no meterle un rate limit nuevo a quien esta autenticado, que
-      // ademas comparte IP con sus companeros detras de cualquier NAT.
-      {
-        name: 'hourly',
-        ttl: 3600000,
-        limit: 100000,
-      },
-      // Ventanas por IP de origen real (el salto que no se puede falsificar).
-      // Mismo motivo y mismo limite inerte que 'hourly': solo existen para que
-      // las rutas publicas puedan bajarlas con @Throttle, ya que el guard solo
-      // evalua los throttlers declarados aqui.
-      {
-        name: 'peerMinute',
-        ttl: 60000,
-        limit: 100000,
-      },
-      {
-        name: 'peerHourly',
-        ttl: 3600000,
-        limit: 100000,
       },
     ]),
     AuthModule,

--- a/src/common/guards/bounded-throttler.storage.spec.ts
+++ b/src/common/guards/bounded-throttler.storage.spec.ts
@@ -28,6 +28,7 @@ describe('BoundedThrottlerStorage', () => {
   });
 
   it('no crece por encima del tope aunque las identidades sean infinitas', async () => {
+    jest.useFakeTimers();
     const storage = buildStorage(5);
 
     // Lo que hace un cliente que rota el X-Forwarded-For en cada peticion.
@@ -36,10 +37,45 @@ describe('BoundedThrottlerStorage', () => {
     }
 
     expect(storage.storage.size).toBeLessThanOrEqual(5);
+    expect(jest.getTimerCount()).toBeLessThanOrEqual(5);
     storage.onApplicationShutdown();
   });
 
+  it('cancela los timers de una clave al expulsarla', async () => {
+    jest.useFakeTimers();
+    const storage = buildStorage(1);
+
+    await storage.increment('expulsada', TTL, 5, 0, 'test');
+    await storage.increment('expulsada', TTL, 5, 0, 'test');
+    await storage.increment('vigente', TTL, 5, 0, 'test');
+
+    expect(storage.storage.has('expulsada')).toBe(false);
+    expect(storage.storage.has('vigente')).toBe(true);
+    expect(jest.getTimerCount()).toBe(1);
+
+    // El callback de la clave expulsada ya no puede ejecutarse sobre undefined.
+    jest.advanceTimersByTime(TTL);
+    expect(storage.storage.size).toBe(0);
+    expect(jest.getTimerCount()).toBe(0);
+    storage.onApplicationShutdown();
+  });
+
+  it('cancela todos los timers pendientes al cerrar la aplicacion', async () => {
+    jest.useFakeTimers();
+    const storage = buildStorage(10);
+
+    await storage.increment('a', TTL, 5, 0, 'test');
+    await storage.increment('b', TTL, 5, 0, 'test');
+    expect(jest.getTimerCount()).toBe(2);
+
+    storage.onApplicationShutdown();
+
+    expect(jest.getTimerCount()).toBe(0);
+    expect(storage.storage.size).toBe(0);
+  });
+
   it('expulsa las identidades inventadas antes que el contador que está frenando el abuso', async () => {
+    jest.useFakeTimers();
     const storage = buildStorage(3);
 
     // El contador de verdad se toca en cada peticion; los inventados, una vez.

--- a/src/common/guards/bounded-throttler.storage.spec.ts
+++ b/src/common/guards/bounded-throttler.storage.spec.ts
@@ -1,0 +1,58 @@
+import {
+  BoundedThrottlerStorage,
+  BOUNDED_THROTTLER_MAX_KEYS,
+} from './bounded-throttler.storage.js';
+
+const TTL = 60000;
+
+const buildStorage = (maxKeys: number) => {
+  const storage = new BoundedThrottlerStorage();
+  storage.maxKeys = maxKeys;
+  return storage;
+};
+
+describe('BoundedThrottlerStorage', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('cuenta como el storage de siempre mientras cabe', async () => {
+    const storage = buildStorage(10);
+
+    const primera = await storage.increment('a', TTL, 5, 0, 'test');
+    const segunda = await storage.increment('a', TTL, 5, 0, 'test');
+
+    expect(primera.totalHits).toBe(1);
+    expect(segunda.totalHits).toBe(2);
+    storage.onApplicationShutdown();
+  });
+
+  it('no crece por encima del tope aunque las identidades sean infinitas', async () => {
+    const storage = buildStorage(5);
+
+    // Lo que hace un cliente que rota el X-Forwarded-For en cada peticion.
+    for (let i = 0; i < 200; i++) {
+      await storage.increment(`inventada-${i}`, TTL, 5, 0, 'test');
+    }
+
+    expect(storage.storage.size).toBeLessThanOrEqual(5);
+    storage.onApplicationShutdown();
+  });
+
+  it('expulsa las identidades inventadas antes que el contador que está frenando el abuso', async () => {
+    const storage = buildStorage(3);
+
+    // El contador de verdad se toca en cada peticion; los inventados, una vez.
+    for (let i = 0; i < 50; i++) {
+      await storage.increment('hop:198.51.100.7', TTL, 100, 0, 'peer');
+      await storage.increment(`client:203.0.113.${i}`, TTL, 100, 0, 'client');
+    }
+
+    expect(storage.storage.has('hop:198.51.100.7')).toBe(true);
+    storage.onApplicationShutdown();
+  });
+
+  it('el tope por defecto deja sitio de sobra para trafico honesto', () => {
+    expect(BOUNDED_THROTTLER_MAX_KEYS).toBeGreaterThanOrEqual(1000);
+  });
+});

--- a/src/common/guards/bounded-throttler.storage.ts
+++ b/src/common/guards/bounded-throttler.storage.ts
@@ -1,7 +1,10 @@
-import { Injectable, OnApplicationShutdown } from '@nestjs/common';
-import { ThrottlerStorageService } from '@nestjs/throttler';
+import { Injectable } from '@nestjs/common';
+import type { OnApplicationShutdown } from '@nestjs/common';
 import type { ThrottlerStorage } from '@nestjs/throttler';
+import type { ThrottlerStorageOptions } from '@nestjs/throttler/dist/throttler-storage-options.interface.js';
 import type { ThrottlerStorageRecord } from '@nestjs/throttler/dist/throttler-storage-record.interface.js';
+
+type TimeoutId = ReturnType<typeof setTimeout>;
 
 /**
  * Claves vivas como maximo. Cada una es una entrada pequeña de un Map, asi que
@@ -12,21 +15,24 @@ export const BOUNDED_THROTTLER_MAX_KEYS = 10000;
 
 /**
  * `ThrottlerStorageService` expira los contadores pero NUNCA borra keys de su
- * Map (limitacion ya documentada en `CustomThrottlerGuard`). En una ruta
- * autenticada eso crece despacio; en una publica donde parte de la identidad la
- * elige el cliente —la IP que declara en `X-Forwarded-For`— crece tan rapido
- * como se pidan peticiones, y agotar memoria pasa a ser un ataque sin login.
+ * Map (limitacion ya documentada en `CustomThrottlerGuard`). Ademas agrupa los
+ * timers solo por nombre de throttler, por lo que no permite cancelar de forma
+ * selectiva los de una clave expulsada. En una ruta publica donde parte de la
+ * identidad la elige el cliente —la IP que declara en `X-Forwarded-For`— ambas
+ * cosas permiten que un ataque sin login siga reteniendo memoria.
  *
- * Este storage envuelve al de siempre y le añade expulsion LRU: cada acceso
- * reinserta la clave al final del Map, asi que lo que se descarta al pasarse
- * del tope son siempre las identidades inventadas que nadie vuelve a usar, no
+ * Este storage conserva el contrato y la semantica de ventanas del original,
+ * pero gestiona cada timer junto a su clave. Tambien añade expulsion LRU: cada
+ * acceso reinserta la clave al final del Map, asi que lo que se descarta al
+ * pasarse del tope son las identidades inventadas que nadie vuelve a usar, no
  * los contadores activos que estan conteniendo un abuso.
  */
 @Injectable()
 export class BoundedThrottlerStorage
   implements ThrottlerStorage, OnApplicationShutdown
 {
-  private readonly inner = new ThrottlerStorageService();
+  private readonly entries = new Map<string, ThrottlerStorageOptions>();
+  private readonly timeoutIds = new Map<string, Map<string, Set<TimeoutId>>>();
 
   /**
    * Propiedad y no parametro de constructor: Nest instancia este storage como
@@ -36,7 +42,7 @@ export class BoundedThrottlerStorage
   maxKeys: number = BOUNDED_THROTTLER_MAX_KEYS;
 
   get storage() {
-    return this.inner.storage;
+    return this.entries;
   }
 
   async increment(
@@ -46,39 +52,178 @@ export class BoundedThrottlerStorage
     blockDuration: number,
     throttlerName: string,
   ): Promise<ThrottlerStorageRecord> {
-    const record = await this.inner.increment(
-      key,
-      ttl,
-      limit,
-      blockDuration,
-      throttlerName,
-    );
+    if (!this.entries.has(key)) {
+      this.entries.set(key, {
+        totalHits: new Map([[throttlerName, 0]]),
+        expiresAt: Date.now() + ttl,
+        blockExpiresAt: 0,
+        isBlocked: false,
+      });
+    }
+
+    const entry = this.entries.get(key)!;
+    if (!entry.totalHits.has(throttlerName)) {
+      entry.totalHits.set(throttlerName, 0);
+    }
+
+    let timeToExpire = this.getExpirationTime(entry);
+    if (timeToExpire <= 0) {
+      entry.expiresAt = Date.now() + ttl;
+      timeToExpire = this.getExpirationTime(entry);
+    }
+
+    if (!entry.isBlocked) {
+      this.fireHitCount(key, entry, throttlerName, ttl);
+    }
+
+    if ((entry.totalHits.get(throttlerName) ?? 0) > limit && !entry.isBlocked) {
+      entry.isBlocked = true;
+      entry.blockExpiresAt = Date.now() + blockDuration;
+    }
+
+    let timeToBlockExpire = this.getBlockExpirationTime(entry);
+    if (timeToBlockExpire <= 0 && entry.isBlocked) {
+      this.resetBlockedRequest(key, entry, throttlerName);
+      this.fireHitCount(key, entry, throttlerName, ttl);
+      timeToBlockExpire = this.getBlockExpirationTime(entry);
+    }
 
     this.touch(key);
     this.evictOldest();
 
-    return record;
+    return {
+      totalHits: entry.totalHits.get(throttlerName) ?? 0,
+      timeToExpire,
+      isBlocked: entry.isBlocked,
+      timeToBlockExpire,
+    };
   }
 
   /** Reinsertar mueve la clave al final del orden de iteracion del Map. */
   private touch(key: string): void {
-    const value = this.inner.storage.get(key);
+    const value = this.entries.get(key);
     if (value === undefined) return;
-    this.inner.storage.delete(key);
-    this.inner.storage.set(key, value);
+    this.entries.delete(key);
+    this.entries.set(key, value);
   }
 
   private evictOldest(): void {
-    const map = this.inner.storage;
-    if (map.size <= this.maxKeys) return;
+    if (this.entries.size <= this.maxKeys) return;
 
-    for (const oldest of map.keys()) {
-      map.delete(oldest);
-      if (map.size <= this.maxKeys) break;
+    for (const oldest of this.entries.keys()) {
+      this.deleteEntry(oldest);
+      if (this.entries.size <= this.maxKeys) break;
     }
   }
 
   onApplicationShutdown(): void {
-    this.inner.onApplicationShutdown();
+    for (const key of this.timeoutIds.keys()) {
+      this.clearExpirationTimes(key);
+    }
+    this.entries.clear();
+  }
+
+  private getExpirationTime(entry: ThrottlerStorageOptions): number {
+    return Math.ceil((entry.expiresAt - Date.now()) / 1000);
+  }
+
+  private getBlockExpirationTime(entry: ThrottlerStorageOptions): number {
+    return Math.ceil((entry.blockExpiresAt - Date.now()) / 1000);
+  }
+
+  private fireHitCount(
+    key: string,
+    entry: ThrottlerStorageOptions,
+    throttlerName: string,
+    ttl: number,
+  ): void {
+    entry.totalHits.set(
+      throttlerName,
+      (entry.totalHits.get(throttlerName) ?? 0) + 1,
+    );
+
+    const timeoutId = setTimeout(() => {
+      this.removeTimeoutId(key, throttlerName, timeoutId);
+
+      const current = this.entries.get(key);
+      if (current === undefined) return;
+
+      const remainingHits = Math.max(
+        0,
+        (current.totalHits.get(throttlerName) ?? 0) - 1,
+      );
+      current.totalHits.set(throttlerName, remainingHits);
+
+      if (
+        !current.isBlocked &&
+        [...current.totalHits.values()].every((hits) => hits === 0)
+      ) {
+        this.deleteEntry(key);
+      }
+    }, ttl);
+
+    this.getTimeoutIds(key, throttlerName).add(timeoutId);
+  }
+
+  private resetBlockedRequest(
+    key: string,
+    entry: ThrottlerStorageOptions,
+    throttlerName: string,
+  ): void {
+    entry.isBlocked = false;
+    entry.totalHits.set(throttlerName, 0);
+    this.clearExpirationTimes(key, throttlerName);
+  }
+
+  private getTimeoutIds(key: string, throttlerName: string): Set<TimeoutId> {
+    let byThrottler = this.timeoutIds.get(key);
+    if (byThrottler === undefined) {
+      byThrottler = new Map();
+      this.timeoutIds.set(key, byThrottler);
+    }
+
+    let ids = byThrottler.get(throttlerName);
+    if (ids === undefined) {
+      ids = new Set();
+      byThrottler.set(throttlerName, ids);
+    }
+
+    return ids;
+  }
+
+  private removeTimeoutId(
+    key: string,
+    throttlerName: string,
+    timeoutId: TimeoutId,
+  ): void {
+    const byThrottler = this.timeoutIds.get(key);
+    const ids = byThrottler?.get(throttlerName);
+    if (ids === undefined) return;
+
+    ids.delete(timeoutId);
+    if (ids.size === 0) byThrottler!.delete(throttlerName);
+    if (byThrottler!.size === 0) this.timeoutIds.delete(key);
+  }
+
+  private clearExpirationTimes(key: string, throttlerName?: string): void {
+    const byThrottler = this.timeoutIds.get(key);
+    if (byThrottler === undefined) return;
+
+    if (throttlerName !== undefined) {
+      byThrottler.get(throttlerName)?.forEach(clearTimeout);
+      byThrottler.delete(throttlerName);
+      if (byThrottler.size === 0) this.timeoutIds.delete(key);
+      return;
+    }
+
+    for (const ids of byThrottler.values()) {
+      ids.forEach(clearTimeout);
+    }
+    this.timeoutIds.delete(key);
+  }
+
+  private deleteEntry(key: string): void {
+    this.clearExpirationTimes(key);
+    this.entries.delete(key);
   }
 }

--- a/src/common/guards/bounded-throttler.storage.ts
+++ b/src/common/guards/bounded-throttler.storage.ts
@@ -1,0 +1,84 @@
+import { Injectable, OnApplicationShutdown } from '@nestjs/common';
+import { ThrottlerStorageService } from '@nestjs/throttler';
+import type { ThrottlerStorage } from '@nestjs/throttler';
+import type { ThrottlerStorageRecord } from '@nestjs/throttler/dist/throttler-storage-record.interface.js';
+
+/**
+ * Claves vivas como maximo. Cada una es una entrada pequeña de un Map, asi que
+ * el tope existe para acotar el peor caso, no para ajustar el uso normal: una
+ * ruta publica con trafico honesto no pasa de unos cientos.
+ */
+export const BOUNDED_THROTTLER_MAX_KEYS = 10000;
+
+/**
+ * `ThrottlerStorageService` expira los contadores pero NUNCA borra keys de su
+ * Map (limitacion ya documentada en `CustomThrottlerGuard`). En una ruta
+ * autenticada eso crece despacio; en una publica donde parte de la identidad la
+ * elige el cliente —la IP que declara en `X-Forwarded-For`— crece tan rapido
+ * como se pidan peticiones, y agotar memoria pasa a ser un ataque sin login.
+ *
+ * Este storage envuelve al de siempre y le añade expulsion LRU: cada acceso
+ * reinserta la clave al final del Map, asi que lo que se descarta al pasarse
+ * del tope son siempre las identidades inventadas que nadie vuelve a usar, no
+ * los contadores activos que estan conteniendo un abuso.
+ */
+@Injectable()
+export class BoundedThrottlerStorage
+  implements ThrottlerStorage, OnApplicationShutdown
+{
+  private readonly inner = new ThrottlerStorageService();
+
+  /**
+   * Propiedad y no parametro de constructor: Nest instancia este storage como
+   * provider y trataria un `maxKeys: number` como una dependencia mas que
+   * inyectar. Los tests la bajan despues de construir.
+   */
+  maxKeys: number = BOUNDED_THROTTLER_MAX_KEYS;
+
+  get storage() {
+    return this.inner.storage;
+  }
+
+  async increment(
+    key: string,
+    ttl: number,
+    limit: number,
+    blockDuration: number,
+    throttlerName: string,
+  ): Promise<ThrottlerStorageRecord> {
+    const record = await this.inner.increment(
+      key,
+      ttl,
+      limit,
+      blockDuration,
+      throttlerName,
+    );
+
+    this.touch(key);
+    this.evictOldest();
+
+    return record;
+  }
+
+  /** Reinsertar mueve la clave al final del orden de iteracion del Map. */
+  private touch(key: string): void {
+    const value = this.inner.storage.get(key);
+    if (value === undefined) return;
+    this.inner.storage.delete(key);
+    this.inner.storage.set(key, value);
+  }
+
+  private evictOldest(): void {
+    const map = this.inner.storage;
+    if (map.size <= this.maxKeys) return;
+
+    for (const oldest of map.keys()) {
+      map.delete(oldest);
+      if (map.size <= this.maxKeys) break;
+    }
+  }
+
+  onApplicationShutdown(): void {
+    this.inner.onApplicationShutdown();
+  }
+}

--- a/src/common/guards/public-preview-throttler.guard.spec.ts
+++ b/src/common/guards/public-preview-throttler.guard.spec.ts
@@ -44,14 +44,53 @@ describe('PublicPreviewThrottlerGuard', () => {
     jest.useRealTimers();
   });
 
-  it('evalúa primero las ventanas que no se pueden falsificar', async () => {
+  // El guard incrementa el contador de cada throttler que evalúa y lanza en el
+  // primero que se pasa, así que lo que va delante consume cupo aunque la
+  // petición acabe rechazada. El visitante va primero para que sus 429 no
+  // gasten el cubo que comparte con todos los demás.
+  it('evalúa primero las ventanas del visitante y solo después las agregadas', async () => {
     const { guard, storage } = buildGuard();
 
     await guard.onModuleInit();
 
     const nombres = (guard as any).throttlers.map((t: any) => t.name);
-    expect(nombres[0]).toContain('Peer');
-    expect(nombres[1]).toContain('Peer');
+    expect(nombres).toEqual([
+      'publicPreviewClientMinute',
+      'publicPreviewClientHourly',
+      'publicPreviewPeerMinute',
+      'publicPreviewPeerHourly',
+    ]);
+    storage.onApplicationShutdown();
+  });
+
+  it('las peticiones que rechaza el tope del visitante no gastan cupo agregado', async () => {
+    jest.useFakeTimers();
+    const { guard, storage } = buildGuard();
+    await guard.onModuleInit();
+    const peer = '198.51.100.7';
+    const abusivo = buildContext(`203.0.113.10, ${peer}`);
+
+    for (let i = 0; i < PUBLIC_PREVIEW_THROTTLERS.clientMinute.limit; i++) {
+      await expect(guard.canActivate(abusivo)).resolves.toBe(true);
+    }
+
+    // Justo las que agotarían el cubo agregado si los rechazos contaran: 6
+    // aceptadas + 9 rechazadas = las 15 del tope por origen.
+    const rechazadas =
+      PUBLIC_PREVIEW_THROTTLERS.peerMinute.limit -
+      PUBLIC_PREVIEW_THROTTLERS.clientMinute.limit;
+    for (let i = 0; i < rechazadas; i++) {
+      await expect(guard.canActivate(abusivo)).rejects.toBeInstanceOf(
+        ThrottlerException,
+      );
+    }
+
+    // Otro visitante del mismo salto sigue teniendo su cuota entera: el
+    // abusivo solo se ha gastado sus 6 peticiones buenas del agregado.
+    const otroVisitante = buildContext(`203.0.113.11, ${peer}`);
+    for (let i = 0; i < PUBLIC_PREVIEW_THROTTLERS.clientMinute.limit; i++) {
+      await expect(guard.canActivate(otroVisitante)).resolves.toBe(true);
+    }
     storage.onApplicationShutdown();
   });
 
@@ -108,9 +147,11 @@ describe('PublicPreviewThrottlerGuard', () => {
       ThrottlerException,
     );
 
-    // La peticion bloqueada se corta en el tracker de origen, antes de crear
-    // los dos contadores correspondientes a la nueva IP declarada.
-    expect(storage.storage.size).toBe(32);
+    // 15 IPs declaradas x 2 ventanas de visitante + las 2 agregadas, mas las 2
+    // que estrena la IP de la peticion bloqueada: el visitante se evalua antes,
+    // asi que su contador se crea aunque el corte lo acabe dando el agregado.
+    // Ese crecimiento lo acota el storage, no el orden (ver BoundedThrottlerStorage).
+    expect(storage.storage.size).toBe(34);
     storage.onApplicationShutdown();
   });
 });

--- a/src/common/guards/public-preview-throttler.guard.spec.ts
+++ b/src/common/guards/public-preview-throttler.guard.spec.ts
@@ -5,6 +5,8 @@ import {
 } from './public-preview-throttler.guard.js';
 import { BoundedThrottlerStorage } from './bounded-throttler.storage.js';
 import { PUBLIC_PREVIEW_MAX_UNIQUE_LABELS } from '../../modules/zpl/dto/public-preview.dto.js';
+import { Reflector } from '@nestjs/core';
+import { ThrottlerException } from '@nestjs/throttler';
 
 /** Techo del plan free de Labelary: 1 req/s = 60 llamadas por minuto. */
 const LLAMADAS_LABELARY_POR_MINUTO = 60;
@@ -12,7 +14,7 @@ const LLAMADAS_LABELARY_POR_MINUTO = 60;
 describe('PublicPreviewThrottlerGuard', () => {
   const buildGuard = () => {
     const storage = new BoundedThrottlerStorage();
-    const reflector: any = { getAllAndOverride: jest.fn() };
+    const reflector = new Reflector();
     const guard = new PublicPreviewThrottlerGuard(
       publicPreviewThrottlerOptions,
       storage,
@@ -20,6 +22,27 @@ describe('PublicPreviewThrottlerGuard', () => {
     );
     return { guard, storage };
   };
+
+  const buildContext = (forwardedFor: string) => {
+    const request = {
+      headers: { 'x-forwarded-for': forwardedFor },
+      socket: { remoteAddress: '127.0.0.1' },
+    };
+    const response = { header: jest.fn() };
+
+    return {
+      getClass: () => class ZplController {},
+      getHandler: () => function publicPreview() {},
+      switchToHttp: () => ({
+        getRequest: () => request,
+        getResponse: () => response,
+      }),
+    } as any;
+  };
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
 
   it('evalúa primero las ventanas que no se pueden falsificar', async () => {
     const { guard, storage } = buildGuard();
@@ -51,5 +74,43 @@ describe('PublicPreviewThrottlerGuard', () => {
     expect(PUBLIC_PREVIEW_THROTTLERS.clientHourly.limit).toBeLessThan(
       PUBLIC_PREVIEW_THROTTLERS.peerHourly.limit,
     );
+  });
+
+  it('corta en la peticion 7 cuando el visitante mantiene su IP', async () => {
+    jest.useFakeTimers();
+    const { guard, storage } = buildGuard();
+    await guard.onModuleInit();
+    const context = buildContext('203.0.113.10, 198.51.100.7');
+
+    for (let i = 0; i < PUBLIC_PREVIEW_THROTTLERS.clientMinute.limit; i++) {
+      await expect(guard.canActivate(context)).resolves.toBe(true);
+    }
+
+    await expect(guard.canActivate(context)).rejects.toBeInstanceOf(
+      ThrottlerException,
+    );
+    storage.onApplicationShutdown();
+  });
+
+  it('corta en la peticion 16 aunque rote la IP declarada', async () => {
+    jest.useFakeTimers();
+    const { guard, storage } = buildGuard();
+    await guard.onModuleInit();
+    const peer = '198.51.100.7';
+
+    for (let i = 0; i < PUBLIC_PREVIEW_THROTTLERS.peerMinute.limit; i++) {
+      const context = buildContext(`203.0.113.${i}, ${peer}`);
+      await expect(guard.canActivate(context)).resolves.toBe(true);
+    }
+
+    const bloqueada = buildContext(`203.0.113.200, ${peer}`);
+    await expect(guard.canActivate(bloqueada)).rejects.toBeInstanceOf(
+      ThrottlerException,
+    );
+
+    // La peticion bloqueada se corta en el tracker de origen, antes de crear
+    // los dos contadores correspondientes a la nueva IP declarada.
+    expect(storage.storage.size).toBe(32);
+    storage.onApplicationShutdown();
   });
 });

--- a/src/common/guards/public-preview-throttler.guard.spec.ts
+++ b/src/common/guards/public-preview-throttler.guard.spec.ts
@@ -1,0 +1,55 @@
+import { PublicPreviewThrottlerGuard } from './public-preview-throttler.guard.js';
+import {
+  PUBLIC_PREVIEW_THROTTLERS,
+  publicPreviewThrottlerOptions,
+} from './public-preview-throttler.guard.js';
+import { BoundedThrottlerStorage } from './bounded-throttler.storage.js';
+import { PUBLIC_PREVIEW_MAX_UNIQUE_LABELS } from '../../modules/zpl/dto/public-preview.dto.js';
+
+/** Techo del plan free de Labelary: 1 req/s = 60 llamadas por minuto. */
+const LLAMADAS_LABELARY_POR_MINUTO = 60;
+
+describe('PublicPreviewThrottlerGuard', () => {
+  const buildGuard = () => {
+    const storage = new BoundedThrottlerStorage();
+    const reflector: any = { getAllAndOverride: jest.fn() };
+    const guard = new PublicPreviewThrottlerGuard(
+      publicPreviewThrottlerOptions,
+      storage,
+      reflector,
+    );
+    return { guard, storage };
+  };
+
+  it('evalúa primero las ventanas que no se pueden falsificar', async () => {
+    const { guard, storage } = buildGuard();
+
+    await guard.onModuleInit();
+
+    const nombres = (guard as any).throttlers.map((t: any) => t.name);
+    expect(nombres[0]).toContain('Peer');
+    expect(nombres[1]).toContain('Peer');
+    storage.onApplicationShutdown();
+  });
+
+  it('el tope agregado deja a Labelary la mitad de su capacidad libre', () => {
+    // Cada peticion anonima renderiza hasta N etiquetas y cada etiqueta es una
+    // llamada: lo que hay que comparar con el techo son las llamadas.
+    const llamadasPorMinuto =
+      PUBLIC_PREVIEW_THROTTLERS.peerMinute.limit *
+      PUBLIC_PREVIEW_MAX_UNIQUE_LABELS;
+
+    expect(llamadasPorMinuto).toBeLessThanOrEqual(
+      LLAMADAS_LABELARY_POR_MINUTO / 2,
+    );
+  });
+
+  it('un solo visitante no puede vaciar el cubo agregado', () => {
+    expect(PUBLIC_PREVIEW_THROTTLERS.clientMinute.limit).toBeLessThan(
+      PUBLIC_PREVIEW_THROTTLERS.peerMinute.limit,
+    );
+    expect(PUBLIC_PREVIEW_THROTTLERS.clientHourly.limit).toBeLessThan(
+      PUBLIC_PREVIEW_THROTTLERS.peerHourly.limit,
+    );
+  });
+});

--- a/src/common/guards/public-preview-throttler.guard.ts
+++ b/src/common/guards/public-preview-throttler.guard.ts
@@ -1,0 +1,110 @@
+import { Inject, Injectable } from '@nestjs/common';
+import type { Provider } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ThrottlerGuard, ThrottlerStorageService } from '@nestjs/throttler';
+// Son interfaces: en ESM hay que importarlas como tipo o el arranque muere con
+// "does not provide an export named ...".
+import type {
+  ThrottlerModuleOptions,
+  ThrottlerStorage,
+} from '@nestjs/throttler';
+import { getClientDeclaredIp, getTrustedHopIp } from '../utils/request-ip.js';
+
+/**
+ * Ventanas del endpoint publico de vista previa. Son dos identidades porque
+ * ninguna sirve sola:
+ *
+ * - La IP que declara el cliente segmenta bien el trafico legitimo (todos los
+ *   visitantes entran por el rewrite del frontend y comparten salto), pero es
+ *   falsificable: quien llame directo al servicio de Cloud Run puede mandar un
+ *   `X-Forwarded-For` distinto en cada peticion y estrenar contador.
+ * - La IP del salto de confianza no se puede falsificar, pero agrupa a todos
+ *   los visitantes que comparten edge.
+ *
+ * Asi que la primera lleva el tope por visitante y la segunda el tope agregado,
+ * que es el que de verdad protege el techo compartido de Labelary (plan free:
+ * 1 req/s para toda la plataforma).
+ */
+export const PUBLIC_PREVIEW_THROTTLERS = {
+  clientMinute: { limit: 10, ttl: 60000 },
+  clientHourly: { limit: 30, ttl: 3600000 },
+  peerMinute: { limit: 60, ttl: 60000 },
+  peerHourly: { limit: 600, ttl: 3600000 },
+} as const;
+
+/** Token de las opciones del guard. */
+export const PUBLIC_PREVIEW_THROTTLER_OPTIONS = Symbol(
+  'PUBLIC_PREVIEW_THROTTLER_OPTIONS',
+);
+
+/** Token del storage exclusivo del guard, para no compartir el Map global. */
+export const PUBLIC_PREVIEW_THROTTLER_STORAGE = Symbol(
+  'PUBLIC_PREVIEW_THROTTLER_STORAGE',
+);
+
+export const publicPreviewThrottlerOptions: ThrottlerModuleOptions = {
+  throttlers: [
+    {
+      name: 'publicPreviewClientMinute',
+      ...PUBLIC_PREVIEW_THROTTLERS.clientMinute,
+      getTracker: (req) => `client:${getClientDeclaredIp(req)}`,
+    },
+    {
+      name: 'publicPreviewClientHourly',
+      ...PUBLIC_PREVIEW_THROTTLERS.clientHourly,
+      getTracker: (req) => `client:${getClientDeclaredIp(req)}`,
+    },
+    {
+      name: 'publicPreviewPeerMinute',
+      ...PUBLIC_PREVIEW_THROTTLERS.peerMinute,
+      getTracker: (req) => `hop:${getTrustedHopIp(req)}`,
+    },
+    {
+      name: 'publicPreviewPeerHourly',
+      ...PUBLIC_PREVIEW_THROTTLERS.peerHourly,
+      getTracker: (req) => `hop:${getTrustedHopIp(req)}`,
+    },
+  ],
+};
+
+/**
+ * Guard de rate limit exclusivo de `POST /zpl/public-preview`.
+ *
+ * Va con opciones y storage PROPIOS en vez de declarar throttlers extra en
+ * `ThrottlerModule.forRoot`: el guard global evalua todos los throttlers
+ * declarados ahi en TODAS las rutas, asi que unas ventanas auxiliares —aunque
+ * su limite global fuera inalcanzable— multiplicarian por cuatro las claves que
+ * cada `status/:jobId` y cada batch dejan en el storage in-memory, que nunca
+ * borra keys del Map (ver `CustomThrottlerGuard`). Con storage propio, el coste
+ * se queda en las IPs que usan esta ruta.
+ *
+ * Los `@Inject` explicitos NO son decorativos: `ThrottlerGuard` decora sus dos
+ * primeros parametros con los tokens del modulo global, y esa metadata se
+ * hereda. Sin sobrescribirla, Nest inyecta aqui las opciones globales y el
+ * storage global en las posiciones equivocadas y el guard revienta en la
+ * primera peticion.
+ */
+@Injectable()
+export class PublicPreviewThrottlerGuard extends ThrottlerGuard {
+  constructor(
+    @Inject(PUBLIC_PREVIEW_THROTTLER_OPTIONS) options: ThrottlerModuleOptions,
+    @Inject(PUBLIC_PREVIEW_THROTTLER_STORAGE) storage: ThrottlerStorage,
+    reflector: Reflector,
+  ) {
+    super(options, storage, reflector);
+  }
+}
+
+export const publicPreviewThrottlerProviders: Provider[] = [
+  {
+    provide: PUBLIC_PREVIEW_THROTTLER_OPTIONS,
+    useValue: publicPreviewThrottlerOptions,
+  },
+  // Como provider y no como `new` suelto: asi Nest le aplica su
+  // `onApplicationShutdown` y limpia los timers de expiracion al cerrar.
+  {
+    provide: PUBLIC_PREVIEW_THROTTLER_STORAGE,
+    useClass: ThrottlerStorageService,
+  },
+  PublicPreviewThrottlerGuard,
+];

--- a/src/common/guards/public-preview-throttler.guard.ts
+++ b/src/common/guards/public-preview-throttler.guard.ts
@@ -87,11 +87,21 @@ export const publicPreviewThrottlerOptions: ThrottlerModuleOptions = {
  * borra keys del Map (ver `CustomThrottlerGuard`). Con storage propio, el coste
  * se queda en las IPs que usan esta ruta.
  *
- * El orden de evaluacion tambien importa: `ThrottlerGuard` recorre los
- * throttlers y lanza en el primero que se pase, asi que las ventanas por
- * identidad NO falsificable van delante. Quien rote el `X-Forwarded-For` recibe
- * su 429 antes de que la identidad que se acaba de inventar llegue a ocupar
- * sitio en el storage.
+ * El orden de evaluacion importa, y va al reves de lo que parece: `ThrottlerGuard`
+ * recorre los throttlers, incrementa el contador de cada uno y lanza en el
+ * primero que se pase, asi que TODO lo que se evalue antes del que rechaza ya ha
+ * consumido cupo. Por eso las ventanas por visitante van primero: si fuera al
+ * reves, las peticiones que se rechazan por el tope del visitante seguirian
+ * gastando el cubo agregado, y a un solo visitante le bastarian 6 peticiones
+ * buenas mas 9 rechazadas para agotar el minuto compartido y dejar sin vista
+ * previa a TODOS los que comparten salto — un DoS de 15 peticiones contra la
+ * pagina que este endpoint venia a abrir.
+ *
+ * Evaluar primero al visitante tiene una contrapartida conocida: quien rote el
+ * `X-Forwarded-For` estrena clave en cada peticion antes de que el tope
+ * agregado le corte. Eso lo acota `BoundedThrottlerStorage` con su expulsion
+ * LRU, que es donde ese problema se resuelve de verdad; el orden de evaluacion
+ * nunca fue la herramienta adecuada para ello.
  *
  * Los `@Inject` explicitos NO son decorativos: `ThrottlerGuard` decora sus dos
  * primeros parametros con los tokens del modulo global, y esa metadata se
@@ -112,17 +122,30 @@ export class PublicPreviewThrottlerGuard extends ThrottlerGuard {
   async onModuleInit(): Promise<void> {
     await super.onModuleInit();
 
-    // super ordena por ttl y deja el criterio sin definir entre ventanas con el
-    // mismo ttl. Las que cuentan sobre la identidad no falsificable van
-    // primero: ver el comentario de la clase.
+    // super ordena por ttl, que aqui no es el criterio que hace falta: lo que
+    // decide quien consume cupo es el orden, y el visitante va primero (ver el
+    // comentario de la clase). Un nombre que no este en la lista se queda al
+    // final en vez de romper el orden de los que si estan.
     this.throttlers.sort(
-      (a, b) => Number(isPeerThrottler(b)) - Number(isPeerThrottler(a)),
+      (a, b) => ordenDeEvaluacion(a.name) - ordenDeEvaluacion(b.name),
     );
   }
 }
 
-function isPeerThrottler(throttler: { name?: string }): boolean {
-  return throttler.name?.includes('Peer') ?? false;
+/**
+ * Orden explicito y no una heuristica sobre el nombre: quien anada una ventana
+ * nueva tiene que decidir a proposito si consume cupo agregado o no.
+ */
+const ORDEN_DE_EVALUACION = [
+  'publicPreviewClientMinute',
+  'publicPreviewClientHourly',
+  'publicPreviewPeerMinute',
+  'publicPreviewPeerHourly',
+];
+
+function ordenDeEvaluacion(name?: string): number {
+  const posicion = ORDEN_DE_EVALUACION.indexOf(name ?? '');
+  return posicion === -1 ? ORDEN_DE_EVALUACION.length : posicion;
 }
 
 export const publicPreviewThrottlerProviders: Provider[] = [

--- a/src/common/guards/public-preview-throttler.guard.ts
+++ b/src/common/guards/public-preview-throttler.guard.ts
@@ -1,7 +1,8 @@
 import { Inject, Injectable } from '@nestjs/common';
 import type { Provider } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { ThrottlerGuard, ThrottlerStorageService } from '@nestjs/throttler';
+import { ThrottlerGuard } from '@nestjs/throttler';
+import { BoundedThrottlerStorage } from './bounded-throttler.storage.js';
 // Son interfaces: en ESM hay que importarlas como tipo o el arranque muere con
 // "does not provide an export named ...".
 import type {
@@ -23,13 +24,21 @@ import { getClientDeclaredIp, getTrustedHopIp } from '../utils/request-ip.js';
  *
  * Asi que la primera lleva el tope por visitante y la segunda el tope agregado,
  * que es el que de verdad protege el techo compartido de Labelary (plan free:
- * 1 req/s para toda la plataforma).
+ * 1 req/s para toda la plataforma, o sea 60 llamadas/minuto).
+ *
+ * Los numeros del tope agregado se cuentan en LLAMADAS A LABELARY, no en
+ * peticiones: cada peticion anonima renderiza hasta
+ * `PUBLIC_PREVIEW_MAX_UNIQUE_LABELS` (2) etiquetas unicas, y cada etiqueta es
+ * una llamada. 15 peticiones/minuto son como mucho 30 llamadas/minuto — la
+ * mitad del techo — para que el trafico anonimo nunca pueda dejar sin cola a
+ * las conversiones de quien paga. En la hora, 300 peticiones son como mucho
+ * 600 llamadas, un 17% del techo sostenido.
  */
 export const PUBLIC_PREVIEW_THROTTLERS = {
-  clientMinute: { limit: 10, ttl: 60000 },
+  clientMinute: { limit: 6, ttl: 60000 },
   clientHourly: { limit: 30, ttl: 3600000 },
-  peerMinute: { limit: 60, ttl: 60000 },
-  peerHourly: { limit: 600, ttl: 3600000 },
+  peerMinute: { limit: 15, ttl: 60000 },
+  peerHourly: { limit: 300, ttl: 3600000 },
 } as const;
 
 /** Token de las opciones del guard. */
@@ -78,6 +87,12 @@ export const publicPreviewThrottlerOptions: ThrottlerModuleOptions = {
  * borra keys del Map (ver `CustomThrottlerGuard`). Con storage propio, el coste
  * se queda en las IPs que usan esta ruta.
  *
+ * El orden de evaluacion tambien importa: `ThrottlerGuard` recorre los
+ * throttlers y lanza en el primero que se pase, asi que las ventanas por
+ * identidad NO falsificable van delante. Quien rote el `X-Forwarded-For` recibe
+ * su 429 antes de que la identidad que se acaba de inventar llegue a ocupar
+ * sitio en el storage.
+ *
  * Los `@Inject` explicitos NO son decorativos: `ThrottlerGuard` decora sus dos
  * primeros parametros con los tokens del modulo global, y esa metadata se
  * hereda. Sin sobrescribirla, Nest inyecta aqui las opciones globales y el
@@ -93,6 +108,21 @@ export class PublicPreviewThrottlerGuard extends ThrottlerGuard {
   ) {
     super(options, storage, reflector);
   }
+
+  async onModuleInit(): Promise<void> {
+    await super.onModuleInit();
+
+    // super ordena por ttl y deja el criterio sin definir entre ventanas con el
+    // mismo ttl. Las que cuentan sobre la identidad no falsificable van
+    // primero: ver el comentario de la clase.
+    this.throttlers.sort(
+      (a, b) => Number(isPeerThrottler(b)) - Number(isPeerThrottler(a)),
+    );
+  }
+}
+
+function isPeerThrottler(throttler: { name?: string }): boolean {
+  return throttler.name?.includes('Peer') ?? false;
 }
 
 export const publicPreviewThrottlerProviders: Provider[] = [
@@ -104,7 +134,7 @@ export const publicPreviewThrottlerProviders: Provider[] = [
   // `onApplicationShutdown` y limpia los timers de expiracion al cerrar.
   {
     provide: PUBLIC_PREVIEW_THROTTLER_STORAGE,
-    useClass: ThrottlerStorageService,
+    useClass: BoundedThrottlerStorage,
   },
   PublicPreviewThrottlerGuard,
 ];

--- a/src/common/utils/request-ip.spec.ts
+++ b/src/common/utils/request-ip.spec.ts
@@ -1,0 +1,52 @@
+import { getClientDeclaredIp, getTrustedHopIp } from './request-ip.js';
+
+const req = (xff?: string | string[], remoteAddress = '10.0.0.1') => ({
+  headers: xff === undefined ? {} : { 'x-forwarded-for': xff },
+  socket: { remoteAddress },
+});
+
+describe('request-ip', () => {
+  describe('getTrustedHopIp', () => {
+    it('devuelve la IP que añade la infraestructura al final del XFF', () => {
+      // Cloud Run añade el peer real detrás de lo que mandara el cliente.
+      expect(getTrustedHopIp(req('203.0.113.9, 198.51.100.7'))).toBe(
+        '198.51.100.7',
+      );
+    });
+
+    it('ignora lo que el cliente se invente delante', () => {
+      const falsificado = getTrustedHopIp(
+        req('1.1.1.1, 2.2.2.2, 3.3.3.3, 198.51.100.7'),
+      );
+      const otroIntento = getTrustedHopIp(req('9.9.9.9, 198.51.100.7'));
+
+      // Da igual la cadena falsa: el tope agregado sigue cayendo en el mismo
+      // contador, que es justo lo que impide estrenar cuota por peticion.
+      expect(falsificado).toBe('198.51.100.7');
+      expect(otroIntento).toBe('198.51.100.7');
+    });
+
+    it('cae al socket cuando no hay XFF (desarrollo local)', () => {
+      expect(getTrustedHopIp(req(undefined, '::1'))).toBe('::1');
+      expect(getTrustedHopIp(req('', '::1'))).toBe('::1');
+    });
+
+    it('tolera el header repetido', () => {
+      expect(getTrustedHopIp(req(['1.1.1.1', '198.51.100.7']))).toBe(
+        '198.51.100.7',
+      );
+    });
+  });
+
+  describe('getClientDeclaredIp', () => {
+    it('devuelve la IP del visitante que reenvía el frontend', () => {
+      expect(getClientDeclaredIp(req('203.0.113.9, 198.51.100.7'))).toBe(
+        '203.0.113.9',
+      );
+    });
+
+    it('cae al socket cuando no hay XFF', () => {
+      expect(getClientDeclaredIp(req(undefined, '::1'))).toBe('::1');
+    });
+  });
+});

--- a/src/common/utils/request-ip.ts
+++ b/src/common/utils/request-ip.ts
@@ -1,0 +1,69 @@
+/**
+ * Identidades de red de una request, para rate limiting.
+ *
+ * Detras de Cloud Run el `X-Forwarded-For` que ve la app tiene esta forma:
+ *
+ *     X-Forwarded-For: <lo que mando el cliente>, <IP real del peer>
+ *
+ * La infraestructura de Google AÑADE la IP del peer TCP al final de lo que
+ * llegue; nunca lo reemplaza. Eso parte la cabecera en dos mitades con
+ * garantias muy distintas, y el rate limit publico usa las dos.
+ */
+
+interface RequestWithIp {
+  headers?: Record<string, string | string[] | undefined>;
+  socket?: { remoteAddress?: string };
+  ip?: string;
+}
+
+/**
+ * Saltos de infraestructura al final del `X-Forwarded-For`. Con el domain
+ * mapping de Cloud Run (api.zplpdf.com -> ghs.googlehosted.com) solo hay uno:
+ * la IP del peer. Si algun dia se mete un balanceador o Cloud Armor delante,
+ * este numero sube — si no, el tracker acabaria agrupando TODO el trafico en la
+ * IP del balanceador y devolviendo 429 a todo el mundo.
+ */
+const TRUSTED_HOPS = 1;
+
+function parseForwardedFor(req: RequestWithIp): string[] {
+  const raw = req.headers?.['x-forwarded-for'];
+  const value = Array.isArray(raw) ? raw.join(',') : raw;
+  return (value ?? '')
+    .split(',')
+    .map((ip) => ip.trim())
+    .filter(Boolean);
+}
+
+/**
+ * IP del salto de confianza: la que añade la infraestructura al final del
+ * `X-Forwarded-For`, es decir quien abrio la conexion de verdad (el edge de
+ * Vercel para el trafico del frontend, o el propio cliente si llama directo al
+ * servicio de Cloud Run).
+ *
+ * **No es falsificable**: lo que el cliente invente queda ANTES en la cabecera.
+ * Por eso es la identidad con la que se pone el tope agregado que protege el
+ * techo compartido de Labelary.
+ */
+export function getTrustedHopIp(req: RequestWithIp): string {
+  const chain = parseForwardedFor(req);
+  return (
+    chain[chain.length - TRUSTED_HOPS] ??
+    req.socket?.remoteAddress ??
+    req.ip ??
+    'unknown'
+  );
+}
+
+/**
+ * IP que el cliente dice tener: la primera entrada del `X-Forwarded-For`, que
+ * detras del rewrite del frontend es la del visitante.
+ *
+ * Sirve para SEGMENTAR (que un visitante no gaste la cuota de los demas que
+ * comparten edge), nunca como unico tope: quien llame directo al servicio de
+ * Cloud Run puede inventarse una distinta en cada peticion y estrenar contador.
+ * Siempre acompañada de un tope sobre `getTrustedHopIp`.
+ */
+export function getClientDeclaredIp(req: RequestWithIp): string {
+  const chain = parseForwardedFor(req);
+  return chain[0] ?? req.socket?.remoteAddress ?? req.ip ?? 'unknown';
+}

--- a/src/modules/zpl/dto/public-preview.dto.ts
+++ b/src/modules/zpl/dto/public-preview.dto.ts
@@ -1,0 +1,48 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsEnum,
+  MaxLength,
+} from 'class-validator';
+import { LabelSize } from '../enums/label-size.enum.js';
+
+/**
+ * Etiquetas únicas que renderiza como mucho una petición anónima.
+ *
+ * Cada etiqueta única es una petición al plan free de Labelary (1 req/s para
+ * TODA la plataforma), así que el tope protege capacidad, no facturación: el
+ * archivo completo sigue requiriendo cuenta. El frontend ya recorta a este
+ * mismo número (`ANONYMOUS_PREVIEW_LABEL_LIMIT`), pero el tope de verdad es
+ * este porque es el que no se puede saltar.
+ */
+export const PUBLIC_PREVIEW_MAX_UNIQUE_LABELS = 2;
+
+/** Tamaño máximo del ZPL aceptado en el endpoint público (caracteres). */
+export const PUBLIC_PREVIEW_MAX_ZPL_LENGTH = 50_000;
+
+export class PublicPreviewDto {
+  @ApiProperty({
+    description:
+      'Contenido ZPL a previsualizar (max 50.000 caracteres). Debe contener ^XA y ^XZ. ' +
+      `Solo se renderizan las primeras ${PUBLIC_PREVIEW_MAX_UNIQUE_LABELS} etiquetas unicas.`,
+    example: '^XA^A0N,50,50^FO20,20^FDHello World^FS^XZ',
+    maxLength: PUBLIC_PREVIEW_MAX_ZPL_LENGTH,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(PUBLIC_PREVIEW_MAX_ZPL_LENGTH)
+  zplContent: string;
+
+  @ApiProperty({
+    description: 'Tamano de la etiqueta (por defecto 2x1)',
+    example: LabelSize.TWO_BY_ONE,
+    enum: LabelSize,
+    default: LabelSize.TWO_BY_ONE,
+    required: false,
+  })
+  @IsEnum(LabelSize)
+  @IsOptional()
+  labelSize?: LabelSize;
+}

--- a/src/modules/zpl/services/labelary-queue.service.spec.ts
+++ b/src/modules/zpl/services/labelary-queue.service.spec.ts
@@ -78,3 +78,61 @@ describe('LabelaryQueueService — traducción de LabelSize a dimensiones de Lab
     });
   });
 });
+
+/**
+ * El plan free de Labelary admite 1 req/s para TODA la plataforma. Antes,
+ * `waitForRateLimit` leía `lastCallTime` y solo lo actualizaba DESPUÉS de
+ * dormir: varias previews concurrentes calculaban la misma espera, despertaban
+ * juntas y salían de golpe. Con el endpoint público (issue #108) esas ráfagas
+ * las puede provocar cualquier visitante.
+ */
+describe('LabelaryQueueService — el rate limit global serializa las llamadas concurrentes', () => {
+  function buildService(): LabelaryQueueService {
+    const labelaryAnalyticsService: any = {
+      trackSuccess: jest.fn().mockResolvedValue(undefined),
+      trackRateLimit: jest.fn().mockResolvedValue(undefined),
+      trackError: jest.fn().mockResolvedValue(undefined),
+    };
+    return new LabelaryQueueService(labelaryAnalyticsService);
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reparte en el tiempo tres peticiones lanzadas a la vez', async () => {
+    mockedAxios.post.mockResolvedValue({ data: Buffer.from('png') });
+    const service = buildService();
+    const momentos: number[] = [];
+    mockedAxios.post.mockImplementation(async () => {
+      momentos.push(Date.now());
+      return { data: Buffer.from('png') } as any;
+    });
+
+    await Promise.all([
+      service.enqueuePngDirect('^XA^FDuno^XZ', LabelSize.TWO_BY_ONE),
+      service.enqueuePngDirect('^XA^FDdos^XZ', LabelSize.TWO_BY_ONE),
+      service.enqueuePngDirect('^XA^FDtres^XZ', LabelSize.TWO_BY_ONE),
+    ]);
+
+    expect(momentos).toHaveLength(3);
+    momentos.sort((a, b) => a - b);
+    // Margen de 50 ms para el jitter del scheduler de timers.
+    expect(momentos[1] - momentos[0]).toBeGreaterThanOrEqual(950);
+    expect(momentos[2] - momentos[1]).toBeGreaterThanOrEqual(950);
+  }, 15000);
+
+  it('un turno que falla no rompe la cadena para los siguientes', async () => {
+    const service = buildService();
+    mockedAxios.post
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValue({ data: Buffer.from('png') } as any);
+
+    await expect(
+      service.enqueuePngDirect('^XA^XZ', LabelSize.TWO_BY_ONE),
+    ).rejects.toThrow();
+    await expect(
+      service.enqueuePngDirect('^XA^XZ', LabelSize.TWO_BY_ONE),
+    ).resolves.toBeInstanceOf(Buffer);
+  }, 15000);
+});

--- a/src/modules/zpl/services/labelary-queue.service.ts
+++ b/src/modules/zpl/services/labelary-queue.service.ts
@@ -41,6 +41,8 @@ export class LabelaryQueueService {
 
   // Rate limiting global
   private lastCallTime = 0;
+  /** Cola de turnos de `waitForRateLimit` (ver alli el porque). */
+  private rateLimitChain: Promise<void> = Promise.resolve();
   private isProcessing = false;
 
   constructor(
@@ -215,18 +217,33 @@ export class LabelaryQueueService {
   }
 
   /**
-   * Espera para respetar el rate limit global
+   * Espera para respetar el rate limit global.
+   *
+   * Los turnos se encadenan (`rateLimitChain`) en vez de calcularse cada uno
+   * por su cuenta: si N llamadas concurrentes leyeran `lastCallTime` a la vez
+   * —lo que pasa con varias previews simultaneas— todas calcularian la misma
+   * espera, despertarian juntas y saldrian de golpe hacia Labelary, que es
+   * exactamente lo que el limite de 1 req/s prohibe. Encadenando, cada llamada
+   * espera a que la anterior haya fijado `lastCallTime` antes de calcular la
+   * suya, y las N salen repartidas en el tiempo.
    */
   private async waitForRateLimit(): Promise<void> {
-    const now = Date.now();
-    const timeSinceLastCall = now - this.lastCallTime;
-    const waitTime = QUEUE_CONFIG.minTimeBetweenCallsMs - timeSinceLastCall;
+    const turn = this.rateLimitChain.then(async () => {
+      const waitTime =
+        QUEUE_CONFIG.minTimeBetweenCallsMs - (Date.now() - this.lastCallTime);
 
-    if (waitTime > 0) {
-      await new Promise((resolve) => setTimeout(resolve, waitTime));
-    }
+      if (waitTime > 0) {
+        await new Promise((resolve) => setTimeout(resolve, waitTime));
+      }
 
-    this.lastCallTime = Date.now();
+      this.lastCallTime = Date.now();
+    });
+
+    // La cadena nunca debe quedarse rota: si un turno fallara, los siguientes
+    // seguirian encolados detras de una promesa rechazada.
+    this.rateLimitChain = turn.catch(() => undefined);
+
+    return turn;
   }
 
   /**

--- a/src/modules/zpl/zpl.controller.spec.ts
+++ b/src/modules/zpl/zpl.controller.spec.ts
@@ -21,11 +21,7 @@ jest.mock('firebase-admin', () => ({
 
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { GUARDS_METADATA } from '@nestjs/common/constants.js';
-import {
-  THROTTLER_LIMIT,
-  THROTTLER_TRACKER,
-  THROTTLER_TTL,
-} from '@nestjs/throttler/dist/throttler.constants.js';
+import { THROTTLER_LIMIT } from '@nestjs/throttler/dist/throttler.constants.js';
 import { ZplController } from './zpl.controller.js';
 import { LabelSize } from './enums/label-size.enum.js';
 import { validate } from 'class-validator';
@@ -37,6 +33,10 @@ import {
 } from './dto/public-preview.dto.js';
 import { ErrorCodes } from '../../common/constants/error-codes.js';
 import { FirebaseAuthGuard } from '../../common/guards/firebase-auth.guard.js';
+import {
+  PublicPreviewThrottlerGuard,
+  PUBLIC_PREVIEW_THROTTLERS,
+} from '../../common/guards/public-preview-throttler.guard.js';
 
 const ZPL_VALIDO = '^XA^FO20,20^FDHola^FS^XZ';
 
@@ -110,6 +110,19 @@ describe('ZplController — POST /zpl/public-preview (issue #108)', () => {
     ).rejects.toBeInstanceOf(HttpException);
   });
 
+  it('devuelve 503 si Labelary no dejó renderizar ninguna etiqueta', async () => {
+    // getLabelsPreview se traga el fallo de cada etiqueta y puede devolver una
+    // lista vacía; un 200 con `data: []` le pintaría al visitante un lienzo en
+    // blanco sin decirle que el problema es temporal.
+    const { controller, getLabelsPreview } = buildController();
+    getLabelsPreview.mockResolvedValue([]);
+
+    await expect(controller.publicPreview(dto())).rejects.toMatchObject({
+      status: HttpStatus.SERVICE_UNAVAILABLE,
+      response: { error: ErrorCodes.SERVICE_UNAVAILABLE },
+    });
+  });
+
   // El tope de tamaño lo aplica el ValidationPipe global antes de llegar al
   // handler, así que se comprueba sobre el DTO.
   describe('límite de tamaño del zplContent', () => {
@@ -150,58 +163,35 @@ describe('ZplController — POST /zpl/public-preview (issue #108)', () => {
     const publicPreview = ZplController.prototype.publicPreview;
 
     it('no lleva guard de autenticación', () => {
-      expect(
-        Reflect.getMetadata(GUARDS_METADATA, publicPreview),
-      ).toBeUndefined();
+      const guards = Reflect.getMetadata(GUARDS_METADATA, publicPreview) ?? [];
+
+      expect(guards).not.toContain(FirebaseAuthGuard);
     });
 
-    it('lleva rate limit por visitante, por minuto y por hora', () => {
-      expect(
-        Reflect.getMetadata(THROTTLER_LIMIT + 'default', publicPreview),
-      ).toBe(10);
-      expect(
-        Reflect.getMetadata(THROTTLER_TTL + 'default', publicPreview),
-      ).toBe(60000);
-      expect(
-        Reflect.getMetadata(THROTTLER_LIMIT + 'hourly', publicPreview),
-      ).toBe(30);
-      expect(Reflect.getMetadata(THROTTLER_TTL + 'hourly', publicPreview)).toBe(
-        3600000,
+    it('lleva el guard de rate limit propio de la ruta', () => {
+      expect(Reflect.getMetadata(GUARDS_METADATA, publicPreview)).toContain(
+        PublicPreviewThrottlerGuard,
       );
     });
 
-    it('lleva ademas un tope agregado por IP de origen real', () => {
-      expect(
-        Reflect.getMetadata(THROTTLER_LIMIT + 'peerMinute', publicPreview),
-      ).toBe(60);
-      expect(
-        Reflect.getMetadata(THROTTLER_LIMIT + 'peerHourly', publicPreview),
-      ).toBe(600);
-    });
-
-    // La ventana por visitante se puede esquivar variando el X-Forwarded-For;
-    // la agregada no, porque se cuenta sobre el salto que anade Cloud Run.
-    it('separa la identidad por visitante de la identidad por origen', () => {
-      const conXffFalso = {
-        headers: { 'x-forwarded-for': '9.9.9.9, 198.51.100.7' },
-        socket: { remoteAddress: '10.0.0.1' },
-      };
-      const conOtroXffFalso = {
-        headers: { 'x-forwarded-for': '8.8.8.8, 198.51.100.7' },
-        socket: { remoteAddress: '10.0.0.1' },
-      };
-      const porVisitante = Reflect.getMetadata(
-        THROTTLER_TRACKER + 'default',
-        publicPreview,
+    it('limita por visitante por minuto y por hora, y agrega por origen', () => {
+      expect(PUBLIC_PREVIEW_THROTTLERS.clientMinute).toEqual({
+        limit: 10,
+        ttl: 60000,
+      });
+      expect(PUBLIC_PREVIEW_THROTTLERS.clientHourly).toEqual({
+        limit: 30,
+        ttl: 3600000,
+      });
+      // El tope agregado es mas alto porque lo comparten todos los visitantes
+      // que entran por el mismo edge, pero sigue por debajo de lo que aguanta
+      // el plan free de Labelary.
+      expect(PUBLIC_PREVIEW_THROTTLERS.peerMinute.limit).toBeGreaterThan(
+        PUBLIC_PREVIEW_THROTTLERS.clientMinute.limit,
       );
-      const porOrigen = Reflect.getMetadata(
-        THROTTLER_TRACKER + 'peerMinute',
-        publicPreview,
+      expect(PUBLIC_PREVIEW_THROTTLERS.peerHourly.limit).toBeGreaterThan(
+        PUBLIC_PREVIEW_THROTTLERS.clientHourly.limit,
       );
-
-      expect(porVisitante(conXffFalso)).not.toBe(porVisitante(conOtroXffFalso));
-      expect(porOrigen(conXffFalso)).toBe(porOrigen(conOtroXffFalso));
-      expect(porOrigen(conXffFalso)).toContain('198.51.100.7');
     });
   });
 
@@ -216,15 +206,18 @@ describe('ZplController — POST /zpl/public-preview (issue #108)', () => {
       );
     });
 
+    it('no hereda el guard de rate limit del endpoint publico', () => {
+      expect(Reflect.getMetadata(GUARDS_METADATA, previewZpl)).not.toContain(
+        PublicPreviewThrottlerGuard,
+      );
+    });
+
     it('sigue sin rate limit propio', () => {
       expect(
         Reflect.getMetadata(THROTTLER_LIMIT + 'default', previewZpl),
       ).toBeUndefined();
       expect(
         Reflect.getMetadata(THROTTLER_LIMIT + 'hourly', previewZpl),
-      ).toBeUndefined();
-      expect(
-        Reflect.getMetadata(THROTTLER_LIMIT + 'peerMinute', previewZpl),
       ).toBeUndefined();
     });
   });

--- a/src/modules/zpl/zpl.controller.spec.ts
+++ b/src/modules/zpl/zpl.controller.spec.ts
@@ -1,0 +1,193 @@
+// Mockear dependencias pesadas/nativas que la cadena de imports del controller
+// arrastra (zpl.service y firebase-admin) pero que estos tests no ejercitan.
+jest.mock('sharp', () => jest.fn());
+jest.mock('pdf-to-png-converter', () => ({ pdfToPng: jest.fn() }));
+jest.mock('pdf-merger-js', () => jest.fn());
+jest.mock('archiver', () => jest.fn());
+jest.mock('@google-cloud/storage', () => ({
+  Storage: jest.fn().mockImplementation(() => ({
+    bucket: jest.fn().mockReturnValue({
+      exists: jest.fn().mockResolvedValue([true]),
+      file: jest.fn(),
+    }),
+  })),
+}));
+jest.mock('firebase-admin', () => ({
+  apps: [],
+  initializeApp: jest.fn(),
+  credential: { cert: jest.fn() },
+  auth: jest.fn(),
+}));
+
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { GUARDS_METADATA } from '@nestjs/common/constants.js';
+import {
+  THROTTLER_LIMIT,
+  THROTTLER_TTL,
+} from '@nestjs/throttler/dist/throttler.constants.js';
+import { ZplController } from './zpl.controller.js';
+import { LabelSize } from './enums/label-size.enum.js';
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import {
+  PublicPreviewDto,
+  PUBLIC_PREVIEW_MAX_UNIQUE_LABELS,
+  PUBLIC_PREVIEW_MAX_ZPL_LENGTH,
+} from './dto/public-preview.dto.js';
+import { ErrorCodes } from '../../common/constants/error-codes.js';
+import { FirebaseAuthGuard } from '../../common/guards/firebase-auth.guard.js';
+
+const ZPL_VALIDO = '^XA^FO20,20^FDHola^FS^XZ';
+
+const buildController = () => {
+  const getLabelsPreview = jest
+    .fn()
+    .mockResolvedValue([{ img: 'data:image/png;base64,AAA', qty: 1 }]);
+  const zplService: any = { getLabelsPreview };
+  const controller = new ZplController(zplService, {} as any);
+  return { controller, getLabelsPreview };
+};
+
+const dto = (overrides: Partial<PublicPreviewDto> = {}): PublicPreviewDto =>
+  Object.assign(new PublicPreviewDto(), { zplContent: ZPL_VALIDO }, overrides);
+
+describe('ZplController — POST /zpl/public-preview (issue #108)', () => {
+  it('responde con la misma forma que /zpl/preview', async () => {
+    const { controller } = buildController();
+
+    const res = await controller.publicPreview(dto());
+
+    expect(res).toEqual({
+      success: true,
+      message: 'Vista previa generada correctamente',
+      data: [{ img: 'data:image/png;base64,AAA', qty: 1 }],
+    });
+  });
+
+  it('acota el render a las primeras etiquetas únicas', async () => {
+    const { controller, getLabelsPreview } = buildController();
+
+    await controller.publicPreview(dto());
+
+    expect(getLabelsPreview).toHaveBeenCalledWith(
+      ZPL_VALIDO,
+      LabelSize.TWO_BY_ONE,
+      { maxUniqueLabels: PUBLIC_PREVIEW_MAX_UNIQUE_LABELS },
+    );
+    expect(PUBLIC_PREVIEW_MAX_UNIQUE_LABELS).toBeLessThanOrEqual(2);
+  });
+
+  it('respeta el labelSize recibido', async () => {
+    const { controller, getLabelsPreview } = buildController();
+
+    await controller.publicPreview(dto({ labelSize: LabelSize.FOUR_BY_SIX }));
+
+    expect(getLabelsPreview).toHaveBeenCalledWith(
+      ZPL_VALIDO,
+      LabelSize.FOUR_BY_SIX,
+      expect.anything(),
+    );
+  });
+
+  it('rechaza con 400 INVALID_ZPL si falta ^XA/^XZ, sin tocar Labelary', async () => {
+    const { controller, getLabelsPreview } = buildController();
+
+    await expect(
+      controller.publicPreview(dto({ zplContent: 'esto no es ZPL' })),
+    ).rejects.toMatchObject({
+      status: HttpStatus.BAD_REQUEST,
+      response: { error: ErrorCodes.INVALID_ZPL },
+    });
+    expect(getLabelsPreview).not.toHaveBeenCalled();
+  });
+
+  it('rechaza contenido vacío', async () => {
+    const { controller } = buildController();
+
+    await expect(
+      controller.publicPreview(dto({ zplContent: '' })),
+    ).rejects.toBeInstanceOf(HttpException);
+  });
+
+  // El tope de tamaño lo aplica el ValidationPipe global antes de llegar al
+  // handler, así que se comprueba sobre el DTO.
+  describe('límite de tamaño del zplContent', () => {
+    it('acepta un ZPL dentro del tope', async () => {
+      const errors = await validate(
+        plainToInstance(PublicPreviewDto, {
+          zplContent:
+            '^XA' + 'X'.repeat(PUBLIC_PREVIEW_MAX_ZPL_LENGTH - 6) + '^XZ',
+        }),
+      );
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('rechaza un ZPL que se pasa del tope', async () => {
+      const errors = await validate(
+        plainToInstance(PublicPreviewDto, {
+          zplContent: 'X'.repeat(PUBLIC_PREVIEW_MAX_ZPL_LENGTH + 1),
+        }),
+      );
+
+      expect(errors[0].constraints).toHaveProperty('maxLength');
+    });
+
+    it('rechaza un labelSize desconocido', async () => {
+      const errors = await validate(
+        plainToInstance(PublicPreviewDto, {
+          zplContent: ZPL_VALIDO,
+          labelSize: '9x9',
+        }),
+      );
+
+      expect(errors[0].constraints).toHaveProperty('isEnum');
+    });
+  });
+
+  describe('metadatos de la ruta', () => {
+    const publicPreview = ZplController.prototype.publicPreview;
+
+    it('no lleva guard de autenticación', () => {
+      expect(
+        Reflect.getMetadata(GUARDS_METADATA, publicPreview),
+      ).toBeUndefined();
+    });
+
+    it('lleva rate limit por IP por minuto y por hora', () => {
+      expect(
+        Reflect.getMetadata(THROTTLER_LIMIT + 'default', publicPreview),
+      ).toBe(10);
+      expect(
+        Reflect.getMetadata(THROTTLER_TTL + 'default', publicPreview),
+      ).toBe(60000);
+      expect(
+        Reflect.getMetadata(THROTTLER_LIMIT + 'hourly', publicPreview),
+      ).toBe(30);
+      expect(Reflect.getMetadata(THROTTLER_TTL + 'hourly', publicPreview)).toBe(
+        3600000,
+      );
+    });
+  });
+
+  // El endpoint público es uno nuevo a propósito: el de siempre no debe heredar
+  // ni el guard menos ni el rate limit por IP de más.
+  describe('POST /zpl/preview no cambia', () => {
+    const previewZpl = ZplController.prototype.previewZpl;
+
+    it('sigue exigiendo FirebaseAuthGuard', () => {
+      expect(Reflect.getMetadata(GUARDS_METADATA, previewZpl)).toContain(
+        FirebaseAuthGuard,
+      );
+    });
+
+    it('sigue sin rate limit propio', () => {
+      expect(
+        Reflect.getMetadata(THROTTLER_LIMIT + 'default', previewZpl),
+      ).toBeUndefined();
+      expect(
+        Reflect.getMetadata(THROTTLER_LIMIT + 'hourly', previewZpl),
+      ).toBeUndefined();
+    });
+  });
+});

--- a/src/modules/zpl/zpl.controller.spec.ts
+++ b/src/modules/zpl/zpl.controller.spec.ts
@@ -21,7 +21,10 @@ jest.mock('firebase-admin', () => ({
 
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { GUARDS_METADATA } from '@nestjs/common/constants.js';
-import { THROTTLER_LIMIT } from '@nestjs/throttler/dist/throttler.constants.js';
+import {
+  THROTTLER_LIMIT,
+  THROTTLER_SKIP,
+} from '@nestjs/throttler/dist/throttler.constants.js';
 import { ZplController } from './zpl.controller.js';
 import { LabelSize } from './enums/label-size.enum.js';
 import { validate } from 'class-validator';
@@ -174,6 +177,18 @@ describe('ZplController — POST /zpl/public-preview (issue #108)', () => {
       );
     });
 
+    it('omite el throttler global sin omitir el guard propio', () => {
+      expect(
+        Reflect.getMetadata(THROTTLER_SKIP + 'default', publicPreview),
+      ).toBe(true);
+      expect(
+        Reflect.getMetadata(
+          THROTTLER_SKIP + 'publicPreviewClientMinute',
+          publicPreview,
+        ),
+      ).toBeUndefined();
+    });
+
     it('limita por visitante por minuto y por hora, y agrega por origen', () => {
       expect(PUBLIC_PREVIEW_THROTTLERS.clientMinute).toEqual({
         limit: 6,
@@ -218,6 +233,12 @@ describe('ZplController — POST /zpl/public-preview (issue #108)', () => {
       ).toBeUndefined();
       expect(
         Reflect.getMetadata(THROTTLER_LIMIT + 'hourly', previewZpl),
+      ).toBeUndefined();
+    });
+
+    it('sigue pasando por el throttler global', () => {
+      expect(
+        Reflect.getMetadata(THROTTLER_SKIP + 'default', previewZpl),
       ).toBeUndefined();
     });
   });

--- a/src/modules/zpl/zpl.controller.spec.ts
+++ b/src/modules/zpl/zpl.controller.spec.ts
@@ -176,7 +176,7 @@ describe('ZplController — POST /zpl/public-preview (issue #108)', () => {
 
     it('limita por visitante por minuto y por hora, y agrega por origen', () => {
       expect(PUBLIC_PREVIEW_THROTTLERS.clientMinute).toEqual({
-        limit: 10,
+        limit: 6,
         ttl: 60000,
       });
       expect(PUBLIC_PREVIEW_THROTTLERS.clientHourly).toEqual({

--- a/src/modules/zpl/zpl.controller.spec.ts
+++ b/src/modules/zpl/zpl.controller.spec.ts
@@ -23,6 +23,7 @@ import { HttpException, HttpStatus } from '@nestjs/common';
 import { GUARDS_METADATA } from '@nestjs/common/constants.js';
 import {
   THROTTLER_LIMIT,
+  THROTTLER_TRACKER,
   THROTTLER_TTL,
 } from '@nestjs/throttler/dist/throttler.constants.js';
 import { ZplController } from './zpl.controller.js';
@@ -154,7 +155,7 @@ describe('ZplController — POST /zpl/public-preview (issue #108)', () => {
       ).toBeUndefined();
     });
 
-    it('lleva rate limit por IP por minuto y por hora', () => {
+    it('lleva rate limit por visitante, por minuto y por hora', () => {
       expect(
         Reflect.getMetadata(THROTTLER_LIMIT + 'default', publicPreview),
       ).toBe(10);
@@ -167,6 +168,40 @@ describe('ZplController — POST /zpl/public-preview (issue #108)', () => {
       expect(Reflect.getMetadata(THROTTLER_TTL + 'hourly', publicPreview)).toBe(
         3600000,
       );
+    });
+
+    it('lleva ademas un tope agregado por IP de origen real', () => {
+      expect(
+        Reflect.getMetadata(THROTTLER_LIMIT + 'peerMinute', publicPreview),
+      ).toBe(60);
+      expect(
+        Reflect.getMetadata(THROTTLER_LIMIT + 'peerHourly', publicPreview),
+      ).toBe(600);
+    });
+
+    // La ventana por visitante se puede esquivar variando el X-Forwarded-For;
+    // la agregada no, porque se cuenta sobre el salto que anade Cloud Run.
+    it('separa la identidad por visitante de la identidad por origen', () => {
+      const conXffFalso = {
+        headers: { 'x-forwarded-for': '9.9.9.9, 198.51.100.7' },
+        socket: { remoteAddress: '10.0.0.1' },
+      };
+      const conOtroXffFalso = {
+        headers: { 'x-forwarded-for': '8.8.8.8, 198.51.100.7' },
+        socket: { remoteAddress: '10.0.0.1' },
+      };
+      const porVisitante = Reflect.getMetadata(
+        THROTTLER_TRACKER + 'default',
+        publicPreview,
+      );
+      const porOrigen = Reflect.getMetadata(
+        THROTTLER_TRACKER + 'peerMinute',
+        publicPreview,
+      );
+
+      expect(porVisitante(conXffFalso)).not.toBe(porVisitante(conOtroXffFalso));
+      expect(porOrigen(conXffFalso)).toBe(porOrigen(conOtroXffFalso));
+      expect(porOrigen(conXffFalso)).toContain('198.51.100.7');
     });
   });
 
@@ -187,6 +222,9 @@ describe('ZplController — POST /zpl/public-preview (issue #108)', () => {
       ).toBeUndefined();
       expect(
         Reflect.getMetadata(THROTTLER_LIMIT + 'hourly', previewZpl),
+      ).toBeUndefined();
+      expect(
+        Reflect.getMetadata(THROTTLER_LIMIT + 'peerMinute', previewZpl),
       ).toBeUndefined();
     });
   });

--- a/src/modules/zpl/zpl.controller.ts
+++ b/src/modules/zpl/zpl.controller.ts
@@ -43,9 +43,9 @@ import {
 } from './dto/batch.dto.js';
 import { ErrorCodes } from '../../common/constants/error-codes.js';
 import {
-  getClientDeclaredIp,
-  getTrustedHopIp,
-} from '../../common/utils/request-ip.js';
+  PublicPreviewThrottlerGuard,
+  PUBLIC_PREVIEW_THROTTLERS,
+} from '../../common/guards/public-preview-throttler.guard.js';
 import { FontPreviewPublicDto } from './dto/font-preview-public.dto.js';
 import {
   PublicPreviewDto,
@@ -771,39 +771,10 @@ export class ZplController {
   // quien paga (que ademas comparte IP con toda su oficina detras del NAT).
   @Post('public-preview')
   @HttpCode(HttpStatus.OK)
-  // Dos identidades, porque ninguna sirve sola:
-  //
-  // - La IP que declara el cliente segmenta bien el trafico legitimo (todos los
-  //   visitantes entran por el rewrite del frontend y comparten salto), pero es
-  //   falsificable: quien llame directo al servicio de Cloud Run puede mandar
-  //   un `X-Forwarded-For` distinto en cada peticion y estrenar contador.
-  // - La IP del salto de confianza no se puede falsificar, pero agrupa a todos
-  //   los visitantes que comparten edge.
-  //
-  // Asi que la primera lleva el tope por visitante y la segunda el tope
-  // agregado que de verdad protege el techo compartido de Labelary.
-  @Throttle({
-    default: {
-      limit: 10,
-      ttl: 60000,
-      getTracker: (req) => `public-preview:client:${getClientDeclaredIp(req)}`,
-    },
-    hourly: {
-      limit: 30,
-      ttl: 3600000,
-      getTracker: (req) => `public-preview:client:${getClientDeclaredIp(req)}`,
-    },
-    peerMinute: {
-      limit: 60,
-      ttl: 60000,
-      getTracker: (req) => `public-preview:hop:${getTrustedHopIp(req)}`,
-    },
-    peerHourly: {
-      limit: 600,
-      ttl: 3600000,
-      getTracker: (req) => `public-preview:hop:${getTrustedHopIp(req)}`,
-    },
-  })
+  // El rate limit por IP vive en el guard, con opciones y storage propios (ver
+  // PublicPreviewThrottlerGuard): declararlo en el ThrottlerModule global
+  // habria anadido esas ventanas a TODAS las rutas del API.
+  @UseGuards(PublicPreviewThrottlerGuard)
   @ApiOperation({
     summary: 'Vista previa publica de etiquetas ZPL (sin autenticacion)',
     description:
@@ -811,8 +782,10 @@ export class ZplController {
       'con la misma forma de respuesta que POST /zpl/preview. ' +
       `Renderiza como mucho ${PUBLIC_PREVIEW_MAX_UNIQUE_LABELS} etiquetas unicas por peticion ` +
       '(el recorte se aplica antes de llamar a Labelary; el archivo completo requiere cuenta). ' +
-      'Rate limit por IP del visitante: 10 peticiones/minuto y 30/hora, mas un tope agregado ' +
-      'por IP de origen real (60/minuto, 600/hora). No requiere autenticacion.',
+      `Rate limit por IP del visitante: ${PUBLIC_PREVIEW_THROTTLERS.clientMinute.limit} peticiones/minuto ` +
+      `y ${PUBLIC_PREVIEW_THROTTLERS.clientHourly.limit}/hora, mas un tope agregado por IP de origen real ` +
+      `(${PUBLIC_PREVIEW_THROTTLERS.peerMinute.limit}/minuto, ${PUBLIC_PREVIEW_THROTTLERS.peerHourly.limit}/hora). ` +
+      'No requiere autenticacion.',
   })
   @ApiBody({ type: PublicPreviewDto })
   @ApiResponse({
@@ -855,8 +828,12 @@ export class ZplController {
   @ApiResponse({
     status: HttpStatus.TOO_MANY_REQUESTS,
     description:
-      'Rate limit superado: por visitante (10 req/min, 30 req/hora) o agregado por origen ' +
-      '(60 req/min, 600 req/hora)',
+      'Rate limit superado, por visitante o agregado por IP de origen real',
+  })
+  @ApiResponse({
+    status: HttpStatus.SERVICE_UNAVAILABLE,
+    description:
+      'No se pudo renderizar ninguna etiqueta (Labelary no responde)',
   })
   async publicPreview(
     @Body() dto: PublicPreviewDto,
@@ -869,6 +846,21 @@ export class ZplController {
       size,
       { maxUniqueLabels: PUBLIC_PREVIEW_MAX_UNIQUE_LABELS },
     );
+
+    // `getLabelsPreview` se traga el fallo de cada etiqueta para seguir con las
+    // demas, asi que si Labelary esta caido o devolviendo 429 la lista llega
+    // vacia. Devolver 200 con `data: []` le pintaria al visitante un lienzo en
+    // blanco sin explicacion; el frontend sabe distinguir un error.
+    if (previews.length === 0) {
+      throw new HttpException(
+        {
+          error: ErrorCodes.SERVICE_UNAVAILABLE,
+          message:
+            'No se pudo generar la vista previa en este momento. Intenta de nuevo en unos segundos.',
+        },
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+    }
 
     return {
       success: true,

--- a/src/modules/zpl/zpl.controller.ts
+++ b/src/modules/zpl/zpl.controller.ts
@@ -14,7 +14,7 @@ import {
   HttpException,
   UseGuards,
 } from '@nestjs/common';
-import { Throttle } from '@nestjs/throttler';
+import { SkipThrottle, Throttle } from '@nestjs/throttler';
 import { v4 as uuidv4 } from 'uuid';
 import { ZplService } from './zpl.service.js';
 import { ConvertZplDto } from './dto/convert-zpl.dto.js';
@@ -771,6 +771,9 @@ export class ZplController {
   // quien paga (que ademas comparte IP con toda su oficina detras del NAT).
   @Post('public-preview')
   @HttpCode(HttpStatus.OK)
+  // Omite solo el throttler global `default`, cuyo storage no esta acotado.
+  // Los nombres del guard propio son distintos, asi que este sigue activo.
+  @SkipThrottle()
   // El rate limit por IP vive en el guard, con opciones y storage propios (ver
   // PublicPreviewThrottlerGuard): declararlo en el ThrottlerModule global
   // habria anadido esas ventanas a TODAS las rutas del API.

--- a/src/modules/zpl/zpl.controller.ts
+++ b/src/modules/zpl/zpl.controller.ts
@@ -42,6 +42,10 @@ import {
   BatchDownloadResponseDto,
 } from './dto/batch.dto.js';
 import { ErrorCodes } from '../../common/constants/error-codes.js';
+import {
+  getClientDeclaredIp,
+  getTrustedHopIp,
+} from '../../common/utils/request-ip.js';
 import { FontPreviewPublicDto } from './dto/font-preview-public.dto.js';
 import {
   PublicPreviewDto,
@@ -767,9 +771,38 @@ export class ZplController {
   // quien paga (que ademas comparte IP con toda su oficina detras del NAT).
   @Post('public-preview')
   @HttpCode(HttpStatus.OK)
+  // Dos identidades, porque ninguna sirve sola:
+  //
+  // - La IP que declara el cliente segmenta bien el trafico legitimo (todos los
+  //   visitantes entran por el rewrite del frontend y comparten salto), pero es
+  //   falsificable: quien llame directo al servicio de Cloud Run puede mandar
+  //   un `X-Forwarded-For` distinto en cada peticion y estrenar contador.
+  // - La IP del salto de confianza no se puede falsificar, pero agrupa a todos
+  //   los visitantes que comparten edge.
+  //
+  // Asi que la primera lleva el tope por visitante y la segunda el tope
+  // agregado que de verdad protege el techo compartido de Labelary.
   @Throttle({
-    default: { limit: 10, ttl: 60000 },
-    hourly: { limit: 30, ttl: 3600000 },
+    default: {
+      limit: 10,
+      ttl: 60000,
+      getTracker: (req) => `public-preview:client:${getClientDeclaredIp(req)}`,
+    },
+    hourly: {
+      limit: 30,
+      ttl: 3600000,
+      getTracker: (req) => `public-preview:client:${getClientDeclaredIp(req)}`,
+    },
+    peerMinute: {
+      limit: 60,
+      ttl: 60000,
+      getTracker: (req) => `public-preview:hop:${getTrustedHopIp(req)}`,
+    },
+    peerHourly: {
+      limit: 600,
+      ttl: 3600000,
+      getTracker: (req) => `public-preview:hop:${getTrustedHopIp(req)}`,
+    },
   })
   @ApiOperation({
     summary: 'Vista previa publica de etiquetas ZPL (sin autenticacion)',
@@ -778,7 +811,8 @@ export class ZplController {
       'con la misma forma de respuesta que POST /zpl/preview. ' +
       `Renderiza como mucho ${PUBLIC_PREVIEW_MAX_UNIQUE_LABELS} etiquetas unicas por peticion ` +
       '(el recorte se aplica antes de llamar a Labelary; el archivo completo requiere cuenta). ' +
-      'Rate limit por IP: 10 peticiones/minuto y 30/hora. No requiere autenticacion.',
+      'Rate limit por IP del visitante: 10 peticiones/minuto y 30/hora, mas un tope agregado ' +
+      'por IP de origen real (60/minuto, 600/hora). No requiere autenticacion.',
   })
   @ApiBody({ type: PublicPreviewDto })
   @ApiResponse({
@@ -820,7 +854,9 @@ export class ZplController {
   })
   @ApiResponse({
     status: HttpStatus.TOO_MANY_REQUESTS,
-    description: 'Rate limit por IP superado (10 req/min o 30 req/hora)',
+    description:
+      'Rate limit superado: por visitante (10 req/min, 30 req/hora) o agregado por origen ' +
+      '(60 req/min, 600 req/hora)',
   })
   async publicPreview(
     @Body() dto: PublicPreviewDto,

--- a/src/modules/zpl/zpl.controller.ts
+++ b/src/modules/zpl/zpl.controller.ts
@@ -43,6 +43,10 @@ import {
 } from './dto/batch.dto.js';
 import { ErrorCodes } from '../../common/constants/error-codes.js';
 import { FontPreviewPublicDto } from './dto/font-preview-public.dto.js';
+import {
+  PublicPreviewDto,
+  PUBLIC_PREVIEW_MAX_UNIQUE_LABELS,
+} from './dto/public-preview.dto.js';
 
 interface ProcessZplDto {
   zplContent: string;
@@ -754,6 +758,87 @@ export class ZplController {
 
     const labelSize = dto.labelSize || LabelSize.FOUR_BY_SIX;
     return this.zplService.getPublicFontPreview(dto.zplContent, labelSize);
+  }
+
+  // ============== PUBLIC PREVIEW ENDPOINT (VISOR ZPL) ==============
+
+  // Endpoint aparte y no `POST /zpl/preview` sin guard a proposito: el rate
+  // limit por IP y el tope de etiquetas son para el visitante anonimo, no para
+  // quien paga (que ademas comparte IP con toda su oficina detras del NAT).
+  @Post('public-preview')
+  @HttpCode(HttpStatus.OK)
+  @Throttle({
+    default: { limit: 10, ttl: 60000 },
+    hourly: { limit: 30, ttl: 3600000 },
+  })
+  @ApiOperation({
+    summary: 'Vista previa publica de etiquetas ZPL (sin autenticacion)',
+    description:
+      'Recibe codigo ZPL y devuelve imagenes PNG de las etiquetas unicas con sus cantidades, ' +
+      'con la misma forma de respuesta que POST /zpl/preview. ' +
+      `Renderiza como mucho ${PUBLIC_PREVIEW_MAX_UNIQUE_LABELS} etiquetas unicas por peticion ` +
+      '(el recorte se aplica antes de llamar a Labelary; el archivo completo requiere cuenta). ' +
+      'Rate limit por IP: 10 peticiones/minuto y 30/hora. No requiere autenticacion.',
+  })
+  @ApiBody({ type: PublicPreviewDto })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Vista previa generada correctamente',
+    schema: {
+      properties: {
+        success: { type: 'boolean', example: true },
+        message: {
+          type: 'string',
+          example: 'Vista previa generada correctamente',
+        },
+        data: {
+          type: 'array',
+          description: `Como mucho ${PUBLIC_PREVIEW_MAX_UNIQUE_LABELS} elementos`,
+          items: {
+            type: 'object',
+            properties: {
+              img: {
+                type: 'string',
+                description: 'Imagen PNG en base64',
+                example: 'data:image/png;base64,...',
+              },
+              qty: {
+                type: 'number',
+                description:
+                  'Cantidad real de copias de la etiqueta en el archivo (^PQ incluido)',
+                example: 5,
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Contenido ZPL invalido (INVALID_ZPL) o demasiado grande',
+  })
+  @ApiResponse({
+    status: HttpStatus.TOO_MANY_REQUESTS,
+    description: 'Rate limit por IP superado (10 req/min o 30 req/hora)',
+  })
+  async publicPreview(
+    @Body() dto: PublicPreviewDto,
+  ): Promise<ZplPreviewResponseDto> {
+    this.validateZplContent(dto.zplContent);
+
+    const size = dto.labelSize || LabelSize.TWO_BY_ONE;
+    const previews = await this.zplService.getLabelsPreview(
+      dto.zplContent,
+      size,
+      { maxUniqueLabels: PUBLIC_PREVIEW_MAX_UNIQUE_LABELS },
+    );
+
+    return {
+      success: true,
+      message: 'Vista previa generada correctamente',
+      data: previews,
+    };
   }
 
   // ============== BATCH PROCESSING ENDPOINTS ==============

--- a/src/modules/zpl/zpl.module.ts
+++ b/src/modules/zpl/zpl.module.ts
@@ -11,6 +11,7 @@ import { CacheModule } from '../cache/cache.module.js';
 import { UtilsModule } from '../../utils/utils.module.js';
 import { UsersModule } from '../users/users.module.js';
 import { GoogleAuthProvider } from '../../config/google-auth.provider.js';
+import { publicPreviewThrottlerProviders } from '../../common/guards/public-preview-throttler.guard.js';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { GoogleAuthProvider } from '../../config/google-auth.provider.js';
     LabelaryQueueService,
     LabelaryAnalyticsService,
     GoogleAuthProvider,
+    ...publicPreviewThrottlerProviders,
   ],
   exports: [
     ZplService,

--- a/src/modules/zpl/zpl.service.spec.ts
+++ b/src/modules/zpl/zpl.service.spec.ts
@@ -18,6 +18,7 @@ jest.mock('@google-cloud/storage', () => ({
   })),
 }));
 
+import { HttpException } from '@nestjs/common';
 import { ZplService, LabelSize } from './zpl.service.js';
 
 /**
@@ -760,5 +761,144 @@ describe('ZplService — el batch deja el ZPL disponible para reconvertir', () =
     await service.processBatchFiles('batch-1', [archivo], [job], '4x6', 'pdf');
 
     expect(observado).toEqual([true]);
+  });
+});
+
+/**
+ * El render de la vista previa va contra el plan FREE de Labelary (1 req/s para
+ * TODA la plataforma) y cada etiqueta única es una petición. El endpoint
+ * público (issue #108) acota cuántas se renderizan, y lo que importa es que el
+ * recorte ocurra ANTES de llamar a Labelary: recortar la respuesta no ahorraría
+ * nada del techo compartido.
+ */
+describe('ZplService — etiquetas únicas y vista previa acotada', () => {
+  const buildService = (): ZplService => {
+    const configService: any = { get: jest.fn(() => 'test-bucket') };
+    return new ZplService(configService, {} as any, {} as any, {}, {} as any);
+  };
+
+  const label = (texto: string, extra = '') =>
+    `^XA\n^FO20,20^FD${texto}^FS${extra}\n^XZ`;
+
+  describe('extractUniqueLabels', () => {
+    it('agrupa etiquetas idénticas y suma las copias de ^PQ', () => {
+      const service = buildService();
+
+      const uniques = service.extractUniqueLabels(
+        [
+          label('A', '^PQ3'),
+          label('B'),
+          // Misma etiqueta que la primera salvo formato: sin saltos de línea
+          // y con otro ^PQ. Debe fundirse con ella.
+          '^XA^FO20,20^FDA^FS^PQ2^XZ',
+        ].join('\n'),
+      );
+
+      expect(uniques).toHaveLength(2);
+      expect(uniques[0].qty).toBe(5); // 3 + 2 copias
+      expect(uniques[1].qty).toBe(1);
+      expect(uniques[0].zpl).not.toContain('^PQ');
+      expect(uniques[0].zpl).not.toContain('\n');
+      expect(uniques[0].zpl.startsWith('^XA')).toBe(true);
+      expect(uniques[0].zpl.endsWith('^XZ')).toBe(true);
+    });
+
+    it('respeta el orden de aparición', () => {
+      const service = buildService();
+
+      const uniques = service.extractUniqueLabels(
+        [label('primera'), label('segunda'), label('tercera')].join('\n'),
+      );
+
+      expect(uniques.map((u) => u.zpl.includes('primera'))).toEqual([
+        true,
+        false,
+        false,
+      ]);
+      expect(uniques[2].zpl).toContain('tercera');
+    });
+
+    it('lanza 400 si no hay ningún bloque ^XA…^XZ', () => {
+      const service = buildService();
+
+      expect(() => service.extractUniqueLabels('esto no es ZPL')).toThrow(
+        HttpException,
+      );
+    });
+  });
+
+  describe('getLabelsPreview con maxUniqueLabels', () => {
+    const buildServiceConLabelaryMockeado = () => {
+      const service = buildService();
+      const getSingleLabelaryPngImage = jest
+        .fn()
+        .mockResolvedValue(Buffer.from('png'));
+      (service as any).getSingleLabelaryPngImage = getSingleLabelaryPngImage;
+      return { service, getSingleLabelaryPngImage };
+    };
+
+    const zplDeCincoUnicas = [
+      label('uno'),
+      label('dos'),
+      label('tres'),
+      label('cuatro'),
+      label('cinco'),
+    ].join('\n');
+
+    it('no manda a Labelary más etiquetas de las permitidas', async () => {
+      const { service, getSingleLabelaryPngImage } =
+        buildServiceConLabelaryMockeado();
+
+      const previews = await service.getLabelsPreview(
+        zplDeCincoUnicas,
+        LabelSize.TWO_BY_ONE,
+        { maxUniqueLabels: 2 },
+      );
+
+      expect(previews).toHaveLength(2);
+      expect(getSingleLabelaryPngImage).toHaveBeenCalledTimes(2);
+      expect(getSingleLabelaryPngImage.mock.calls[0][0]).toContain('uno');
+      expect(getSingleLabelaryPngImage.mock.calls[1][0]).toContain('dos');
+    });
+
+    it('conserva las cantidades reales de las etiquetas que sí renderiza', async () => {
+      const { service } = buildServiceConLabelaryMockeado();
+
+      const previews = await service.getLabelsPreview(
+        [label('uno', '^PQ10'), label('dos'), label('tres')].join('\n'),
+        LabelSize.TWO_BY_ONE,
+        { maxUniqueLabels: 2 },
+      );
+
+      expect(previews.map((p) => p.qty)).toEqual([10, 1]);
+      expect(previews[0].img.startsWith('data:image/png;base64,')).toBe(true);
+    });
+
+    it('mil copias de la misma etiqueta siguen siendo una sola petición', async () => {
+      const { service, getSingleLabelaryPngImage } =
+        buildServiceConLabelaryMockeado();
+
+      const previews = await service.getLabelsPreview(
+        Array.from({ length: 1000 }, () => label('igual')).join('\n'),
+        LabelSize.TWO_BY_ONE,
+        { maxUniqueLabels: 2 },
+      );
+
+      expect(getSingleLabelaryPngImage).toHaveBeenCalledTimes(1);
+      expect(previews).toEqual([expect.objectContaining({ qty: 1000 })]);
+    });
+
+    it('sin tope renderiza todas las etiquetas únicas (comportamiento de /zpl/preview)', async () => {
+      const { service, getSingleLabelaryPngImage } =
+        buildServiceConLabelaryMockeado();
+
+      const previews = await service.getLabelsPreview(
+        zplDeCincoUnicas,
+        LabelSize.TWO_BY_ONE,
+      );
+
+      expect(previews).toHaveLength(5);
+      expect(getSingleLabelaryPngImage).toHaveBeenCalledTimes(5);
+    });
   });
 });

--- a/src/modules/zpl/zpl.service.ts
+++ b/src/modules/zpl/zpl.service.ts
@@ -1812,70 +1812,96 @@ export class ZplService {
   }
 
   /**
+   * Agrupa las etiquetas únicas del ZPL con su número de copias.
+   *
+   * Normaliza cada bloque `^XA…^XZ` (sin saltos de línea, espacios colapsados
+   * y sin `^PQ`) para que dos etiquetas idénticas cuenten como una sola: cada
+   * etiqueta única es una petición a Labelary, las copias no cuestan nada.
+   *
+   * @param zplContent Contenido ZPL a analizar
+   * @returns Etiquetas únicas normalizadas, en orden de aparición, con su qty
+   */
+  extractUniqueLabels(zplContent: string): { zpl: string; qty: number }[] {
+    const labelMatches = zplContent.match(/\^XA.*?\^XZ/gs);
+    if (!labelMatches) {
+      throw new HttpException(
+        'No se encontraron etiquetas válidas en el contenido ZPL',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const uniqueLabels = new Map<string, number>();
+
+    for (const label of labelMatches) {
+      let normalized = label
+        .replace(/[\r\n]+/g, '') // Eliminar saltos de línea
+        .replace(/\s+/g, ' ') // Normalizar espacios
+        .trim();
+
+      // Extraer y eliminar ^PQ para contar copias
+      const pqMatch = normalized.match(/\^PQ(\d+)/);
+      const copies = pqMatch ? parseInt(pqMatch[1], 10) : 1;
+      normalized = normalized.replace(/\^PQ\d+,?\d*,?\d*,?\d*/g, '');
+
+      // Asegurar formato ZPL correcto
+      if (!normalized.startsWith('^XA')) normalized = '^XA' + normalized;
+      if (!normalized.endsWith('^XZ')) normalized += '^XZ';
+
+      uniqueLabels.set(
+        normalized,
+        (uniqueLabels.get(normalized) || 0) + copies,
+      );
+    }
+
+    return Array.from(uniqueLabels.entries()).map(([zpl, qty]) => ({
+      zpl,
+      qty,
+    }));
+  }
+
+  /**
    * Obtiene las previsualizaciones de las etiquetas únicas con sus cantidades
    * @param zplContent Contenido ZPL a analizar
    * @param labelSize Tamaño de la etiqueta
+   * @param options.maxUniqueLabels Renderiza como mucho N etiquetas únicas.
+   *   El recorte ocurre ANTES de llamar a Labelary (plan free: 1 req/s para
+   *   toda la plataforma), así que acota el gasto real, no solo la respuesta.
    * @returns Array de objetos con imagen y cantidad de cada etiqueta única
    */
   async getLabelsPreview(
     zplContent: string,
     labelSize: LabelSize,
+    options?: { maxUniqueLabels?: number },
   ): Promise<ZplPreviewItemDto[]> {
     try {
-      // 1. Extraer etiquetas individuales (separar por ^XA...^XZ)
-      const labelMatches = zplContent.match(/\^XA.*?\^XZ/gs);
-      if (!labelMatches) {
-        throw new HttpException(
-          'No se encontraron etiquetas válidas en el contenido ZPL',
-          HttpStatus.BAD_REQUEST,
+      // 1. Extraer etiquetas únicas normalizadas con sus copias
+      const uniqueLabels = this.extractUniqueLabels(zplContent);
+
+      this.logger.debug(`Total de etiquetas únicas: ${uniqueLabels.length}`);
+
+      // 2. Recortar antes de tocar Labelary si el llamador puso un tope
+      const maxUniqueLabels = options?.maxUniqueLabels;
+      const labelsToRender =
+        maxUniqueLabels && maxUniqueLabels > 0
+          ? uniqueLabels.slice(0, maxUniqueLabels)
+          : uniqueLabels;
+
+      if (labelsToRender.length < uniqueLabels.length) {
+        this.logger.debug(
+          `Vista previa acotada a ${labelsToRender.length} de ${uniqueLabels.length} etiquetas únicas`,
         );
       }
-
-      // 2. Procesar etiquetas y contar duplicados
-      const uniqueLabels = new Map<string, number>();
-      const normalizedLabels: string[] = [];
-
-      for (const label of labelMatches) {
-        let normalized = label
-          .replace(/[\r\n]+/g, '') // Eliminar saltos de línea
-          .replace(/\s+/g, ' ') // Normalizar espacios
-          .trim();
-
-        // Extraer y eliminar ^PQ para contar copias
-        const pqMatch = normalized.match(/\^PQ(\d+)/);
-        const copies = pqMatch ? parseInt(pqMatch[1], 10) : 1;
-        normalized = normalized.replace(/\^PQ\d+,?\d*,?\d*,?\d*/g, '');
-
-        // Asegurar formato ZPL correcto
-        if (!normalized.startsWith('^XA')) normalized = '^XA' + normalized;
-        if (!normalized.endsWith('^XZ')) normalized += '^XZ';
-
-        uniqueLabels.set(
-          normalized,
-          (uniqueLabels.get(normalized) || 0) + copies,
-        );
-        if (!normalizedLabels.includes(normalized)) {
-          normalizedLabels.push(normalized);
-        }
-      }
-
-      this.logger.debug(
-        `Total de etiquetas encontradas: ${labelMatches.length}`,
-      );
-      this.logger.debug(
-        `Total de etiquetas únicas: ${normalizedLabels.length}`,
-      );
 
       // 3. Procesar etiquetas y generar previsualizaciones
       const labelPreviews: ZplPreviewItemDto[] = [];
 
       // Procesar cada etiqueta única individualmente, pero secuencialmente para evitar errores de rate limit
-      for (const zpl of normalizedLabels) {
+      for (const { zpl, qty } of labelsToRender) {
         try {
           const buffer = await this.getSingleLabelaryPngImage(zpl, labelSize);
           labelPreviews.push({
             img: `data:image/png;base64,${buffer.toString('base64')}`,
-            qty: uniqueLabels.get(zpl) || 0,
+            qty,
           });
         } catch (error) {
           this.logger.error(`Error al procesar etiqueta: ${error.message}`);


### PR DESCRIPTION
Closes #108

## Qué hace

`POST /api/zpl/public-preview`: vista previa sin autenticación para el visitante de `/[lang]/zpl-viewer-online`, con la **misma forma de respuesta** que `POST /zpl/preview` (`{ success, message, data: [{ img, qty }] }`) para que el frontend reutilice su código de pintado.

`POST /zpl/preview` no se toca: sigue con `FirebaseAuthGuard` y **sin** rate limit por IP. El endpoint es nuevo a propósito — el rate limit y el tope de etiquetas son para el anónimo, no para quien paga (que además comparte IP con toda su oficina detrás del NAT).

## Los dos topes

El render va contra el plan free de Labelary (1 req/s para **toda** la plataforma) y cada etiqueta única es una petición, así que el problema es de capacidad, no de facturación:

1. **Rate limit por IP** (detalle en la sección siguiente).
2. **Máximo 2 etiquetas únicas por petición**, recortadas **antes** de llamar a Labelary (recortar la respuesta no ahorraría nada del techo compartido). El archivo completo sigue requiriendo cuenta.

Las únicas se cuentan igual que en `getLabelsPreview` (sin saltos de línea, espacios colapsados, sin `^PQ`), así que mil copias de la misma etiqueta cuestan una sola petición y las `qty` que ve el visitante son las reales. Esa normalización sale a `extractUniqueLabels` para poder acotarla y testearla; `getLabelsPreview` acepta ahora un `options.maxUniqueLabels` opcional y sin él se comporta exactamente igual que antes.

## Rate limit: cómo quedó tras el review

Cuatro ventanas, sobre dos identidades distintas, en un guard propio (`PublicPreviewThrottlerGuard`) con storage propio — no en el `ThrottlerModule` global, que se evalúa en todas las rutas:

| Identidad | Ventana | Por qué |
|---|---|---|
| IP declarada por el cliente (primera del `X-Forwarded-For`, la del visitante tras el rewrite) | 6/min, 30/h | Segmenta el tráfico legítimo. Es falsificable, así que nunca va sola. |
| IP del salto de confianza (la que añade Cloud Run al final del `X-Forwarded-For`) | 15/min, 300/h | No se puede falsificar. Es el tope que protege de verdad a Labelary. |

Los números del tope agregado se cuentan en **llamadas a Labelary**, no en peticiones: cada petición renderiza hasta 2 etiquetas y cada etiqueta es una llamada, así que 15/min son ≤30 llamadas/min — la mitad del techo de 60 — y las conversiones de pago nunca se quedan sin cola.

Las cuatro se evalúan **en ese orden**, y no es un detalle: el guard incrementa el contador de cada ventana que evalúa y lanza en la primera que se pasa, así que lo que va delante consume cupo aunque la petición acabe rechazada. Con el agregado delante, a un visitante le bastaban 6 peticiones buenas más 9 rechazadas para agotar el minuto compartido y dejar sin vista previa a todos los que comparten salto.

La ruta lleva además `@SkipThrottle()` para saltar el throttler global: su storage no está acotado y, con `trust proxy` activo, rotar el `X-Forwarded-For` creaba una clave nueva por petición ahí aunque el guard propio ya respondiera 429.

## Verificado contra el servidor local (`PORT=8081`)

- `POST /api/zpl/public-preview` sin `Authorization` con 3 etiquetas únicas (una con `^PQ7`) → **200**, `data` con 2 items, `qty` `[1, 7]`, imágenes `data:image/png;base64,…`.
- ZPL inválido → **400** `INVALID_ZPL`, sin tocar Labelary.
- Corte por visitante en la 7ª petición del minuto; rotando el `X-Forwarded-For` en cada petición, corte agregado en la 16ª.
- Un visitante que se come sus 6 y encadena 9 rechazos **no** deja sin cuota a otro visitante del mismo salto: las 6 de este último pasan.
- `POST /zpl/preview` sin token sigue devolviendo 401.

## Tests

`npm test` (531 ✓), `npm run lint` y `npm run build` en verde. Nuevos:
- `zpl.service.spec.ts`: agrupación por etiqueta única, suma de `^PQ`, orden de aparición, 400 si no hay `^XA…^XZ`, y que el recorte reduce las **llamadas a Labelary** (no solo la respuesta).
- `zpl.controller.spec.ts`: forma de la respuesta, tope aplicado, `labelSize`, 400 `INVALID_ZPL`, 503 si no se renderizó nada, límites del DTO, y metadatos de ruta — que `public-preview` no lleva `FirebaseAuthGuard` y sí el suyo, y que `preview` conserva el guard y sigue sin rate limit propio.
- `request-ip.spec.ts`: que rotar el `X-Forwarded-For` no cambia la identidad del salto de confianza.
- `bounded-throttler.storage.spec.ts` y `public-preview-throttler.guard.spec.ts`: expulsión LRU, cancelación de timers, orden de evaluación y que los topes cuadran con la capacidad de Labelary.
- `labelary-queue.service.spec.ts`: tres llamadas concurrentes salen repartidas en el tiempo, no en ráfaga.


## Review

Cinco rondas con Codex (gpt-5.6-sol, medium). Tres las corregí yo, dos las corrigió Codex con esfuerzo xhigh; la quinta salió limpia. Lo que salió y se arregló: el tope por IP se eludía falsificando `X-Forwarded-For`; `waitForRateLimit` dejaba salir en ráfaga las llamadas concurrentes a Labelary (bug preexistente que este endpoint abría a los anónimos); los throttlers auxiliares ensuciaban el storage de todas las rutas; los topes se medían en peticiones y no en llamadas; el storage crecía sin expulsión; y al expulsar una clave quedaban vivos sus temporizadores.

## Lo que no se arregla aquí: la cola no reserva capacidad para el tráfico de pago

Una ráfaga permitida por el tope agregado puede meter hasta 30 turnos seguidos en la cadena FIFO de `enqueuePngDirect` (15 peticiones × 2 etiquetas), así que una preview autenticada que llegue justo detrás puede esperar ~30 s. El tope por minuto baja la media pero no reserva nada: la cadena es FIFO y trata igual al anónimo y a quien paga.

Se deja fuera a propósito. `LabelaryQueueService` **sí** tiene slots separados por plan, pero solo en `enqueue` (la cola completa de conversiones); la vía directa de previews (`enqueuePngDirect`) los ignora y es la que usan por igual `/zpl/preview`, `/zpl/font-preview` y esta ruta nueva. Darle prioridad al tráfico de pago significa tocar esa vía para las tres, que es un cambio de comportamiento en endpoints que hoy funcionan y merece su propio issue con su propia verificación — no colarlo en el PR que abre el visor a los anónimos. Mientras tanto el daño está acotado por diseño: el tope agregado deja libre la mitad del techo de Labelary.

## Notas

- El cuerpo del 429 sale como `error: "SERVER_ERROR"` porque `HttpExceptionFilter` no mapea el 429 a ningún `ErrorCode`; el frontend distingue por status, así que se deja fuera de este PR (tocarlo cambiaría también `font-preview` y el resto de rutas con throttle).
- Si detrás del rewrite del frontend la IP del visitante no llegara en `X-Forwarded-For`, todos los visitantes caerían en el mismo cubo por-visitante además del agregado. Conviene mirar los 429 tras el despliegue y subir los topes si el tráfico legítimo los roza.
- `TRUSTED_HOPS` vale 1 porque `api.zplpdf.com` es un domain mapping de Cloud Run, sin balanceador delante. Si algún día se pone un LB o Cloud Armor, hay que subirlo o el tope agregado se convierte en un único cubo global.
- Despliegue manual a Cloud Run; hasta entonces el frontend recibe 404 y enseña el modal de registro de siempre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqWuqow5DKmWv3Y9Xbi6Ta


