### PR TITLE
feat(users): baja de cuenta (DELETE /me) y preferencias de notificación

### DIFF
--- a/.agent-docs/ENDPOINTS.md
+++ b/.agent-docs/ENDPOINTS.md
@@ -75,21 +75,28 @@ cae en la foto del proveedor de acceso.
 Lógica en `src/modules/users/account-deletion.service.ts`. Encadena, **en este orden**:
 
 1. Cuenta las facturas de Stripe que van a conservarse.
-2. **Cancela la suscripción** (inmediata, no a fin de periodo). Si Stripe la rechaza,
-   la petición muere aquí con `409 SUBSCRIPTION_CANCEL_FAILED` y **no se borra nada**:
-   esa es la razón de que la cancelación vaya primero.
+2. **Cancela las suscripciones vivas** (inmediata, no a fin de periodo). Mira el
+   `stripeSubscriptionId` guardado **y** las del `stripeCustomerId`: el id local puede
+   faltar o estar desfasado, y fiarse solo de él dejaría un contrato cobrando a una
+   cuenta borrada. Si Stripe rechaza cualquiera, la petición muere aquí con
+   `409 SUBSCRIPTION_CANCEL_FAILED` y **no se borra nada**.
 3. Borra `conversion_history` y los archivos de Storage que cuelguen de la URL firmada
    de cada fila, más el prefijo `debug-zpl/<uid>/` y sus docs de `zpl_debug_files`.
 4. Borra los batches (`zpl-batches` + los ZIP de `batches/<batchId>/`) y los docs de
    estado de `zpl-conversions`, que siguen sirviendo `GET /zpl/status/:jobId`.
 5. Borra `usage`, el perfil fiscal (`tax_profiles`) y cancela los emails en cola.
-6. Anonimiza lo que se conserva: los `cfdis` y los registros contables
-   (`stripe_transactions`, `subscription_events`) pasan a `userId: 'deleted_user'` con
-   `userEmail` vacío, y el customer de Stripe pierde nombre, email y metadata. El
-   XML/PDF timbrado NO se toca: es el documento fiscal.
-7. Borra el doc de `users` y, por último, la cuenta de Firebase Auth. Si el doc no
-   llega a borrarse, la cuenta de Auth se deja viva: sin ella el usuario no podría
-   autenticarse para reintentar la baja.
+6. Anonimiza lo que se conserva: los `cfdis`, los registros contables
+   (`stripe_transactions`, `subscription_events`) y los de actividad (`email_queue`,
+   `email_events`, `feedback`) pasan a `userId: 'deleted_user'` con `userEmail` vacío,
+   y el customer de Stripe pierde nombre, email, teléfono, domicilio, metadata y sus
+   tax IDs. El XML/PDF timbrado NO se toca: es el documento fiscal. Tras borrar el
+   perfil se repite el barrido contable, porque el webhook de cancelación puede
+   escribir un `subscription_event` con PII mientras la baja avanza.
+7. Borra el doc de `users` y, por último, la cuenta de Firebase Auth — **solo si
+   ningún paso anterior falló**. Con datos o archivos pendientes, la identidad se
+   conserva: es lo único que permite reintentar la baja, y sin ella esos restos
+   quedarían sin dueño. Si el doc no llega a borrarse, tampoco se borra la cuenta de
+   Auth.
 
 `FirebaseAuthGuard` comprueba en Firebase Auth que la cuenta existe **antes** de su
 "lazy user creation": un ID token sigue siendo válido hasta una hora después de la

--- a/.agent-docs/ENDPOINTS.md
+++ b/.agent-docs/ENDPOINTS.md
@@ -87,11 +87,12 @@ Lógica en `src/modules/users/account-deletion.service.ts`. Encadena, **en este 
 5. Borra `usage`, el perfil fiscal (`tax_profiles`) y cancela los emails en cola.
 6. Anonimiza lo que se conserva: los `cfdis`, los registros contables
    (`stripe_transactions`, `subscription_events`) y los de actividad (`email_queue`,
-   `email_events`, `feedback`) pasan a `userId: 'deleted_user'` con `userEmail` vacío,
+   `email_events`, `feedback`, `error_logs`) pasan a `userId: 'deleted_user'` con `userEmail` vacío,
    y el customer de Stripe pierde nombre, email, teléfono, domicilio, metadata y sus
    tax IDs. El XML/PDF timbrado NO se toca: es el documento fiscal. Tras borrar el
-   perfil se repite el barrido contable, porque el webhook de cancelación puede
-   escribir un `subscription_event` con PII mientras la baja avanza.
+   perfil —y antes de borrar Firebase Auth— se repite el barrido, porque el webhook
+   de cancelación puede escribir un `subscription_event` con PII mientras la baja
+   avanza.
 7. Borra el doc de `users` y, por último, la cuenta de Firebase Auth — **solo si
    ningún paso anterior falló**. Con datos o archivos pendientes, la identidad se
    conserva: es lo único que permite reintentar la baja, y sin ella esos restos
@@ -117,7 +118,8 @@ afirmar que la cuenta ya no existe cuando sigue existiendo.
 `{ notifications: { product, billing, usageReminders } }`, guardadas en el doc de
 `users` (`notificationPreferences`). Ausente equivale a todo activado. El `PUT` es
 parcial: las claves que no vengan conservan su valor, y la respuesta trae siempre las
-tres resueltas.
+tres resueltas. Se escriben con ruta anidada (`notificationPreferences.product`) para
+que dos clics seguidos en la pantalla de ajustes no se pisen.
 
 `EmailService.processQueue` las comprueba **justo antes de enviar** —no solo al
 encolar, porque las secuencias se programan con días de antelación— usando el mapa

--- a/.agent-docs/ENDPOINTS.md
+++ b/.agent-docs/ENDPOINTS.md
@@ -83,7 +83,9 @@ Lógica en `src/modules/users/account-deletion.service.ts`. Encadena, **en este 
    Si la marca falla después de cancelar Stripe, la respuesta es
    `ACCOUNT_DELETION_PARTIAL` con `failedSteps: ['deletionMark']`, no un 500 opaco.
 4. Borra `conversion_history` y los archivos de Storage que cuelguen de la URL firmada
-   de cada fila, más el prefijo `debug-zpl/<uid>/` y sus docs de `zpl_debug_files`.
+   de cada fila, más el prefijo `debug-zpl/<uid>/`, sus docs de `zpl_debug_files` y la
+   foto de perfil (`users/<uid>/avatar.webp` del bucket **público**, #106): esa URL no
+   está firmada ni caduca, así que es el archivo que más importa retirar.
    Los workers comprueban la lápida justo antes y después de cada subida a GCS; si la
    baja empieza durante la subida, retiran el objeto para que no quede huérfano tras
    este barrido.

--- a/.agent-docs/ENDPOINTS.md
+++ b/.agent-docs/ENDPOINTS.md
@@ -80,11 +80,21 @@ Lógica en `src/modules/users/account-deletion.service.ts`. Encadena, **en este 
    esa es la razón de que la cancelación vaya primero.
 3. Borra `conversion_history` y los archivos de Storage que cuelguen de la URL firmada
    de cada fila, más el prefijo `debug-zpl/<uid>/` y sus docs de `zpl_debug_files`.
-4. Borra `usage`, el perfil fiscal (`tax_profiles`) y cancela los emails en cola.
-5. Anonimiza lo que tiene retención legal: los `cfdis` del usuario pasan a
-   `userId: 'deleted_user'` y el customer de Stripe pierde nombre, email y metadata.
-   El XML/PDF timbrado NO se toca: es el documento fiscal.
-6. Borra el doc de `users` y, por último, la cuenta de Firebase Auth.
+4. Borra los batches (`zpl-batches` + los ZIP de `batches/<batchId>/`) y los docs de
+   estado de `zpl-conversions`, que siguen sirviendo `GET /zpl/status/:jobId`.
+5. Borra `usage`, el perfil fiscal (`tax_profiles`) y cancela los emails en cola.
+6. Anonimiza lo que se conserva: los `cfdis` y los registros contables
+   (`stripe_transactions`, `subscription_events`) pasan a `userId: 'deleted_user'` con
+   `userEmail` vacío, y el customer de Stripe pierde nombre, email y metadata. El
+   XML/PDF timbrado NO se toca: es el documento fiscal.
+7. Borra el doc de `users` y, por último, la cuenta de Firebase Auth. Si el doc no
+   llega a borrarse, la cuenta de Auth se deja viva: sin ella el usuario no podría
+   autenticarse para reintentar la baja.
+
+`FirebaseAuthGuard` comprueba en Firebase Auth que la cuenta existe **antes** de su
+"lazy user creation": un ID token sigue siendo válido hasta una hora después de la
+baja, y sin esa comprobación la primera petición posterior recrearía el perfil. Solo
+se paga en el alta; el resto de peticiones encuentran el documento y no pasan por ahí.
 
 Respuesta 200: `{ deleted: { conversions, storedFiles, taxProfile, subscription:
 { cancelled, plan, effectiveAt } }, retained: { invoices, reason } }`. `reason` es un

--- a/.agent-docs/ENDPOINTS.md
+++ b/.agent-docs/ENDPOINTS.md
@@ -134,6 +134,13 @@ que dos clics seguidos en la pantalla de ajustes no se pisen; después se relee 
 documento y se devuelve el estado completo realmente persistido, incluidos cambios
 concurrentes en otras claves.
 
+Un envío que ya está en `sending` cuando empieza una baja no se puede abortar —el
+worker tiene el destinatario en memoria—, así que la baja espera a que se resuelva
+(hasta 3 s) antes de confirmar nada; si sigue en vuelo, responde
+`ACCOUNT_DELETION_PARTIAL` con `failedSteps: ['pendingEmails']` en vez de afirmar un
+borrado que todavía puede producir un correo. Los nuevos ya no salen: el claim lee la
+lápida de `deleted_accounts` dentro de su transacción.
+
 `EmailService.processQueue` las comprueba **justo antes de enviar** —no solo al
 encolar, porque las secuencias se programan con días de antelación— usando el mapa
 `EMAIL_NOTIFICATION_CATEGORY` (`src/modules/email/email-categories.ts`). Lo que no
@@ -141,6 +148,15 @@ sale se marca `cancelled` con su `skipReason` y cuenta en `skipped`, no en `fail
 Justo antes de llamar a Resend, el worker reclama atómicamente el documento con
 `pending -> sending`; si una baja u otro worker cambió ya su estado, no envía ni lo
 sobrescribe a `sent`, y ese elemento también cuenta en `skipped`.
+
+Ese `sending` es un **lease de 10 minutos** (`EMAIL_SEND_LEASE_MS`), no un estado
+final: si el proceso muere entre la reclamación y la escritura del resultado, el
+siguiente ciclo lo retoma en vez de perderlo para siempre. El reintento es seguro
+porque el envío lleva `idempotencyKey` con el id de la cola. El barrido consulta
+`status == 'sending'` con **un solo filtro** y descarta por antigüedad en memoria: en
+`email_queue` solo existen los índices compuestos `emailType+status+userId+createdAt`
+y `status+scheduledFor`, y una consulta sin su índice ya costó una tanda de avisos sin
+enviar.
 
 ### Acciones sobre el historial
 

--- a/.agent-docs/ENDPOINTS.md
+++ b/.agent-docs/ENDPOINTS.md
@@ -31,8 +31,14 @@ All endpoints are prefixed with `/api` (configured in `main.ts`).
 |--------|------|------|------------|-------------|
 | POST | /users/sync | User | UsersController.syncUser | Sync Firebase user with Firestore |
 | GET | /users/me | User | UsersController.getUserProfile | Get current user profile |
+<<<<<<< HEAD
 | POST | /users/me/photo | User | UsersController.uploadPhoto | Upload the profile photo (multipart, campo `file`) |
 | DELETE | /users/me/photo | User | UsersController.deletePhoto | Remove the profile photo (204) |
+=======
+| DELETE | /users/me | User | UsersController.deleteAccount | Baja de cuenta (irreversible) |
+| GET | /users/me/preferences | User | UsersController.getPreferences | Preferencias de notificación |
+| PUT | /users/me/preferences | User | UsersController.updatePreferences | Actualizar preferencias (parcial) |
+>>>>>>> a260325 (feat(users): baja de cuenta (DELETE /me) y preferencias de notificación)
 | GET | /users/verification-status | User | UsersController.getVerificationStatus | Check email verification status |
 | GET | /users/limits | User | UsersController.getUserLimits | Get plan limits and current usage |
 | GET | /users/history | User | UsersController.getUserHistory | Get conversion history (Pro+ only) |
@@ -41,6 +47,7 @@ All endpoints are prefixed with `/api` (configured in `main.ts`).
 
 **File:** `src/modules/users/users.controller.ts`
 
+<<<<<<< HEAD
 ### Foto de perfil
 
 `POST /users/me/photo` recibe `multipart/form-data` con el campo `file` y responde
@@ -62,6 +69,44 @@ si solo se guardara en Firestore seguiría mostrando la foto de Google.
 es lo que devuelve al usuario a sus iniciales; `null` (y no el campo ausente) es lo
 que distingue "la quitó" de "nunca subió ninguna", el caso en que `GET /users/me` sí
 cae en la foto del proveedor de acceso.
+=======
+### Baja de cuenta (`DELETE /users/me`)
+
+Lógica en `src/modules/users/account-deletion.service.ts`. Encadena, **en este orden**:
+
+1. Cuenta las facturas de Stripe que van a conservarse.
+2. **Cancela la suscripción** (inmediata, no a fin de periodo). Si Stripe la rechaza,
+   la petición muere aquí con `409 SUBSCRIPTION_CANCEL_FAILED` y **no se borra nada**:
+   esa es la razón de que la cancelación vaya primero.
+3. Borra `conversion_history` y los archivos de Storage que cuelguen de la URL firmada
+   de cada fila, más el prefijo `debug-zpl/<uid>/` y sus docs de `zpl_debug_files`.
+4. Borra `usage`, el perfil fiscal (`tax_profiles`) y cancela los emails en cola.
+5. Anonimiza lo que tiene retención legal: los `cfdis` del usuario pasan a
+   `userId: 'deleted_user'` y el customer de Stripe pierde nombre, email y metadata.
+   El XML/PDF timbrado NO se toca: es el documento fiscal.
+6. Borra el doc de `users` y, por último, la cuenta de Firebase Auth.
+
+Respuesta 200: `{ deleted: { conversions, storedFiles, taxProfile, subscription:
+{ cancelled, plan, effectiveAt } }, retained: { invoices, reason } }`. `reason` es un
+código estable (`fiscal_retention`), no una frase: la app está en cuatro idiomas.
+
+Si algún paso posterior a la cancelación falla, responde `500
+ACCOUNT_DELETION_PARTIAL` con `data.accountDeleted` (si la cuenta llegó a
+desaparecer) y `data.failedSteps`. El frontend necesita ese primer campo para no
+afirmar que la cuenta ya no existe cuando sigue existiendo.
+
+### Preferencias de notificación (`/users/me/preferences`)
+
+`{ notifications: { product, billing, usageReminders } }`, guardadas en el doc de
+`users` (`notificationPreferences`). Ausente equivale a todo activado. El `PUT` es
+parcial: las claves que no vengan conservan su valor, y la respuesta trae siempre las
+tres resueltas.
+
+`EmailService.processQueue` las comprueba **justo antes de enviar** —no solo al
+encolar, porque las secuencias se programan con días de antelación— usando el mapa
+`EMAIL_NOTIFICATION_CATEGORY` (`src/modules/email/email-categories.ts`). Lo que no
+sale se marca `cancelled` con su `skipReason` y cuenta en `skipped`, no en `failed`.
+>>>>>>> a260325 (feat(users): baja de cuenta (DELETE /me) y preferencias de notificación)
 
 ### Acciones sobre el historial
 

--- a/.agent-docs/ENDPOINTS.md
+++ b/.agent-docs/ENDPOINTS.md
@@ -76,21 +76,30 @@ Lógica en `src/modules/users/account-deletion.service.ts`. Encadena, **en este 
    cuenta borrada. Si Stripe rechaza cualquiera, la petición muere aquí con
    `409 SUBSCRIPTION_CANCEL_FAILED` y **no se borra nada**.
 3. Escribe `deleted_accounts/<uid>` con `deletedAt`. Esta lápida bloquea desde ese
-   instante las autorizaciones y las escrituras tardías de conversiones/batches; las
-   escrituras críticas la leen en la misma transacción con la que guardan el dato.
+   instante las autorizaciones y las escrituras tardías de conversiones/batches. Las
+   creaciones persistentes (historial, uso, cola, batches y localizadores) la leen en
+   la misma transacción con la que guardan el dato. Las actualizaciones de progreso
+   usan `update()` directo: no recrean un doc barrido ni pagan lecturas por avance.
+   Si la marca falla después de cancelar Stripe, la respuesta es
+   `ACCOUNT_DELETION_PARTIAL` con `failedSteps: ['deletionMark']`, no un 500 opaco.
 4. Borra `conversion_history` y los archivos de Storage que cuelguen de la URL firmada
    de cada fila, más el prefijo `debug-zpl/<uid>/` y sus docs de `zpl_debug_files`.
+   Los workers comprueban la lápida justo antes y después de cada subida a GCS; si la
+   baja empieza durante la subida, retiran el objeto para que no quede huérfano tras
+   este barrido.
 5. Borra los batches (`zpl-batches` + los ZIP de `batches/<batchId>/`) y los docs de
    estado de `zpl-conversions`, que siguen sirviendo `GET /zpl/status/:jobId`.
 6. Borra `usage`, el perfil fiscal (`tax_profiles`) y cancela los emails en cola.
 7. Anonimiza lo que se conserva: los `cfdis`, los registros contables
    (`stripe_transactions`, `subscription_events`) y los de actividad (`email_queue`,
-   `email_events`, `feedback`, `error_logs`) pasan a `userId: 'deleted_user'` con `userEmail` vacío,
-   y el customer de Stripe pierde nombre, email, teléfono, domicilio, metadata y sus
-   tax IDs. El XML/PDF timbrado NO se toca: es el documento fiscal. Tras borrar el
-   perfil —y antes de borrar Firebase Auth— se repite el barrido, porque el webhook
-   de cancelación puede escribir un `subscription_event` con PII mientras la baja
-   avanza.
+   `email_events`, `feedback`, `error_logs`) pasan a `userId: 'deleted_user'` con
+   `userEmail` vacío. También quita el UID de `daily_stats.activeUserIds` sin alterar
+   ningún contador y anonimiza `admin_audit_log.requestParams.userId`, conservando el
+   resto del evento administrativo. El customer de Stripe pierde nombre, email,
+   teléfono, domicilio, metadata y sus tax IDs. El XML/PDF timbrado NO se toca: es el
+   documento fiscal. Tras borrar el perfil —y antes de borrar Firebase Auth— se repite
+   el barrido, porque el webhook de cancelación puede escribir un `subscription_event`
+   con PII mientras la baja avanza.
 8. Borra el doc de `users` y, por último, la cuenta de Firebase Auth — **solo si
    ningún paso anterior falló**. Con datos o archivos pendientes, la identidad se
    conserva: es lo único que permite reintentar la baja, y sin ella esos restos

--- a/.agent-docs/ENDPOINTS.md
+++ b/.agent-docs/ENDPOINTS.md
@@ -31,14 +31,11 @@ All endpoints are prefixed with `/api` (configured in `main.ts`).
 |--------|------|------|------------|-------------|
 | POST | /users/sync | User | UsersController.syncUser | Sync Firebase user with Firestore |
 | GET | /users/me | User | UsersController.getUserProfile | Get current user profile |
-<<<<<<< HEAD
 | POST | /users/me/photo | User | UsersController.uploadPhoto | Upload the profile photo (multipart, campo `file`) |
 | DELETE | /users/me/photo | User | UsersController.deletePhoto | Remove the profile photo (204) |
-=======
 | DELETE | /users/me | User | UsersController.deleteAccount | Baja de cuenta (irreversible) |
 | GET | /users/me/preferences | User | UsersController.getPreferences | Preferencias de notificación |
 | PUT | /users/me/preferences | User | UsersController.updatePreferences | Actualizar preferencias (parcial) |
->>>>>>> a260325 (feat(users): baja de cuenta (DELETE /me) y preferencias de notificación)
 | GET | /users/verification-status | User | UsersController.getVerificationStatus | Check email verification status |
 | GET | /users/limits | User | UsersController.getUserLimits | Get plan limits and current usage |
 | GET | /users/history | User | UsersController.getUserHistory | Get conversion history (Pro+ only) |
@@ -47,7 +44,6 @@ All endpoints are prefixed with `/api` (configured in `main.ts`).
 
 **File:** `src/modules/users/users.controller.ts`
 
-<<<<<<< HEAD
 ### Foto de perfil
 
 `POST /users/me/photo` recibe `multipart/form-data` con el campo `file` y responde
@@ -69,7 +65,6 @@ si solo se guardara en Firestore seguiría mostrando la foto de Google.
 es lo que devuelve al usuario a sus iniciales; `null` (y no el campo ausente) es lo
 que distingue "la quitó" de "nunca subió ninguna", el caso en que `GET /users/me` sí
 cae en la foto del proveedor de acceso.
-=======
 ### Baja de cuenta (`DELETE /users/me`)
 
 Lógica en `src/modules/users/account-deletion.service.ts`. Encadena, **en este orden**:
@@ -80,12 +75,15 @@ Lógica en `src/modules/users/account-deletion.service.ts`. Encadena, **en este 
    faltar o estar desfasado, y fiarse solo de él dejaría un contrato cobrando a una
    cuenta borrada. Si Stripe rechaza cualquiera, la petición muere aquí con
    `409 SUBSCRIPTION_CANCEL_FAILED` y **no se borra nada**.
-3. Borra `conversion_history` y los archivos de Storage que cuelguen de la URL firmada
+3. Escribe `deleted_accounts/<uid>` con `deletedAt`. Esta lápida bloquea desde ese
+   instante las autorizaciones y las escrituras tardías de conversiones/batches; las
+   escrituras críticas la leen en la misma transacción con la que guardan el dato.
+4. Borra `conversion_history` y los archivos de Storage que cuelguen de la URL firmada
    de cada fila, más el prefijo `debug-zpl/<uid>/` y sus docs de `zpl_debug_files`.
-4. Borra los batches (`zpl-batches` + los ZIP de `batches/<batchId>/`) y los docs de
+5. Borra los batches (`zpl-batches` + los ZIP de `batches/<batchId>/`) y los docs de
    estado de `zpl-conversions`, que siguen sirviendo `GET /zpl/status/:jobId`.
-5. Borra `usage`, el perfil fiscal (`tax_profiles`) y cancela los emails en cola.
-6. Anonimiza lo que se conserva: los `cfdis`, los registros contables
+6. Borra `usage`, el perfil fiscal (`tax_profiles`) y cancela los emails en cola.
+7. Anonimiza lo que se conserva: los `cfdis`, los registros contables
    (`stripe_transactions`, `subscription_events`) y los de actividad (`email_queue`,
    `email_events`, `feedback`, `error_logs`) pasan a `userId: 'deleted_user'` con `userEmail` vacío,
    y el customer de Stripe pierde nombre, email, teléfono, domicilio, metadata y sus
@@ -93,16 +91,16 @@ Lógica en `src/modules/users/account-deletion.service.ts`. Encadena, **en este 
    perfil —y antes de borrar Firebase Auth— se repite el barrido, porque el webhook
    de cancelación puede escribir un `subscription_event` con PII mientras la baja
    avanza.
-7. Borra el doc de `users` y, por último, la cuenta de Firebase Auth — **solo si
+8. Borra el doc de `users` y, por último, la cuenta de Firebase Auth — **solo si
    ningún paso anterior falló**. Con datos o archivos pendientes, la identidad se
    conserva: es lo único que permite reintentar la baja, y sin ella esos restos
    quedarían sin dueño. Si el doc no llega a borrarse, tampoco se borra la cuenta de
    Auth.
 
-`FirebaseAuthGuard` comprueba en Firebase Auth que la cuenta existe **antes** de su
-"lazy user creation": un ID token sigue siendo válido hasta una hora después de la
-baja, y sin esa comprobación la primera petición posterior recrearía el perfil. Solo
-se paga en el alta; el resto de peticiones encuentran el documento y no pasan por ahí.
+`FirebaseAuthGuard` consulta la lápida en cada request y comprueba en Firebase Auth
+que la cuenta existe **antes** de su "lazy user creation": un ID token sigue siendo
+válido hasta una hora después de la baja, y sin esas dos redes la primera petición
+posterior podría recrear el perfil. La comprobación de Auth solo se paga en el alta.
 
 Respuesta 200: `{ deleted: { conversions, storedFiles, taxProfile, subscription:
 { cancelled, plan, effectiveAt } }, retained: { invoices, reason } }`. `reason` es un
@@ -111,7 +109,9 @@ código estable (`fiscal_retention`), no una frase: la app está en cuatro idiom
 Si algún paso posterior a la cancelación falla, responde `500
 ACCOUNT_DELETION_PARTIAL` con `data.accountDeleted` (si la cuenta llegó a
 desaparecer) y `data.failedSteps`. El frontend necesita ese primer campo para no
-afirmar que la cuenta ya no existe cuando sigue existiendo.
+afirmar que la cuenta ya no existe cuando sigue existiendo. Si Firebase Auth no se
+borra, también se elimina `deleted_accounts/<uid>` para que el usuario conserve el
+acceso y pueda reintentar.
 
 ### Preferencias de notificación (`/users/me/preferences`)
 
@@ -119,13 +119,17 @@ afirmar que la cuenta ya no existe cuando sigue existiendo.
 `users` (`notificationPreferences`). Ausente equivale a todo activado. El `PUT` es
 parcial: las claves que no vengan conservan su valor, y la respuesta trae siempre las
 tres resueltas. Se escriben con ruta anidada (`notificationPreferences.product`) para
-que dos clics seguidos en la pantalla de ajustes no se pisen.
+que dos clics seguidos en la pantalla de ajustes no se pisen; después se relee el
+documento y se devuelve el estado completo realmente persistido, incluidos cambios
+concurrentes en otras claves.
 
 `EmailService.processQueue` las comprueba **justo antes de enviar** —no solo al
 encolar, porque las secuencias se programan con días de antelación— usando el mapa
 `EMAIL_NOTIFICATION_CATEGORY` (`src/modules/email/email-categories.ts`). Lo que no
 sale se marca `cancelled` con su `skipReason` y cuenta en `skipped`, no en `failed`.
->>>>>>> a260325 (feat(users): baja de cuenta (DELETE /me) y preferencias de notificación)
+Justo antes de llamar a Resend, el worker reclama atómicamente el documento con
+`pending -> sending`; si una baja u otro worker cambió ya su estado, no envía ni lo
+sobrescribe a `sent`, y ese elemento también cuenta en `skipped`.
 
 ### Acciones sobre el historial
 

--- a/.agent-docs/SCHEMAS.md
+++ b/.agent-docs/SCHEMAS.md
@@ -65,6 +65,13 @@ interface User {
   countrySource?: 'ip' | 'stripe' | 'manual';
   countryDetectedAt?: Date;
 
+  // Preferencias de notificación por email (ausente = todo activado)
+  notificationPreferences?: {
+    product?: boolean;        // novedades del producto, onboarding, retención
+    billing?: boolean;        // cobros, fallos de pago, facturas
+    usageReminders?: boolean; // avisos al acercarse al límite del plan
+  };
+
   // Activity tracking
   lastActivityAt?: Date;
   notifiedInactive7Days?: boolean;

--- a/src/common/constants/error-codes.ts
+++ b/src/common/constants/error-codes.ts
@@ -52,6 +52,21 @@ export const ErrorCodes = {
    */
   ZPL_NOT_AVAILABLE: 'ZPL_NOT_AVAILABLE',
 
+  // Errores de baja de cuenta (409/500)
+  /**
+   * Stripe rechazó cancelar la suscripción, así que NO se borró nada: cancelar
+   * el contrato es el primer paso del borrado justamente para que un fallo aquí
+   * deje la cuenta intacta. El usuario conserva su plan y puede reintentar.
+   */
+  SUBSCRIPTION_CANCEL_FAILED: 'SUBSCRIPTION_CANCEL_FAILED',
+  /**
+   * La baja se quedó a medias: la suscripción sí quedó cancelada en Stripe pero
+   * alguno de los borrados posteriores falló. `data.accountDeleted` dice si la
+   * cuenta llegó a desaparecer —el frontend no puede afirmar que ya no existe
+   * sin mirarlo— y `data.failedSteps` enumera lo que quedó pendiente.
+   */
+  ACCOUNT_DELETION_PARTIAL: 'ACCOUNT_DELETION_PARTIAL',
+
   // Errores de estado (400)
   BATCH_PROCESSING: 'BATCH_PROCESSING',
   JOB_NOT_COMPLETE: 'JOB_NOT_COMPLETE',
@@ -107,6 +122,9 @@ export const ErrorHttpStatus: Record<ErrorCode, number> = {
   [ErrorCodes.DOWNLOAD_NOT_AVAILABLE]: 404,
   [ErrorCodes.HISTORY_NOT_FOUND]: 404,
 
+  // 409 Conflict
+  [ErrorCodes.SUBSCRIPTION_CANCEL_FAILED]: 409,
+
   // 410 Gone
   [ErrorCodes.JOB_EXPIRED]: 410,
   [ErrorCodes.ZPL_NOT_AVAILABLE]: 410,
@@ -117,6 +135,7 @@ export const ErrorHttpStatus: Record<ErrorCode, number> = {
 
   // 500 Internal Server Error
   [ErrorCodes.SERVER_ERROR]: 500,
+  [ErrorCodes.ACCOUNT_DELETION_PARTIAL]: 500,
 
   // 503 Service Unavailable
   [ErrorCodes.SERVICE_UNAVAILABLE]: 503,
@@ -157,6 +176,10 @@ export const ErrorMessagesEs: Record<ErrorCode, string> = {
   [ErrorCodes.HISTORY_NOT_FOUND]: 'Registro de historial no encontrado',
   [ErrorCodes.ZPL_NOT_AVAILABLE]:
     'El ZPL original de esta conversión ya no está disponible',
+  [ErrorCodes.SUBSCRIPTION_CANCEL_FAILED]:
+    'No se pudo cancelar la suscripción; no se ha borrado nada de tu cuenta',
+  [ErrorCodes.ACCOUNT_DELETION_PARTIAL]:
+    'La baja quedó incompleta: revisa el detalle antes de darla por hecha',
   [ErrorCodes.BATCH_PROCESSING]: 'El batch aún está procesándose',
   [ErrorCodes.JOB_NOT_COMPLETE]: 'La conversión no está completa',
   [ErrorCodes.SERVER_ERROR]: 'Error interno del servidor',
@@ -194,6 +217,10 @@ export const ErrorMessagesEn: Record<ErrorCode, string> = {
   [ErrorCodes.HISTORY_NOT_FOUND]: 'History record not found',
   [ErrorCodes.ZPL_NOT_AVAILABLE]:
     'The original ZPL for this conversion is no longer available',
+  [ErrorCodes.SUBSCRIPTION_CANCEL_FAILED]:
+    'Could not cancel the subscription; nothing was deleted from your account',
+  [ErrorCodes.ACCOUNT_DELETION_PARTIAL]:
+    'Account deletion was left incomplete: check the details before assuming it finished',
   [ErrorCodes.BATCH_PROCESSING]: 'Batch is still processing',
   [ErrorCodes.JOB_NOT_COMPLETE]: 'Conversion is not complete',
   [ErrorCodes.SERVER_ERROR]: 'Internal server error',

--- a/src/common/guards/firebase-auth.guard.spec.ts
+++ b/src/common/guards/firebase-auth.guard.spec.ts
@@ -1,0 +1,101 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { FirebaseAuthGuard } from './firebase-auth.guard.js';
+
+/**
+ * El guard crea el documento de usuario a la primera petición autenticada
+ * ("lazy user creation"). Un ID token sigue siendo criptográficamente válido
+ * hasta una hora después de borrar la cuenta, así que sin comprobar Firebase
+ * Auth esa creación resucitaría cualquier cuenta recién dada de baja (issue
+ * #99).
+ */
+describe('FirebaseAuthGuard — cuentas borradas', () => {
+  function buildContext(token = 'token-valido') {
+    const request: Record<string, any> = {
+      headers: { authorization: `Bearer ${token}` },
+    };
+    return {
+      request,
+      context: {
+        switchToHttp: () => ({ getRequest: () => request }),
+      } as any,
+    };
+  }
+
+  function buildGuard(options: {
+    storedUser?: Record<string, any> | null;
+    getUser?: jest.Mock;
+  }) {
+    const createUser = jest.fn().mockResolvedValue(undefined);
+    const getUser =
+      options.getUser ??
+      jest.fn().mockResolvedValue({ uid: 'uid-1', emailVerified: true });
+
+    const guard = new FirebaseAuthGuard(
+      {
+        verifyToken: jest
+          .fn()
+          .mockResolvedValue({ uid: 'uid-1', email: 'user@example.com' }),
+        getUser,
+      } as any,
+      {
+        getUserById: jest.fn().mockResolvedValue(options.storedUser ?? null),
+        createUser,
+      } as any,
+    );
+
+    return { guard, createUser, getUser };
+  }
+
+  it('no recrea el perfil de una cuenta que ya no existe en Firebase Auth', async () => {
+    const { guard, createUser } = buildGuard({
+      storedUser: null,
+      getUser: jest
+        .fn()
+        .mockRejectedValue(
+          Object.assign(new Error('no user'), { code: 'auth/user-not-found' }),
+        ),
+    });
+    const { context } = buildContext();
+
+    await expect(guard.canActivate(context)).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+    expect(createUser).not.toHaveBeenCalled();
+  });
+
+  it('sigue creando el perfil de un usuario nuevo cuya cuenta sí existe', async () => {
+    const { guard, createUser } = buildGuard({ storedUser: null });
+    const { context, request } = buildContext();
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+    expect(createUser).toHaveBeenCalled();
+    expect(request.user.uid).toBe('uid-1');
+  });
+
+  it('no comprueba Firebase Auth cuando el perfil ya existe', async () => {
+    const { guard, getUser, createUser } = buildGuard({
+      storedUser: {
+        id: 'uid-1',
+        email: 'user@example.com',
+        displayName: 'User',
+      },
+    });
+    const { context } = buildContext();
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+    // El camino caliente no paga la llamada extra.
+    expect(getUser).not.toHaveBeenCalled();
+    expect(createUser).not.toHaveBeenCalled();
+  });
+
+  it('un fallo de Firebase Auth distinto de user-not-found no bloquea el alta', async () => {
+    const { guard, createUser } = buildGuard({
+      storedUser: null,
+      getUser: jest.fn().mockRejectedValue(new Error('auth caído')),
+    });
+    const { context } = buildContext();
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+    expect(createUser).toHaveBeenCalled();
+  });
+});

--- a/src/common/guards/firebase-auth.guard.spec.ts
+++ b/src/common/guards/firebase-auth.guard.spec.ts
@@ -24,6 +24,7 @@ describe('FirebaseAuthGuard — cuentas borradas', () => {
   function buildGuard(options: {
     storedUser?: Record<string, any> | null;
     getUser?: jest.Mock;
+    deletionMarked?: boolean;
   }) {
     const createUser = jest.fn().mockResolvedValue(undefined);
     const getUser =
@@ -38,6 +39,9 @@ describe('FirebaseAuthGuard — cuentas borradas', () => {
         getUser,
       } as any,
       {
+        isAccountDeletionMarked: jest
+          .fn()
+          .mockResolvedValue(options.deletionMarked ?? false),
         getUserById: jest.fn().mockResolvedValue(options.storedUser ?? null),
         createUser,
       } as any,
@@ -60,6 +64,22 @@ describe('FirebaseAuthGuard — cuentas borradas', () => {
     await expect(guard.canActivate(context)).rejects.toBeInstanceOf(
       UnauthorizedException,
     );
+    expect(createUser).not.toHaveBeenCalled();
+  });
+
+  it('no recrea ni admite un uid con una baja marcada aunque Auth siga vivo', async () => {
+    const { guard, createUser, getUser } = buildGuard({
+      storedUser: null,
+      deletionMarked: true,
+    });
+    const { context } = buildContext();
+
+    await expect(guard.canActivate(context)).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+    // Durante el barrido Auth existe todavía: consultarlo no puede convertir
+    // esa existencia transitoria en permiso para resucitar el perfil.
+    expect(getUser).not.toHaveBeenCalled();
     expect(createUser).not.toHaveBeenCalled();
   });
 

--- a/src/common/guards/firebase-auth.guard.ts
+++ b/src/common/guards/firebase-auth.guard.ts
@@ -43,6 +43,16 @@ export class FirebaseAuthGuard implements CanActivate {
 
     // Lazy user creation: buscar o crear usuario en Firestore
     try {
+      // La cuenta de Auth todavía puede existir mientras la baja barre datos o
+      // si su borrado fue el último paso en fallar. La lápida de Firestore es la
+      // segunda red: bloquea tráfico nuevo y, sobre todo, impide que el camino
+      // de creación perezosa resucite el perfil entre ambos borrados.
+      if (
+        await this.firestoreService.isAccountDeletionMarked(decodedToken.uid)
+      ) {
+        throw new UnauthorizedException('Account no longer exists');
+      }
+
       let user = await this.firestoreService.getUserById(decodedToken.uid);
 
       if (!user) {

--- a/src/common/guards/firebase-auth.guard.ts
+++ b/src/common/guards/firebase-auth.guard.ts
@@ -46,6 +46,15 @@ export class FirebaseAuthGuard implements CanActivate {
       let user = await this.firestoreService.getUserById(decodedToken.uid);
 
       if (!user) {
+        // Antes de crear nada: comprobar que la cuenta sigue existiendo en
+        // Firebase Auth. Un ID token sigue siendo criptográficamente válido
+        // hasta una hora después de borrar la cuenta, así que sin esta
+        // comprobación la primera petición posterior a una baja recrearía el
+        // documento y la cuenta "borrada" volvería a existir. Solo se paga en
+        // el alta —el resto de peticiones encuentran el documento y no pasan
+        // por aquí—, así que no añade latencia al camino normal.
+        await this.assertAuthAccountExists(decodedToken.uid);
+
         // Crear usuario con plan free
         const newUser: User = {
           id: decodedToken.uid,
@@ -71,6 +80,13 @@ export class FirebaseAuthGuard implements CanActivate {
       };
       return true;
     } catch (error) {
+      // El rechazo por cuenta inexistente es una decisión, no un fallo de
+      // Firestore: degradarlo al acceso permitido de abajo reabriría justo el
+      // agujero que cierra.
+      if (error instanceof UnauthorizedException) {
+        throw error;
+      }
+
       this.logger.error(`Firestore error: ${error.message}`);
       // Si Firestore falla, aún permitimos el acceso con datos del token
       request.user = {
@@ -81,6 +97,31 @@ export class FirebaseAuthGuard implements CanActivate {
         picture: decodedToken.picture,
       };
       return true;
+    }
+  }
+
+  /**
+   * Rechaza al portador de un token cuya cuenta de Firebase Auth ya no existe.
+   *
+   * Solo `auth/user-not-found` bloquea: cualquier otro fallo (Auth caído, SDK
+   * sin credenciales) dejaría sin registrarse a usuarios legítimos, y esta
+   * comprobación es una salvaguarda contra la resurrección de una cuenta
+   * borrada, no el control de acceso principal.
+   */
+  private async assertAuthAccountExists(uid: string): Promise<void> {
+    try {
+      await this.firebaseAdminService.getUser(uid);
+    } catch (error) {
+      if (error?.code === 'auth/user-not-found') {
+        this.logger.warn(
+          `Token válido de una cuenta ya borrada (${uid}); no se recrea el perfil`,
+        );
+        throw new UnauthorizedException('Account no longer exists');
+      }
+
+      this.logger.warn(
+        `No se pudo comprobar la cuenta ${uid} en Firebase Auth: ${error.message}`,
+      );
     }
   }
 }

--- a/src/common/interfaces/cfdi.interface.ts
+++ b/src/common/interfaces/cfdi.interface.ts
@@ -41,6 +41,12 @@ export interface Cfdi {
   attempts: number;
 
   stampedAt?: Date | null;
+  /**
+   * Momento en que el titular se dio de baja y el comprobante se desvinculó de
+   * él (`userId` pasa a `deleted_user`). El CFDI se conserva cinco años por
+   * obligación fiscal, así que no se borra: solo deja de identificar a nadie.
+   */
+  anonymizedAt?: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/src/common/interfaces/notification-preferences.interface.ts
+++ b/src/common/interfaces/notification-preferences.interface.ts
@@ -1,0 +1,46 @@
+/**
+ * Preferencias de notificación por email, agrupadas por tipo de contenido.
+ *
+ * Viven dentro del documento de `users` (campo `notificationPreferences`) en vez
+ * de en su propia colección: son tres booleanos que se consultan justo antes de
+ * enviar cada email, y el doc de usuario ya se lee en ese punto.
+ *
+ * Ausente equivale a "todo activado": la opción por defecto tiene que ser la
+ * misma para las cuentas antiguas —creadas antes de que existieran estas
+ * preferencias— y para las nuevas, y ninguna de las dos ha pedido dejar de
+ * recibir nada.
+ */
+export interface NotificationPreferences {
+  /** Novedades y cambios del producto. */
+  product: boolean;
+  /** Cobros, fallos de pago y facturas. */
+  billing: boolean;
+  /** Avisos al acercarse al límite del plan. */
+  usageReminders: boolean;
+}
+
+export type NotificationCategory = keyof NotificationPreferences;
+
+export const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
+  product: true,
+  billing: true,
+  usageReminders: true,
+};
+
+/**
+ * Normaliza lo que haya en Firestore a las tres claves del contrato.
+ *
+ * Rellena con los valores por defecto lo que falte —un documento anterior a
+ * esta feature no tiene el campo— y descarta cualquier clave extra, para que la
+ * respuesta del endpoint no dependa de lo que se haya persistido alguna vez.
+ */
+export function resolveNotificationPreferences(
+  stored?: Partial<NotificationPreferences> | null,
+): NotificationPreferences {
+  return {
+    product: stored?.product ?? DEFAULT_NOTIFICATION_PREFERENCES.product,
+    billing: stored?.billing ?? DEFAULT_NOTIFICATION_PREFERENCES.billing,
+    usageReminders:
+      stored?.usageReminders ?? DEFAULT_NOTIFICATION_PREFERENCES.usageReminders,
+  };
+}

--- a/src/common/interfaces/user.interface.ts
+++ b/src/common/interfaces/user.interface.ts
@@ -1,3 +1,5 @@
+import type { NotificationPreferences } from './notification-preferences.interface.js';
+
 export type PlanType = 'free' | 'lite' | 'pro' | 'promax' | 'enterprise';
 export type UserRole = 'user' | 'admin';
 export type CountrySource = 'ip' | 'stripe' | 'manual';
@@ -73,6 +75,11 @@ export interface User {
   city?: string;
   countrySource?: CountrySource;
   countryDetectedAt?: Date;
+  /**
+   * Preferencias de notificación por email. Ausente = todo activado; ver
+   * `resolveNotificationPreferences`.
+   */
+  notificationPreferences?: Partial<NotificationPreferences>;
   // Campos de actividad e inactividad (para GA4)
   lastActivityAt?: Date;
   notifiedInactive7Days?: boolean;

--- a/src/common/utils/storage-url.util.ts
+++ b/src/common/utils/storage-url.util.ts
@@ -1,0 +1,20 @@
+/**
+ * Extrae el path dentro del bucket de una URL firmada de Google Cloud Storage.
+ *
+ * Formato: `https://storage.googleapis.com/<bucket>/<path>?X-Goog-...`
+ *
+ * Devuelve `null` si la URL no tiene esa forma. El historial guarda la URL
+ * firmada tal cual se generó, y las hay antiguas o vacías: quien llama decide
+ * si eso es un error (no lo es al borrar una cuenta: sin path, no hay objeto
+ * que borrar).
+ */
+export function extractStoragePathFromSignedUrl(
+  signedUrl: string | undefined | null,
+): string | null {
+  if (!signedUrl) {
+    return null;
+  }
+
+  const match = signedUrl.match(/googleapis\.com\/[^/]+\/([^?]+)/);
+  return match ? match[1] : null;
+}

--- a/src/modules/auth/firebase-admin.service.ts
+++ b/src/modules/auth/firebase-admin.service.ts
@@ -72,4 +72,29 @@ export class FirebaseAdminService implements OnModuleInit {
     }
     return this.app.auth().updateUser(uid, properties);
   }
+
+  /**
+   * Borra la cuenta de Firebase Auth.
+   *
+   * Trata `auth/user-not-found` como éxito: la baja de cuenta es reintentable, y
+   * un segundo intento tras un fallo posterior no puede quedarse bloqueado
+   * porque el usuario ya no esté en Auth.
+   */
+  async deleteUser(uid: string): Promise<void> {
+    if (!this.app) {
+      throw new Error('Firebase Admin SDK not initialized');
+    }
+
+    try {
+      await this.app.auth().deleteUser(uid);
+    } catch (error) {
+      if (error?.code === 'auth/user-not-found') {
+        this.logger.warn(
+          `El usuario ${uid} ya no existía en Firebase Auth al borrarlo`,
+        );
+        return;
+      }
+      throw error;
+    }
+  }
 }

--- a/src/modules/cache/firestore.service.spec.ts
+++ b/src/modules/cache/firestore.service.spec.ts
@@ -1459,3 +1459,199 @@ describe('FirestoreService — anonimiza UIDs en agregados y auditoría', () => 
     expect(anonymized).toBe(2);
   });
 });
+
+/**
+ * La cola de emails ya costó una tanda de avisos sin enviar por un índice que
+ * faltaba, así que sus consultas se mantienen a un solo filtro y el resto se
+ * descarta en memoria. Lo que estos tests protegen es eso y el ciclo del lease:
+ * un envío reclamado por un proceso que muere no puede quedarse en `sending`
+ * para siempre, ni reenviarse mientras otro worker lo está mandando.
+ */
+describe('FirestoreService — lease de la cola de emails', () => {
+  function emailDoc(
+    id: string,
+    data: Record<string, unknown>,
+  ): Record<string, any> {
+    return {
+      id,
+      exists: true,
+      get: (field: string) => data[field],
+      data: () => data,
+      ref: { id },
+    };
+  }
+
+  function buildService(options: {
+    pending?: Record<string, any>[];
+    sending?: Record<string, any>[];
+    doc?: Record<string, unknown> | null;
+    deletionMarked?: boolean;
+  }) {
+    const queries: Array<Record<string, any>> = [];
+    const update = jest.fn();
+
+    function makeQuery(collection: string, filters: Record<string, any>) {
+      const query: any = {
+        collection,
+        filters,
+        where: (field: string, _op: string, value: unknown) =>
+          makeQuery(collection, { ...filters, [field]: value }),
+        orderBy: () => query,
+        limit: () => query,
+        get: async () => {
+          queries.push({ collection, filters });
+          const docs =
+            filters.status === 'sending'
+              ? (options.sending ?? [])
+              : (options.pending ?? []);
+          return { docs, size: docs.length, empty: docs.length === 0 };
+        },
+      };
+      return query;
+    }
+
+    const service: any = Object.create(FirestoreService.prototype);
+    service.emailQueueCollection = 'email_queue';
+    service.deletedAccountsCollection = 'deleted_accounts';
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    service.firestore = {
+      collection: (name: string) => ({
+        ...makeQuery(name, {}),
+        doc: (id: string) => ({ id, collection: name }),
+      }),
+      runTransaction: (fn: (t: unknown) => Promise<boolean>) =>
+        fn({
+          get: async (ref: any) =>
+            ref.collection === 'deleted_accounts'
+              ? { exists: !!options.deletionMarked }
+              : options.doc
+                ? emailDoc(ref.id, options.doc)
+                : { exists: false, get: () => undefined },
+          update,
+        }),
+    };
+
+    return { service, update, queries };
+  }
+
+  const HACE_UNA_HORA = new Date(Date.now() - 60 * 60 * 1000);
+  const HACE_UN_SEGUNDO = new Date(Date.now() - 1000);
+
+  it('devuelve al ciclo los envíos que llevan demasiado en sending', async () => {
+    const { service } = buildService({
+      pending: [],
+      sending: [
+        emailDoc('abandonado', {
+          userId: 'uid-1',
+          userEmail: 'a@example.com',
+          emailType: 'welcome',
+          abVariant: 'A',
+          language: 'es',
+          sendingAt: HACE_UNA_HORA,
+        }),
+      ],
+    });
+
+    const result = await service.getPendingEmails(50);
+
+    expect(result.map((e: any) => e.id)).toEqual(['abandonado']);
+  });
+
+  it('no toca el envío que otro worker acaba de reclamar', async () => {
+    const { service } = buildService({
+      pending: [],
+      sending: [
+        emailDoc('en-vuelo', {
+          userId: 'uid-1',
+          sendingAt: HACE_UN_SEGUNDO,
+        }),
+      ],
+    });
+
+    await expect(service.getPendingEmails(50)).resolves.toEqual([]);
+  });
+
+  it('consulta los sending con un solo filtro, sin índice compuesto', async () => {
+    const { service, queries } = buildService({ pending: [], sending: [] });
+
+    await service.getPendingEmails(50);
+    await service.countInFlightEmails('uid-1');
+
+    // Un `where` extra sobre sendingAt o userId exigiría un índice compuesto que
+    // no existe en `email_queue`, y la query fallaría en producción con
+    // FAILED_PRECONDITION.
+    for (const query of queries.filter((q) => q.filters.status === 'sending')) {
+      expect(Object.keys(query.filters)).toEqual(['status']);
+    }
+  });
+
+  it('cuenta solo los envíos en vuelo del usuario que se da de baja', async () => {
+    const { service } = buildService({
+      sending: [
+        emailDoc('suyo', { userId: 'uid-1', sendingAt: HACE_UN_SEGUNDO }),
+        emailDoc('ajeno', { userId: 'uid-2', sendingAt: HACE_UN_SEGUNDO }),
+      ],
+    });
+
+    await expect(service.countInFlightEmails('uid-1')).resolves.toBe(1);
+  });
+
+  it('reclama un email pendiente', async () => {
+    const { service, update } = buildService({
+      doc: { status: 'pending', userId: 'uid-1' },
+    });
+
+    await expect(service.claimPendingEmail('q-1', 'uid-1')).resolves.toBe(true);
+    expect(update).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ status: 'sending' }),
+    );
+  });
+
+  it('no reclama un email cuya cuenta está marcada para borrado', async () => {
+    const { service, update } = buildService({
+      doc: { status: 'pending', userId: 'uid-1' },
+      deletionMarked: true,
+    });
+
+    // La marca se escribe antes de barrer nada: el destinatario ya pidió que su
+    // dirección se olvidara, así que el correo no puede salir.
+    await expect(service.claimPendingEmail('q-1', 'uid-1')).resolves.toBe(
+      false,
+    );
+    expect(update).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        status: 'cancelled',
+        skipReason: 'account_deleted',
+      }),
+    );
+  });
+
+  it('readmite un sending con el lease vencido', async () => {
+    const { service } = buildService({
+      doc: { status: 'sending', userId: 'uid-1', sendingAt: HACE_UNA_HORA },
+    });
+
+    await expect(service.claimPendingEmail('q-1', 'uid-1')).resolves.toBe(true);
+  });
+
+  it('no readmite un sending que sigue dentro de su lease', async () => {
+    const { service } = buildService({
+      doc: { status: 'sending', userId: 'uid-1', sendingAt: HACE_UN_SEGUNDO },
+    });
+
+    await expect(service.claimPendingEmail('q-1', 'uid-1')).resolves.toBe(
+      false,
+    );
+  });
+
+  it('no reclama lo que ya se envió o se canceló', async () => {
+    for (const status of ['sent', 'cancelled', 'failed']) {
+      const { service } = buildService({ doc: { status, userId: 'uid-1' } });
+      await expect(service.claimPendingEmail('q-1', 'uid-1')).resolves.toBe(
+        false,
+      );
+    }
+  });
+});

--- a/src/modules/cache/firestore.service.spec.ts
+++ b/src/modules/cache/firestore.service.spec.ts
@@ -1337,3 +1337,125 @@ describe('FirestoreService — la inactividad no depende del historial', () => {
     expect(resultado.users.map((u: any) => u.userId)).toEqual(['uid-inactivo']);
   });
 });
+
+/**
+ * Las actualizaciones de progreso son muy frecuentes y solo modifican
+ * documentos ya creados. `update()` no resucita un documento borrado, por lo
+ * que releer estado + lápida en una transacción era coste sin protección extra.
+ */
+describe('FirestoreService — progreso sin transacciones de lápida', () => {
+  function buildService() {
+    const update = jest.fn().mockResolvedValue(undefined);
+    const runTransaction = jest.fn();
+    const service: any = Object.create(FirestoreService.prototype);
+    Object.assign(service, {
+      collectionName: 'zpl-conversions',
+      batchCollection: 'zpl-batches',
+      zplDebugCollection: 'zpl_debug_files',
+      logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+      firestore: {
+        collection: () => ({ doc: () => ({ update }) }),
+        runTransaction,
+      },
+    });
+    return { service, update, runTransaction };
+  }
+
+  it('actualiza el progreso de conversión con una sola escritura', async () => {
+    const { service, update, runTransaction } = buildService();
+
+    await service.updateConversionStatus('job-1', { progress: 50 });
+
+    expect(update).toHaveBeenCalledWith({
+      progress: 50,
+      updatedAt: expect.any(String),
+    });
+    expect(runTransaction).not.toHaveBeenCalled();
+  });
+
+  it('no relee el batch ni la lápida para cada archivo procesado', async () => {
+    const { service, update, runTransaction } = buildService();
+
+    await service.updateBatchJob('batch-1', { completedFiles: 3 });
+
+    expect(update).toHaveBeenCalledWith({
+      completedFiles: 3,
+      updatedAt: expect.any(Date),
+    });
+    expect(runTransaction).not.toHaveBeenCalled();
+  });
+
+  it('marca el resultado debug sin convertirlo en una transacción', async () => {
+    const { service, update, runTransaction } = buildService();
+
+    await service.updateZplDebugResult('job-1', 'success');
+
+    expect(update).toHaveBeenCalledWith({ result: 'success' });
+    expect(runTransaction).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * La baja conserva las series históricas, pero no sus identificadores
+ * auxiliares. Los contadores diarios y los datos del cambio de plan deben
+ * sobrevivir exactamente iguales salvo por el UID.
+ */
+describe('FirestoreService — anonimiza UIDs en agregados y auditoría', () => {
+  it('quita el UID sin reescribir totales ni el resto de requestParams', async () => {
+    const dailyRef = { path: 'daily_stats/2026-08-19' };
+    const auditRef = { path: 'admin_audit_log/audit-1' };
+    const dailyDoc = {
+      ref: dailyRef,
+      get: (field: string) =>
+        field === 'activeUserIds' ? ['uid-1', 'uid-2'] : undefined,
+    };
+    const auditDoc = { ref: auditRef };
+    const update = jest.fn();
+    const commit = jest.fn().mockResolvedValue(undefined);
+
+    const service: any = Object.create(FirestoreService.prototype);
+    Object.assign(service, {
+      emailQueueCollection: 'email_queue',
+      emailEventsCollection: 'email_events',
+      feedbackCollection: 'feedback',
+      errorLogsCollection: 'error_logs',
+      dailyStatsCollection: 'daily_stats',
+      adminAuditCollection: 'admin_audit_log',
+      firestore: {
+        collection: (collection: string) => ({
+          where: (field: string) => ({
+            get: async () => {
+              if (collection === 'daily_stats' && field === 'activeUserIds') {
+                return { docs: [dailyDoc], empty: false };
+              }
+              if (
+                collection === 'admin_audit_log' &&
+                field === 'requestParams.userId'
+              ) {
+                return { docs: [auditDoc], empty: false };
+              }
+              return { docs: [], empty: true };
+            },
+          }),
+        }),
+        batch: () => ({ update, commit }),
+      },
+    });
+
+    const anonymized = await service.anonymizeUserActivityRecords('uid-1');
+
+    expect(update).toHaveBeenCalledWith(dailyRef, {
+      activeUserIds: ['uid-2'],
+    });
+    expect(update).toHaveBeenCalledWith(
+      auditRef,
+      expect.objectContaining({
+        'requestParams.userId': FirestoreService.ANONYMIZED_USER_ID,
+        anonymizedAt: expect.any(Date),
+      }),
+    );
+    // Solo se escriben los campos identificadores: ningún contador histórico
+    // ni los planes guardados en requestParams aparecen en los updates.
+    expect(anonymized).toBe(2);
+  });
+});

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -7645,6 +7645,30 @@ export class FirestoreService {
   /** Tope de documentos por lote en los borrados de la baja de cuenta. */
   private static readonly DELETION_BATCH_SIZE = 400;
 
+  /**
+   * Escribe solo los interruptores que vengan, con rutas de campo anidadas.
+   *
+   * Firestore fusiona `notificationPreferences.product` sin releer el resto del
+   * objeto, así que dos cambios simultáneos —dos clics seguidos en la pantalla
+   * de ajustes— ya no se pisan: escribir el objeto entero haría que el segundo
+   * revirtiera el interruptor del primero con el valor que leyó antes.
+   */
+  async updateNotificationPreferences(
+    userId: string,
+    changes: Record<string, boolean>,
+  ): Promise<void> {
+    const updates: Record<string, any> = { updatedAt: new Date() };
+
+    for (const [key, value] of Object.entries(changes)) {
+      updates[`notificationPreferences.${key}`] = value;
+    }
+
+    await this.firestore
+      .collection(this.usersCollection)
+      .doc(userId)
+      .update(updates);
+  }
+
   /** Borra el documento de `users`. */
   async deleteUser(userId: string): Promise<void> {
     try {
@@ -7768,11 +7792,12 @@ export class FirestoreService {
    * Desvincula del usuario la cola de emails, sus eventos y su feedback.
    *
    * `email_queue` guarda `userEmail` y la metadata con la que se compuso cada
-   * envío (nombre incluido); `email_events` y `feedback` guardan `userId` y
-   * `userEmail`, y el feedback además texto libre. Se anonimizan en vez de
-   * borrarse porque las métricas de email y el feedback del producto se
-   * calculan sobre ellos y borrarlos falsearía la serie histórica: lo que
-   * desaparece es a quién pertenecen.
+   * envío (nombre incluido); `email_events`, `feedback` y `error_logs` guardan
+   * `userId` y `userEmail`, y los dos últimos además texto libre y contexto del
+   * fallo. Se anonimizan en vez de borrarse porque las métricas de email, el
+   * feedback del producto y el dashboard de errores se calculan sobre ellos y
+   * borrarlos falsearía la serie histórica: lo que desaparece es a quién
+   * pertenecen.
    *
    * @returns cuántos documentos se anonimizaron entre las tres colecciones.
    */
@@ -7784,6 +7809,10 @@ export class FirestoreService {
       { collection: this.emailQueueCollection, clearMetadata: true },
       { collection: this.emailEventsCollection, clearMetadata: true },
       { collection: this.feedbackCollection, clearMetadata: false },
+      // `error_logs` guarda `userEmail` y un `context` que puede arrastrar lo
+      // que el usuario tecleó al fallar. Los errores se conservan porque el
+      // dashboard vive de ellos, pero dejan de apuntar a nadie.
+      { collection: this.errorLogsCollection, clearMetadata: true },
     ];
 
     for (const { collection, clearMetadata } of targets) {
@@ -7813,9 +7842,15 @@ export class FirestoreService {
           }
 
           // La metadata del email lleva el nombre con el que se personalizó el
-          // envío. El feedback conserva la suya: es contenido de producto.
-          if (clearMetadata && doc.get('metadata') !== undefined) {
-            updates.metadata = FieldValue.delete();
+          // envío, y el `context` de un error puede arrastrar el contenido que
+          // lo provocó. El feedback conserva la suya: es contenido de producto.
+          if (clearMetadata) {
+            if (doc.get('metadata') !== undefined) {
+              updates.metadata = FieldValue.delete();
+            }
+            if (doc.get('context') !== undefined) {
+              updates.context = FieldValue.delete();
+            }
           }
 
           batch.update(doc.ref, updates);

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -232,6 +232,7 @@ export class FirestoreService {
 
   private readonly collectionName = 'zpl-conversions';
   private readonly usersCollection = 'users';
+  private readonly deletedAccountsCollection = 'deleted_accounts';
   private readonly usageCollection = 'usage';
   private readonly historyCollection = 'conversion_history';
   // Finance collections
@@ -300,10 +301,20 @@ export class FirestoreService {
     status: ConversionStatus,
   ): Promise<void> {
     try {
-      await this.firestore
-        .collection(this.collectionName)
-        .doc(jobId)
-        .set(status, { merge: true });
+      const ref = this.firestore.collection(this.collectionName).doc(jobId);
+
+      if (status.userId) {
+        const deletedRef = this.firestore
+          .collection(this.deletedAccountsCollection)
+          .doc(status.userId);
+        await this.firestore.runTransaction(async (transaction) => {
+          const deleted = await transaction.get(deletedRef);
+          this.assertAccountWritable(status.userId, deleted.exists);
+          transaction.set(ref, status, { merge: true });
+        });
+      } else {
+        await ref.set(status, { merge: true });
+      }
 
       this.logger.log(`Estado de conversion actualizado para jobId: ${jobId}`);
     } catch (error) {
@@ -335,13 +346,26 @@ export class FirestoreService {
     status: Partial<ConversionStatus>,
   ): Promise<void> {
     try {
-      await this.firestore
-        .collection(this.collectionName)
-        .doc(jobId)
-        .update({
+      const ref = this.firestore.collection(this.collectionName).doc(jobId);
+
+      await this.firestore.runTransaction(async (transaction) => {
+        const current = await transaction.get(ref);
+        const userId = status.userId || current.get('userId');
+
+        if (userId) {
+          const deleted = await transaction.get(
+            this.firestore
+              .collection(this.deletedAccountsCollection)
+              .doc(userId),
+          );
+          this.assertAccountWritable(userId, deleted.exists);
+        }
+
+        transaction.update(ref, {
           ...status,
           updatedAt: new Date().toISOString(),
         });
+      });
 
       this.logger.log(`Estado actualizado para jobId: ${jobId}`);
     } catch (error) {
@@ -354,14 +378,22 @@ export class FirestoreService {
 
   async createUser(user: User): Promise<void> {
     try {
-      await this.firestore
+      const userRef = this.firestore
         .collection(this.usersCollection)
-        .doc(user.id)
-        .set({
+        .doc(user.id);
+      const deletedRef = this.firestore
+        .collection(this.deletedAccountsCollection)
+        .doc(user.id);
+
+      await this.firestore.runTransaction(async (transaction) => {
+        const deleted = await transaction.get(deletedRef);
+        this.assertAccountWritable(user.id, deleted.exists);
+        transaction.set(userRef, {
           ...user,
           createdAt: user.createdAt || new Date(),
           updatedAt: new Date(),
         });
+      });
       this.logger.log(`Usuario creado: ${user.id}`);
     } catch (error) {
       this.logger.error(`Error al crear usuario: ${error.message}`);
@@ -397,6 +429,41 @@ export class FirestoreService {
     } catch (error) {
       this.logger.error(`Error al obtener usuario: ${error.message}`);
       throw error;
+    }
+  }
+
+  /** Marca el UID antes de barrer sus datos y bloquea escrituras posteriores. */
+  async markAccountDeletion(userId: string): Promise<void> {
+    await this.firestore
+      .collection(this.deletedAccountsCollection)
+      .doc(userId)
+      .set({ deletedAt: new Date() });
+  }
+
+  /** Permite reintentar una baja parcial con la identidad todavía activa. */
+  async clearAccountDeletionMark(userId: string): Promise<void> {
+    await this.firestore
+      .collection(this.deletedAccountsCollection)
+      .doc(userId)
+      .delete();
+  }
+
+  async isAccountDeletionMarked(userId: string): Promise<boolean> {
+    const doc = await this.firestore
+      .collection(this.deletedAccountsCollection)
+      .doc(userId)
+      .get();
+    return doc.exists;
+  }
+
+  /**
+   * Las transacciones que leen la lápida y escriben el dato forman una única
+   * frontera: si la baja gana la carrera, Firestore reintenta la transacción y
+   * esta termina aquí sin recrear restos del usuario.
+   */
+  private assertAccountWritable(userId: string, deleted: boolean): void {
+    if (deleted) {
+      throw new Error(`Account deletion in progress for user ${userId}`);
     }
   }
 
@@ -1103,21 +1170,29 @@ export class FirestoreService {
       const docRef = this.firestore
         .collection(this.usageCollection)
         .doc(usageId);
-      const doc = await docRef.get();
+      const deletedRef = this.firestore
+        .collection(this.deletedAccountsCollection)
+        .doc(userId);
 
-      if (!doc.exists) {
-        // Create new usage period with initial counts
-        const newUsage = this.createNewUsagePeriod(userId);
-        newUsage.pdfCount = pdfCount;
-        newUsage.labelCount = labelCount;
-        await docRef.set(newUsage);
-      } else {
-        // Atomic increment to avoid race conditions
-        await docRef.update({
-          pdfCount: FieldValue.increment(pdfCount),
-          labelCount: FieldValue.increment(labelCount),
-        });
-      }
+      await this.firestore.runTransaction(async (transaction) => {
+        const deleted = await transaction.get(deletedRef);
+        const doc = await transaction.get(docRef);
+        this.assertAccountWritable(userId, deleted.exists);
+
+        if (!doc.exists) {
+          // Create new usage period with initial counts
+          const newUsage = this.createNewUsagePeriod(userId);
+          newUsage.pdfCount = pdfCount;
+          newUsage.labelCount = labelCount;
+          transaction.create(docRef, newUsage);
+        } else {
+          // Atomic increment to avoid race conditions
+          transaction.update(docRef, {
+            pdfCount: FieldValue.increment(pdfCount),
+            labelCount: FieldValue.increment(labelCount),
+          });
+        }
+      });
 
       this.logger.log(`Uso incrementado para usuario: ${userId}`);
     } catch (error) {
@@ -1211,48 +1286,39 @@ export class FirestoreService {
       const docRef = this.firestore
         .collection(this.usageCollection)
         .doc(periodInfo.periodId);
-      const doc = await docRef.get();
+      const deletedRef = this.firestore
+        .collection(this.deletedAccountsCollection)
+        .doc(userId);
 
-      if (doc.exists) {
-        const data = doc.data();
-        return {
-          ...data,
-          periodStart: data.periodStart?.toDate?.() || data.periodStart,
-          periodEnd: data.periodEnd?.toDate?.() || data.periodEnd,
-        } as Usage;
-      }
+      return await this.firestore.runTransaction(async (transaction) => {
+        const deleted = await transaction.get(deletedRef);
+        const doc = await transaction.get(docRef);
+        this.assertAccountWritable(userId, deleted.exists);
 
-      // Crear nuevo período de uso
-      const newUsage: Usage = {
-        odId: periodInfo.periodId,
-        userId,
-        periodStart: periodInfo.periodStart,
-        periodEnd: periodInfo.periodEnd,
-        pdfCount: 0,
-        labelCount: 0,
-      };
-
-      // create() es atómico: falla con ALREADY_EXISTS si el doc apareció entre
-      // el get() y ahora (ej. un incrementUsageWithPeriod concurrente lo creó).
-      // Eso evita que un set() con contadores en 0 pise uso ya registrado.
-      try {
-        await docRef.create(newUsage);
-        this.logger.log(
-          `Nuevo periodo de uso creado para usuario: ${userId} (${periodInfo.periodId})`,
-        );
-        return newUsage;
-      } catch (createError) {
-        if (createError?.code === 6 /* ALREADY_EXISTS */) {
-          const existing = await docRef.get();
-          const data = existing.data();
+        if (doc.exists) {
+          const data = doc.data();
           return {
             ...data,
             periodStart: data.periodStart?.toDate?.() || data.periodStart,
             periodEnd: data.periodEnd?.toDate?.() || data.periodEnd,
           } as Usage;
         }
-        throw createError;
-      }
+
+        const newUsage: Usage = {
+          odId: periodInfo.periodId,
+          userId,
+          periodStart: periodInfo.periodStart,
+          periodEnd: periodInfo.periodEnd,
+          pdfCount: 0,
+          labelCount: 0,
+        };
+
+        transaction.create(docRef, newUsage);
+        this.logger.log(
+          `Nuevo periodo de uso creado para usuario: ${userId} (${periodInfo.periodId})`,
+        );
+        return newUsage;
+      });
     } catch (error) {
       this.logger.error(
         `Error al obtener/crear uso con período: ${error.message}`,
@@ -1281,17 +1347,26 @@ export class FirestoreService {
       const docRef = this.firestore
         .collection(this.usageCollection)
         .doc(periodInfo.periodId);
-      await docRef.set(
-        {
-          odId: periodInfo.periodId,
-          userId,
-          periodStart: periodInfo.periodStart,
-          periodEnd: periodInfo.periodEnd,
-          pdfCount: FieldValue.increment(pdfCount),
-          labelCount: FieldValue.increment(labelCount),
-        },
-        { merge: true },
-      );
+      const deletedRef = this.firestore
+        .collection(this.deletedAccountsCollection)
+        .doc(userId);
+
+      await this.firestore.runTransaction(async (transaction) => {
+        const deleted = await transaction.get(deletedRef);
+        this.assertAccountWritable(userId, deleted.exists);
+        transaction.set(
+          docRef,
+          {
+            odId: periodInfo.periodId,
+            userId,
+            periodStart: periodInfo.periodStart,
+            periodEnd: periodInfo.periodEnd,
+            pdfCount: FieldValue.increment(pdfCount),
+            labelCount: FieldValue.increment(labelCount),
+          },
+          { merge: true },
+        );
+      });
       this.logger.log(
         `Uso incrementado para usuario: ${userId} (${periodInfo.periodId})`,
       );
@@ -1331,9 +1406,20 @@ export class FirestoreService {
 
   async saveConversionHistory(history: ConversionHistory): Promise<void> {
     try {
-      await this.firestore.collection(this.historyCollection).add({
-        ...history,
-        createdAt: history.createdAt || new Date(),
+      const historyRef = this.firestore
+        .collection(this.historyCollection)
+        .doc();
+      const deletedRef = this.firestore
+        .collection(this.deletedAccountsCollection)
+        .doc(history.userId);
+
+      await this.firestore.runTransaction(async (transaction) => {
+        const deleted = await transaction.get(deletedRef);
+        this.assertAccountWritable(history.userId, deleted.exists);
+        transaction.create(historyRef, {
+          ...history,
+          createdAt: history.createdAt || new Date(),
+        });
       });
       this.logger.log(`Historial guardado para usuario: ${history.userId}`);
     } catch (error) {
@@ -1509,10 +1595,15 @@ export class FirestoreService {
         .collection(this.dailyStatsCollection)
         .doc(dateKey);
       const globalRef = this.firestore.doc(this.globalTotalsDoc);
+      const deletedRef = this.firestore
+        .collection(this.deletedAccountsCollection)
+        .doc(userId);
 
       await this.firestore.runTransaction(async (transaction) => {
+        const deleted = await transaction.get(deletedRef);
         const doc = await transaction.get(docRef);
         const globalDoc = await transaction.get(globalRef);
+        this.assertAccountWritable(userId, deleted.exists);
 
         if (doc.exists) {
           const data = doc.data() as DailyStats;
@@ -1712,14 +1803,22 @@ export class FirestoreService {
 
   async saveBatchJob(batch: BatchJob): Promise<void> {
     try {
-      await this.firestore
+      const batchRef = this.firestore
         .collection(this.batchCollection)
-        .doc(batch.id)
-        .set({
+        .doc(batch.id);
+      const deletedRef = this.firestore
+        .collection(this.deletedAccountsCollection)
+        .doc(batch.userId);
+
+      await this.firestore.runTransaction(async (transaction) => {
+        const deleted = await transaction.get(deletedRef);
+        this.assertAccountWritable(batch.userId, deleted.exists);
+        transaction.set(batchRef, {
           ...batch,
           createdAt: batch.createdAt || new Date(),
           updatedAt: new Date(),
         });
+      });
       this.logger.log(`Batch guardado: ${batch.id}`);
     } catch (error) {
       this.logger.error(`Error al guardar batch: ${error.message}`);
@@ -1755,13 +1854,28 @@ export class FirestoreService {
     data: Partial<BatchJob>,
   ): Promise<void> {
     try {
-      await this.firestore
+      const batchRef = this.firestore
         .collection(this.batchCollection)
-        .doc(batchId)
-        .update({
+        .doc(batchId);
+
+      await this.firestore.runTransaction(async (transaction) => {
+        const batch = await transaction.get(batchRef);
+        const userId = data.userId || batch.get('userId');
+
+        if (userId) {
+          const deleted = await transaction.get(
+            this.firestore
+              .collection(this.deletedAccountsCollection)
+              .doc(userId),
+          );
+          this.assertAccountWritable(userId, deleted.exists);
+        }
+
+        transaction.update(batchRef, {
           ...data,
           updatedAt: new Date(),
         });
+      });
       this.logger.log(`Batch actualizado: ${batchId}`);
     } catch (error) {
       this.logger.error(`Error al actualizar batch: ${error.message}`);
@@ -4889,15 +5003,22 @@ export class FirestoreService {
     metadata?: Record<string, any>;
   }): Promise<string> {
     const docRef = this.firestore.collection(this.emailQueueCollection).doc();
+    const deletedRef = this.firestore
+      .collection(this.deletedAccountsCollection)
+      .doc(data.userId);
     const now = new Date();
 
-    await docRef.set({
-      ...data,
-      id: docRef.id,
-      status: 'pending',
-      scheduledFor: data.scheduledFor,
-      createdAt: now,
-      updatedAt: now,
+    await this.firestore.runTransaction(async (transaction) => {
+      const deleted = await transaction.get(deletedRef);
+      this.assertAccountWritable(data.userId, deleted.exists);
+      transaction.create(docRef, {
+        ...data,
+        id: docRef.id,
+        status: 'pending',
+        scheduledFor: data.scheduledFor,
+        createdAt: now,
+        updatedAt: now,
+      });
     });
 
     return docRef.id;
@@ -4943,6 +5064,32 @@ export class FirestoreService {
   }
 
   /**
+   * Reclama un email solo si continúa pendiente en el instante del envío.
+   * La transición condicional evita que dos workers lo manden y hace que una
+   * cancelación concurrente gane limpiamente la carrera.
+   */
+  async claimPendingEmail(emailId: string): Promise<boolean> {
+    const ref = this.firestore
+      .collection(this.emailQueueCollection)
+      .doc(emailId);
+
+    return this.firestore.runTransaction(async (transaction) => {
+      const email = await transaction.get(ref);
+      if (!email.exists || email.get('status') !== 'pending') {
+        return false;
+      }
+
+      const now = new Date();
+      transaction.update(ref, {
+        status: 'sending',
+        sendingAt: now,
+        updatedAt: now,
+      });
+      return true;
+    });
+  }
+
+  /**
    * Update email queue status after sending
    */
   async updateEmailQueueStatus(
@@ -4979,15 +5126,27 @@ export class FirestoreService {
    * usuario desactivó esa categoría de notificaciones—, para que un hueco en la
    * secuencia de onboarding no parezca un fallo de entrega.
    */
-  async cancelQueuedEmail(emailId: string, skipReason: string): Promise<void> {
-    await this.firestore
+  async cancelQueuedEmail(
+    emailId: string,
+    skipReason: string,
+  ): Promise<boolean> {
+    const ref = this.firestore
       .collection(this.emailQueueCollection)
-      .doc(emailId)
-      .update({
+      .doc(emailId);
+
+    return this.firestore.runTransaction(async (transaction) => {
+      const email = await transaction.get(ref);
+      if (!email.exists || email.get('status') !== 'pending') {
+        return false;
+      }
+
+      transaction.update(ref, {
         status: 'cancelled',
         skipReason,
         updatedAt: new Date(),
       });
+      return true;
+    });
   }
 
   /**
@@ -5001,7 +5160,7 @@ export class FirestoreService {
       .collection(this.emailQueueCollection)
       .where('userId', '==', userId)
       .where('emailType', '==', emailType)
-      .where('status', 'in', ['pending', 'sent'])
+      .where('status', 'in', ['pending', 'sending', 'sent'])
       .limit(1)
       .get();
 
@@ -5021,7 +5180,7 @@ export class FirestoreService {
       .collection(this.emailQueueCollection)
       .where('userId', '==', userId)
       .where('emailType', '==', emailType)
-      .where('status', 'in', ['pending', 'sent'])
+      .where('status', 'in', ['pending', 'sending', 'sent'])
       .where('createdAt', '>=', periodStart)
       .limit(1)
       .get();
@@ -5074,16 +5233,26 @@ export class FirestoreService {
 
     const snapshot = await query.get();
 
-    const batch = this.firestore.batch();
-    snapshot.docs.forEach((doc) => {
-      batch.update(doc.ref, {
-        status: 'cancelled',
-        updatedAt: new Date(),
-      });
-    });
+    let cancelled = 0;
+    for (const doc of snapshot.docs) {
+      const didCancel = await this.firestore.runTransaction(
+        async (transaction) => {
+          const current = await transaction.get(doc.ref);
+          if (!current.exists || current.get('status') !== 'pending') {
+            return false;
+          }
 
-    await batch.commit();
-    return snapshot.size;
+          transaction.update(doc.ref, {
+            status: 'cancelled',
+            updatedAt: new Date(),
+          });
+          return true;
+        },
+      );
+      if (didCancel) cancelled++;
+    }
+
+    return cancelled;
   }
 
   // ============== Email Events Methods ==============
@@ -6258,7 +6427,7 @@ export class FirestoreService {
             'pro_inactive_14_days',
             'pro_inactive_30_days',
           ])
-          .where('status', 'in', ['pending', 'sent'])
+          .where('status', 'in', ['pending', 'sending', 'sent'])
           .get(),
       );
       const emailSnapshots = await Promise.all(emailPromises);
@@ -6582,7 +6751,7 @@ export class FirestoreService {
             'free_dormant_30d',
             'free_abandoned_60d',
           ])
-          .where('status', 'in', ['pending', 'sent'])
+          .where('status', 'in', ['pending', 'sending', 'sent'])
           .get(),
       );
       const emailSnapshots = await Promise.all(emailPromises);
@@ -7163,14 +7332,22 @@ export class FirestoreService {
     outputFormat: string;
   }): Promise<void> {
     try {
-      await this.firestore
+      const debugRef = this.firestore
         .collection(this.zplDebugCollection)
-        .doc(data.jobId)
-        .set({
+        .doc(data.jobId);
+      const deletedRef = this.firestore
+        .collection(this.deletedAccountsCollection)
+        .doc(data.userId);
+
+      await this.firestore.runTransaction(async (transaction) => {
+        const deleted = await transaction.get(deletedRef);
+        this.assertAccountWritable(data.userId, deleted.exists);
+        transaction.set(debugRef, {
           ...data,
           createdAt: new Date(),
           result: 'pending',
         });
+      });
       this.logger.debug(`ZPL debug file saved: ${data.jobId}`);
     } catch (error) {
       this.logger.error(`Error saving ZPL debug file: ${error.message}`);
@@ -7187,10 +7364,24 @@ export class FirestoreService {
       const updateData: Record<string, any> = { result };
       if (errorCode) updateData.errorCode = errorCode;
 
-      await this.firestore
+      const debugRef = this.firestore
         .collection(this.zplDebugCollection)
-        .doc(jobId)
-        .update(updateData);
+        .doc(jobId);
+      await this.firestore.runTransaction(async (transaction) => {
+        const debug = await transaction.get(debugRef);
+        const userId = debug.get('userId');
+
+        if (userId) {
+          const deleted = await transaction.get(
+            this.firestore
+              .collection(this.deletedAccountsCollection)
+              .doc(userId),
+          );
+          this.assertAccountWritable(userId, deleted.exists);
+        }
+
+        transaction.update(debugRef, updateData);
+      });
     } catch (error) {
       this.logger.warn(`Error updating ZPL debug result: ${error.message}`);
     }

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -7661,6 +7661,88 @@ export class FirestoreService {
     }
   }
 
+  /**
+   * Borra los batches del usuario y devuelve sus ids, para poder limpiar
+   * después los ZIP que cuelgan de `batches/<batchId>/` en Storage.
+   */
+  async deleteBatchJobsByUserId(userId: string): Promise<string[]> {
+    const snapshot = await this.firestore
+      .collection(this.batchCollection)
+      .where('userId', '==', userId)
+      .get();
+
+    const ids = snapshot.docs.map((doc) => doc.id);
+    await this.deleteDocs(snapshot.docs);
+
+    return ids;
+  }
+
+  /**
+   * Borra los documentos de estado de conversión del usuario.
+   *
+   * Son los que sirven `GET /zpl/status/:jobId`: llevan `userId`, el nombre del
+   * archivo y la URL firmada del resultado, así que sobrevivir a la baja los
+   * dejaría respondiendo con datos de una cuenta que ya no existe.
+   */
+  async deleteConversionStatusesByUserId(userId: string): Promise<number> {
+    const snapshot = await this.firestore
+      .collection(this.collectionName)
+      .where('userId', '==', userId)
+      .get();
+
+    return this.deleteDocs(snapshot.docs);
+  }
+
+  /**
+   * Desvincula del usuario los registros contables locales.
+   *
+   * `stripe_transactions` y `subscription_events` alimentan las métricas de
+   * ingresos y de churn, así que borrarlos falsearía la contabilidad histórica.
+   * Pero llevan `userId` y `userEmail`, que sí identifican al titular: se les
+   * aplica la misma desvinculación que a los CFDI —los importes, fechas y
+   * planes se quedan— para que la baja no deje al usuario nombrado en un sitio
+   * que la respuesta ni siquiera menciona.
+   *
+   * @returns cuántos registros se anonimizaron entre ambas colecciones.
+   */
+  async anonymizeUserFinancialRecords(userId: string): Promise<number> {
+    const now = new Date();
+    let updated = 0;
+
+    for (const collection of [
+      this.transactionsCollection,
+      this.subscriptionEventsCollection,
+    ]) {
+      const snapshot = await this.firestore
+        .collection(collection)
+        .where('userId', '==', userId)
+        .get();
+
+      if (snapshot.empty) continue;
+
+      for (const chunk of this.chunk(
+        snapshot.docs,
+        FirestoreService.DELETION_BATCH_SIZE,
+      )) {
+        const batch = this.firestore.batch();
+        for (const doc of chunk) {
+          batch.update(doc.ref, {
+            userId: FirestoreService.ANONYMIZED_USER_ID,
+            // Se vacía en vez de borrarse el campo: los consumidores lo leen sin
+            // comprobar que exista, y un `undefined` inesperado rompería el
+            // dashboard de finanzas.
+            userEmail: '',
+            anonymizedAt: now,
+          });
+        }
+        await batch.commit();
+        updated += chunk.length;
+      }
+    }
+
+    return updated;
+  }
+
   /** Borra los registros de historial indicados y devuelve cuántos se borraron. */
   async deleteConversionHistoryByIds(ids: string[]): Promise<number> {
     if (ids.length === 0) {

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -307,6 +307,9 @@ export class FirestoreService {
         const deletedRef = this.firestore
           .collection(this.deletedAccountsCollection)
           .doc(status.userId);
+        // Esta escritura crea el localizador persistente del trabajo y ocurre
+        // una sola vez por conversión. Sí merece compartir frontera con la
+        // lápida; las actualizaciones frecuentes de progreso de abajo no.
         await this.firestore.runTransaction(async (transaction) => {
           const deleted = await transaction.get(deletedRef);
           this.assertAccountWritable(status.userId, deleted.exists);
@@ -346,26 +349,16 @@ export class FirestoreService {
     status: Partial<ConversionStatus>,
   ): Promise<void> {
     try {
-      const ref = this.firestore.collection(this.collectionName).doc(jobId);
-
-      await this.firestore.runTransaction(async (transaction) => {
-        const current = await transaction.get(ref);
-        const userId = status.userId || current.get('userId');
-
-        if (userId) {
-          const deleted = await transaction.get(
-            this.firestore
-              .collection(this.deletedAccountsCollection)
-              .doc(userId),
-          );
-          this.assertAccountWritable(userId, deleted.exists);
-        }
-
-        transaction.update(ref, {
+      // Es el camino caliente: se llama por cada avance de progreso. `update`
+      // no recrea un documento que la baja ya borró, así que una transacción
+      // y dos lecturas por avance no añadían protección persistente.
+      await this.firestore
+        .collection(this.collectionName)
+        .doc(jobId)
+        .update({
           ...status,
           updatedAt: new Date().toISOString(),
         });
-      });
 
       this.logger.log(`Estado actualizado para jobId: ${jobId}`);
     } catch (error) {
@@ -457,9 +450,11 @@ export class FirestoreService {
   }
 
   /**
-   * Las transacciones que leen la lápida y escriben el dato forman una única
-   * frontera: si la baja gana la carrera, Firestore reintenta la transacción y
-   * esta termina aquí sin recrear restos del usuario.
+   * Las creaciones y upserts persistentes que leen la lápida y escriben el dato
+   * forman una única frontera: si la baja gana la carrera, Firestore reintenta
+   * la transacción y esta termina aquí sin recrear restos del usuario. Las
+   * actualizaciones de progreso usan `update()` directo: no pueden recrear un
+   * documento borrado y no deben pagar lecturas en cada avance.
    */
   private assertAccountWritable(userId: string, deleted: boolean): void {
     if (deleted) {
@@ -1599,6 +1594,10 @@ export class FirestoreService {
         .collection(this.deletedAccountsCollection)
         .doc(userId);
 
+      // Esta transacción ya es necesaria para conservar los contadores. La
+      // lectura adicional de la lápida ocurre una vez al terminar, no por cada
+      // progreso, y evita que el fire-and-forget reintroduzca el UID en
+      // `activeUserIds` después de que la baja lo anonimizó.
       await this.firestore.runTransaction(async (transaction) => {
         const deleted = await transaction.get(deletedRef);
         const doc = await transaction.get(docRef);
@@ -1854,28 +1853,16 @@ export class FirestoreService {
     data: Partial<BatchJob>,
   ): Promise<void> {
     try {
-      const batchRef = this.firestore
+      // Solo actualiza un batch creado bajo la guarda de `saveBatchJob`.
+      // `update()` falla si la baja ya borró el doc y nunca lo resucita; el
+      // progreso del batch no necesita releer la lápida en cada archivo.
+      await this.firestore
         .collection(this.batchCollection)
-        .doc(batchId);
-
-      await this.firestore.runTransaction(async (transaction) => {
-        const batch = await transaction.get(batchRef);
-        const userId = data.userId || batch.get('userId');
-
-        if (userId) {
-          const deleted = await transaction.get(
-            this.firestore
-              .collection(this.deletedAccountsCollection)
-              .doc(userId),
-          );
-          this.assertAccountWritable(userId, deleted.exists);
-        }
-
-        transaction.update(batchRef, {
+        .doc(batchId)
+        .update({
           ...data,
           updatedAt: new Date(),
         });
-      });
       this.logger.log(`Batch actualizado: ${batchId}`);
     } catch (error) {
       this.logger.error(`Error al actualizar batch: ${error.message}`);
@@ -7364,24 +7351,13 @@ export class FirestoreService {
       const updateData: Record<string, any> = { result };
       if (errorCode) updateData.errorCode = errorCode;
 
-      const debugRef = this.firestore
+      // Es un cambio de estado sobre metadata ya creada con la lápida. Si el
+      // barrido la borró, `update()` falla sin recrearla; no hacen falta dos
+      // lecturas para cambiar pending -> success/error.
+      await this.firestore
         .collection(this.zplDebugCollection)
-        .doc(jobId);
-      await this.firestore.runTransaction(async (transaction) => {
-        const debug = await transaction.get(debugRef);
-        const userId = debug.get('userId');
-
-        if (userId) {
-          const deleted = await transaction.get(
-            this.firestore
-              .collection(this.deletedAccountsCollection)
-              .doc(userId),
-          );
-          this.assertAccountWritable(userId, deleted.exists);
-        }
-
-        transaction.update(debugRef, updateData);
-      });
+        .doc(jobId)
+        .update(updateData);
     } catch (error) {
       this.logger.warn(`Error updating ZPL debug result: ${error.message}`);
     }
@@ -8049,6 +8025,53 @@ export class FirestoreService {
         await batch.commit();
         updated += chunk.length;
       }
+    }
+
+    // `daily_stats` es histórico: sus totales no se descuentan al borrar una
+    // cuenta, pero la lista auxiliar de usuarios activos sí identifica al
+    // titular. Solo se reescribe esa lista; contadores y desglose por plan
+    // quedan intactos.
+    const dailyStats = await this.firestore
+      .collection(this.dailyStatsCollection)
+      .where('activeUserIds', 'array-contains', userId)
+      .get();
+
+    for (const chunk of this.chunk(
+      dailyStats.docs,
+      FirestoreService.DELETION_BATCH_SIZE,
+    )) {
+      const batch = this.firestore.batch();
+      for (const doc of chunk) {
+        const activeUserIds = (doc.get('activeUserIds') as string[]).filter(
+          (id) => id !== userId,
+        );
+        batch.update(doc.ref, { activeUserIds });
+      }
+      await batch.commit();
+      updated += chunk.length;
+    }
+
+    // El historial de administración se conserva, pero un cambio de plan no
+    // necesita seguir apuntando al UID borrado. La ruta anidada preserva el
+    // resto de requestParams (planes, motivo y resultado de Stripe).
+    const auditLogs = await this.firestore
+      .collection(this.adminAuditCollection)
+      .where('requestParams.userId', '==', userId)
+      .get();
+
+    for (const chunk of this.chunk(
+      auditLogs.docs,
+      FirestoreService.DELETION_BATCH_SIZE,
+    )) {
+      const batch = this.firestore.batch();
+      for (const doc of chunk) {
+        batch.update(doc.ref, {
+          'requestParams.userId': FirestoreService.ANONYMIZED_USER_ID,
+          anonymizedAt: now,
+        });
+      }
+      await batch.commit();
+      updated += chunk.length;
     }
 
     return updated;

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -51,6 +51,21 @@ import type {
   HighUsageUsersResult,
 } from '../email/interfaces/email.interface.js';
 
+/**
+ * Tiempo que un worker puede tener un email en `sending` antes de que se
+ * considere abandonado y otro pueda retomarlo. Holgado a propósito: reintentar
+ * un envío que sigue en vuelo cuesta una entrega duplicada, mientras que esperar
+ * de más solo retrasa un correo que ya se perdió.
+ */
+export const EMAIL_SEND_LEASE_MS = 10 * 60 * 1000;
+
+/**
+ * Tope de documentos en `sending` que se leen de una vez. Son los envíos en
+ * vuelo más los abandonados: si alguna vez hubiera más, sobra con tratarlos en
+ * varias vueltas del cron.
+ */
+const MAX_SENDING_SCAN = 200;
+
 // ============== Daily Stats (Aggregated Metrics) ==============
 
 export interface DailyStats {
@@ -5035,7 +5050,7 @@ export class FirestoreService {
       .limit(limit)
       .get();
 
-    return snapshot.docs.map((doc) => {
+    const toQueueItem = (doc: FirebaseFirestore.DocumentSnapshot) => {
       const data = doc.data();
       return {
         id: doc.id,
@@ -5047,7 +5062,91 @@ export class FirestoreService {
         scheduledFor: data.scheduledFor?.toDate?.() || data.scheduledFor,
         metadata: data.metadata,
       };
+    };
+
+    const pending = snapshot.docs.map(toQueueItem);
+
+    if (pending.length >= limit) {
+      return pending;
+    }
+
+    const abandoned = await this.getAbandonedSendingEmails(
+      limit - pending.length,
+    );
+
+    return [...pending, ...abandoned.map(toQueueItem)];
+  }
+
+  /**
+   * Envíos que se quedaron en `sending` porque el proceso murió entre la
+   * reclamación y la escritura del resultado.
+   *
+   * Sin esto el documento se queda en ese estado para siempre —`getPendingEmails`
+   * solo mira `pending`— y el correo se pierde en silencio, avisos de facturación
+   * incluidos. Reenviarlos es seguro porque el envío va con `idempotencyKey`: si
+   * el proceso murió después de que Resend lo aceptara, el segundo intento no
+   * entrega un duplicado.
+   *
+   * La antigüedad se filtra en memoria, no con `where('sendingAt','<=',...)`:
+   * combinarlo con el filtro de estado exigiría un índice compuesto nuevo, y en
+   * esta colección una consulta sin su índice ya costó una tanda de emails sin
+   * enviar. Los documentos en `sending` son un puñado por definición.
+   */
+  private async getAbandonedSendingEmails(
+    limit: number,
+  ): Promise<FirebaseFirestore.QueryDocumentSnapshot[]> {
+    if (limit <= 0) {
+      return [];
+    }
+
+    const snapshot = await this.firestore
+      .collection(this.emailQueueCollection)
+      .where('status', '==', 'sending')
+      .limit(MAX_SENDING_SCAN)
+      .get();
+
+    const expiredBefore = Date.now() - EMAIL_SEND_LEASE_MS;
+
+    const abandoned = snapshot.docs.filter((doc) => {
+      const sendingAt =
+        doc.get('sendingAt')?.toDate?.() ?? doc.get('sendingAt');
+      // Sin `sendingAt` no se puede saber si sigue en vuelo; se deja estar, que
+      // es el lado seguro: reenviar lo que otro worker está mandando ahora mismo
+      // gasta una entrega de más.
+      return sendingAt instanceof Date && sendingAt.getTime() <= expiredBefore;
     });
+
+    if (abandoned.length > 0) {
+      this.logger.warn(
+        `${abandoned.length} emails llevaban más de ${
+          EMAIL_SEND_LEASE_MS / 60000
+        } minutos en 'sending'; se reintentan`,
+      );
+    }
+
+    return abandoned.slice(0, limit);
+  }
+
+  /**
+   * Emails de un usuario que un worker ya reclamó y todavía no ha resuelto.
+   *
+   * La baja de cuenta los consulta para no confirmar el borrado mientras puede
+   * salir un correo: `cancelPendingEmails` solo alcanza a los `pending`, y quien
+   * ya pasó a `sending` tiene el destinatario cargado en memoria.
+   */
+  async countInFlightEmails(userId: string): Promise<number> {
+    // Un solo filtro y el usuario se compara en memoria, igual que el barrido de
+    // abandonados: los índices compuestos de esta colección son los que son, y
+    // una query sin el suyo falla en producción con FAILED_PRECONDITION. Los
+    // documentos en `sending` son un puñado en todo el sistema, así que filtrar
+    // aquí no cuesta nada.
+    const snapshot = await this.firestore
+      .collection(this.emailQueueCollection)
+      .where('status', '==', 'sending')
+      .limit(MAX_SENDING_SCAN)
+      .get();
+
+    return snapshot.docs.filter((doc) => doc.get('userId') === userId).length;
   }
 
   /**
@@ -5055,18 +5154,60 @@ export class FirestoreService {
    * La transición condicional evita que dos workers lo manden y hace que una
    * cancelación concurrente gane limpiamente la carrera.
    */
-  async claimPendingEmail(emailId: string): Promise<boolean> {
+  async claimPendingEmail(emailId: string, userId?: string): Promise<boolean> {
     const ref = this.firestore
       .collection(this.emailQueueCollection)
       .doc(emailId);
 
     return this.firestore.runTransaction(async (transaction) => {
       const email = await transaction.get(ref);
-      if (!email.exists || email.get('status') !== 'pending') {
+      if (!email.exists) {
         return false;
       }
 
+      const status = email.get('status');
       const now = new Date();
+
+      // `sending` solo se readmite cuando el lease venció: es el envío que dejó
+      // colgado un proceso muerto, no uno que otro worker esté haciendo ahora.
+      if (status !== 'pending') {
+        if (status !== 'sending') {
+          return false;
+        }
+
+        const sendingAt =
+          email.get('sendingAt')?.toDate?.() ?? email.get('sendingAt');
+
+        if (
+          !(sendingAt instanceof Date) ||
+          sendingAt.getTime() > now.getTime() - EMAIL_SEND_LEASE_MS
+        ) {
+          return false;
+        }
+      }
+
+      // La baja de cuenta marca el UID antes de barrer nada, y esta lectura
+      // dentro de la transacción es lo que impide que un envío se cuele entre
+      // esa marca y la cancelación de la cola: el destinatario ya pidió que su
+      // dirección se olvidara.
+      const ownerId = userId ?? email.get('userId');
+      if (ownerId) {
+        const deleted = await transaction.get(
+          this.firestore
+            .collection(this.deletedAccountsCollection)
+            .doc(ownerId),
+        );
+
+        if (deleted.exists) {
+          transaction.update(ref, {
+            status: 'cancelled',
+            skipReason: 'account_deleted',
+            updatedAt: now,
+          });
+          return false;
+        }
+      }
+
       transaction.update(ref, {
         status: 'sending',
         sendingAt: now,

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -7662,19 +7662,40 @@ export class FirestoreService {
   }
 
   /**
-   * Borra los batches del usuario y devuelve sus ids, para poder limpiar
-   * después los ZIP que cuelgan de `batches/<batchId>/` en Storage.
+   * Ids de los batches del usuario, para localizar sus ZIP en Storage.
+   *
+   * Se leen antes de borrar nada: el `batchId` es la única forma de encontrar
+   * `batches/<batchId>/`, así que borrar primero el documento y fallar después
+   * al limpiar el bucket dejaría los archivos huérfanos y sin rastro con el que
+   * volver a buscarlos.
    */
-  async deleteBatchJobsByUserId(userId: string): Promise<string[]> {
+  async getBatchIdsByUserId(userId: string): Promise<string[]> {
     const snapshot = await this.firestore
       .collection(this.batchCollection)
       .where('userId', '==', userId)
       .get();
 
-    const ids = snapshot.docs.map((doc) => doc.id);
-    await this.deleteDocs(snapshot.docs);
+    return snapshot.docs.map((doc) => doc.id);
+  }
 
-    return ids;
+  /** Borra los batches indicados. */
+  async deleteBatchJobsByIds(batchIds: string[]): Promise<number> {
+    if (batchIds.length === 0) {
+      return 0;
+    }
+
+    for (const chunk of this.chunk(
+      batchIds,
+      FirestoreService.DELETION_BATCH_SIZE,
+    )) {
+      const batch = this.firestore.batch();
+      for (const id of chunk) {
+        batch.delete(this.firestore.collection(this.batchCollection).doc(id));
+      }
+      await batch.commit();
+    }
+
+    return batchIds.length;
   }
 
   /**
@@ -7734,6 +7755,70 @@ export class FirestoreService {
             userEmail: '',
             anonymizedAt: now,
           });
+        }
+        await batch.commit();
+        updated += chunk.length;
+      }
+    }
+
+    return updated;
+  }
+
+  /**
+   * Desvincula del usuario la cola de emails, sus eventos y su feedback.
+   *
+   * `email_queue` guarda `userEmail` y la metadata con la que se compuso cada
+   * envío (nombre incluido); `email_events` y `feedback` guardan `userId` y
+   * `userEmail`, y el feedback además texto libre. Se anonimizan en vez de
+   * borrarse porque las métricas de email y el feedback del producto se
+   * calculan sobre ellos y borrarlos falsearía la serie histórica: lo que
+   * desaparece es a quién pertenecen.
+   *
+   * @returns cuántos documentos se anonimizaron entre las tres colecciones.
+   */
+  async anonymizeUserActivityRecords(userId: string): Promise<number> {
+    const now = new Date();
+    let updated = 0;
+
+    const targets: Array<{ collection: string; clearMetadata: boolean }> = [
+      { collection: this.emailQueueCollection, clearMetadata: true },
+      { collection: this.emailEventsCollection, clearMetadata: true },
+      { collection: this.feedbackCollection, clearMetadata: false },
+    ];
+
+    for (const { collection, clearMetadata } of targets) {
+      const snapshot = await this.firestore
+        .collection(collection)
+        .where('userId', '==', userId)
+        .get();
+
+      if (snapshot.empty) continue;
+
+      for (const chunk of this.chunk(
+        snapshot.docs,
+        FirestoreService.DELETION_BATCH_SIZE,
+      )) {
+        const batch = this.firestore.batch();
+        for (const doc of chunk) {
+          const updates: Record<string, any> = {
+            userId: FirestoreService.ANONYMIZED_USER_ID,
+            anonymizedAt: now,
+            updatedAt: now,
+          };
+
+          // Solo se toca `userEmail` si el documento lo tiene: escribirlo en uno
+          // que no lo llevaba añadiría un campo vacío donde no había ninguno.
+          if (doc.get('userEmail') !== undefined) {
+            updates.userEmail = '';
+          }
+
+          // La metadata del email lleva el nombre con el que se personalizó el
+          // envío. El feedback conserva la suya: es contenido de producto.
+          if (clearMetadata && doc.get('metadata') !== undefined) {
+            updates.metadata = FieldValue.delete();
+          }
+
+          batch.update(doc.ref, updates);
         }
         await batch.commit();
         updated += chunk.length;

--- a/src/modules/cache/firestore.service.ts
+++ b/src/modules/cache/firestore.service.ts
@@ -4972,6 +4972,25 @@ export class FirestoreService {
   }
 
   /**
+   * Marca un email de la cola como cancelado sin haberlo enviado.
+   *
+   * Va aparte de `updateEmailQueueStatus` porque no es un resultado del envío:
+   * el email nunca salió. `skipReason` deja por escrito por qué —hoy, que el
+   * usuario desactivó esa categoría de notificaciones—, para que un hueco en la
+   * secuencia de onboarding no parezca un fallo de entrega.
+   */
+  async cancelQueuedEmail(emailId: string, skipReason: string): Promise<void> {
+    await this.firestore
+      .collection(this.emailQueueCollection)
+      .doc(emailId)
+      .update({
+        status: 'cancelled',
+        skipReason,
+        updatedAt: new Date(),
+      });
+  }
+
+  /**
    * Check if user has already received a specific email type
    */
   async hasUserReceivedEmail(
@@ -7612,5 +7631,167 @@ export class FirestoreService {
       this.logger.error(`Error al actualizar CFDI: ${error.message}`);
       throw error;
     }
+  }
+  // ============== Baja de cuenta ==============
+
+  /**
+   * Identificador que sustituye al `userId` real en los documentos que se
+   * conservan por obligación fiscal. No es un id de usuario existente: sirve
+   * para que las queries por usuario dejen de devolverlos sin tener que borrar
+   * el comprobante.
+   */
+  static readonly ANONYMIZED_USER_ID = 'deleted_user';
+
+  /** Tope de documentos por lote en los borrados de la baja de cuenta. */
+  private static readonly DELETION_BATCH_SIZE = 400;
+
+  /** Borra el documento de `users`. */
+  async deleteUser(userId: string): Promise<void> {
+    try {
+      await this.firestore
+        .collection(this.usersCollection)
+        .doc(userId)
+        .delete();
+      this.logger.log(`Usuario eliminado: ${userId}`);
+    } catch (error) {
+      this.logger.error(
+        `Error al eliminar usuario ${userId}: ${error.message}`,
+      );
+      throw error;
+    }
+  }
+
+  /** Borra los registros de historial indicados y devuelve cuántos se borraron. */
+  async deleteConversionHistoryByIds(ids: string[]): Promise<number> {
+    if (ids.length === 0) {
+      return 0;
+    }
+
+    let deleted = 0;
+
+    for (const chunk of this.chunk(ids, FirestoreService.DELETION_BATCH_SIZE)) {
+      const batch = this.firestore.batch();
+      for (const id of chunk) {
+        batch.delete(this.firestore.collection(this.historyCollection).doc(id));
+      }
+      await batch.commit();
+      deleted += chunk.length;
+    }
+
+    return deleted;
+  }
+
+  /**
+   * Borra todos los periodos de uso del usuario.
+   *
+   * Se consulta por el campo `userId` y no por el patrón del docId: conviven el
+   * formato legacy `uid_YYYYMM` con el de periodo de facturación, y componer
+   * ids a mano dejaría documentos sin borrar.
+   */
+  async deleteUsageByUserId(userId: string): Promise<number> {
+    const snapshot = await this.firestore
+      .collection(this.usageCollection)
+      .where('userId', '==', userId)
+      .get();
+
+    return this.deleteDocs(snapshot.docs);
+  }
+
+  /** Borra el perfil fiscal. Devuelve `false` si el usuario nunca lo cargó. */
+  async deleteTaxProfile(userId: string): Promise<boolean> {
+    const ref = this.firestore
+      .collection(this.taxProfilesCollection)
+      .doc(userId);
+    const doc = await ref.get();
+
+    if (!doc.exists) {
+      return false;
+    }
+
+    await ref.delete();
+    return true;
+  }
+
+  /** Borra la metadata de los ZPL guardados para depuración. */
+  async deleteZplDebugFilesByUserId(userId: string): Promise<number> {
+    const snapshot = await this.firestore
+      .collection(this.zplDebugCollection)
+      .where('userId', '==', userId)
+      .get();
+
+    return this.deleteDocs(snapshot.docs);
+  }
+
+  /**
+   * Desvincula del usuario los CFDI ya emitidos, sin borrarlos.
+   *
+   * Un comprobante timbrado se conserva cinco años ante el SAT: no se puede
+   * borrar aunque su titular se dé de baja. Lo que sí desaparece es el vínculo
+   * con la persona en nuestra base — `userId` pasa a `ANONYMIZED_USER_ID` —, de
+   * modo que el comprobante deja de ser localizable por usuario y las queries
+   * por `userId` no lo devuelven. El XML timbrado y el PDF siguen intactos en
+   * Storage: son el documento fiscal en sí, y alterarlos lo invalidaría.
+   *
+   * @returns cuántos CFDI se anonimizaron.
+   */
+  async anonymizeUserCfdis(userId: string): Promise<number> {
+    const snapshot = await this.firestore
+      .collection(this.cfdisCollection)
+      .where('userId', '==', userId)
+      .get();
+
+    if (snapshot.empty) {
+      return 0;
+    }
+
+    const now = new Date();
+    let updated = 0;
+
+    for (const chunk of this.chunk(
+      snapshot.docs,
+      FirestoreService.DELETION_BATCH_SIZE,
+    )) {
+      const batch = this.firestore.batch();
+      for (const doc of chunk) {
+        batch.update(doc.ref, {
+          userId: FirestoreService.ANONYMIZED_USER_ID,
+          anonymizedAt: now,
+          updatedAt: now,
+        });
+      }
+      await batch.commit();
+      updated += chunk.length;
+    }
+
+    return updated;
+  }
+
+  private async deleteDocs(
+    docs: FirebaseFirestore.QueryDocumentSnapshot[],
+  ): Promise<number> {
+    if (docs.length === 0) {
+      return 0;
+    }
+
+    for (const chunk of this.chunk(
+      docs,
+      FirestoreService.DELETION_BATCH_SIZE,
+    )) {
+      const batch = this.firestore.batch();
+      for (const doc of chunk) {
+        batch.delete(doc.ref);
+      }
+      await batch.commit();
+    }
+
+    return docs.length;
+  }
+
+  private chunk<T>(items: T[], size: number): T[][] {
+    const chunks: T[][] = [];
+    for (let i = 0; i < items.length; i += size) {
+      chunks.push(items.slice(i, i + size));
+    }
+    return chunks;
   }
 }

--- a/src/modules/email/email-categories.ts
+++ b/src/modules/email/email-categories.ts
@@ -1,0 +1,56 @@
+import type { NotificationCategory } from '../../common/interfaces/notification-preferences.interface.js';
+import type { EmailType } from './interfaces/email.interface.js';
+
+/**
+ * Categoría de preferencias a la que pertenece cada tipo de email.
+ *
+ * El `Record` va completo a propósito: si mañana se añade un tipo de email a
+ * `EmailType` y no se clasifica aquí, el compilador lo rechaza. Sin esa red, un
+ * tipo nuevo se enviaría a todo el mundo saltándose unas preferencias que el
+ * usuario cree respetadas.
+ */
+export const EMAIL_NOTIFICATION_CATEGORY: Record<
+  EmailType,
+  NotificationCategory
+> = {
+  // Onboarding y ciclo de vida: hablan del producto.
+  welcome: 'product',
+  tutorial: 'product',
+  help: 'product',
+  success_story: 'product',
+  miss_you: 'product',
+
+  // Cuota: avisan de que el plan se está agotando.
+  limit_80_percent: 'usageReminders',
+  limit_100_percent: 'usageReminders',
+  conversion_blocked: 'usageReminders',
+  high_usage: 'usageReminders',
+
+  // Retención y reactivación: contenido de producto, no de facturación.
+  pro_inactive_7_days: 'product',
+  pro_inactive_14_days: 'product',
+  pro_inactive_30_days: 'product',
+  pro_power_user: 'product',
+  free_never_used_7d: 'product',
+  free_never_used_14d: 'product',
+  free_tried_abandoned: 'product',
+  free_dormant_30d: 'product',
+  free_abandoned_60d: 'product',
+
+  // Cobros y suscripción.
+  payment_failed: 'billing',
+  subscription_downgraded: 'billing',
+};
+
+/**
+ * Categoría de un tipo de email, o `null` si no está clasificado.
+ *
+ * La cola guarda `emailType` como string libre, así que puede llegar un valor
+ * que no esté en `EmailType` (una plantilla creada a mano en Firestore, por
+ * ejemplo). Quien llama decide qué hacer con `null`.
+ */
+export function getEmailNotificationCategory(
+  emailType: string,
+): NotificationCategory | null {
+  return EMAIL_NOTIFICATION_CATEGORY[emailType as EmailType] ?? null;
+}

--- a/src/modules/email/email.service.spec.ts
+++ b/src/modules/email/email.service.spec.ts
@@ -682,7 +682,9 @@ describe('EmailService.processQueue — preferencias de notificación', () => {
 
     // El snapshot seguía diciendo pending, pero la transacción es la autoridad
     // final. Sobrescribir cancelled con sent reactivaría un correo de la baja.
-    expect(firestore.claimPendingEmail).toHaveBeenCalledWith('q-1');
+    // El userId viaja con el claim: la transacción comprueba la lápida de la
+    // baja de cuenta antes de autorizar el envío.
+    expect(firestore.claimPendingEmail).toHaveBeenCalledWith('q-1', 'uid-1');
     expect(resendSend).not.toHaveBeenCalled();
     expect(firestore.updateEmailQueueStatus).not.toHaveBeenCalled();
     expect(result).toMatchObject({ sent: 0, failed: 0, skipped: 1 });

--- a/src/modules/email/email.service.spec.ts
+++ b/src/modules/email/email.service.spec.ts
@@ -600,8 +600,11 @@ describe('EmailService.processQueue — preferencias de notificación', () => {
     getPendingEmails: jest.Mock;
     getUserById: jest.Mock;
     cancelQueuedEmail: jest.Mock;
+    claimPendingEmail: jest.Mock;
+    getEmailTemplateByKey: jest.Mock;
     updateEmailQueueStatus: jest.Mock;
   };
+  let sendEmailSpy: jest.SpyInstance;
 
   function queued(overrides: Record<string, any> = {}) {
     return {
@@ -621,6 +624,8 @@ describe('EmailService.processQueue — preferencias de notificación', () => {
       getPendingEmails: jest.fn().mockResolvedValue([]),
       getUserById: jest.fn().mockResolvedValue({ id: 'uid-1' }),
       cancelQueuedEmail: jest.fn().mockResolvedValue(undefined),
+      claimPendingEmail: jest.fn().mockResolvedValue(true),
+      getEmailTemplateByKey: jest.fn(),
       updateEmailQueueStatus: jest.fn().mockResolvedValue(undefined),
     };
 
@@ -641,9 +646,9 @@ describe('EmailService.processQueue — preferencias de notificación', () => {
 
     service = module.get<EmailService>(EmailService);
     // El envío real se prueba aparte; aquí interesa quién llega a él.
-    jest
+    sendEmailSpy = jest
       .spyOn(service as any, 'sendEmail')
-      .mockResolvedValue(undefined as never);
+      .mockResolvedValue(true as never);
   });
 
   it('envía cuando la categoría del email sigue activada', async () => {
@@ -657,6 +662,30 @@ describe('EmailService.processQueue — preferencias de notificación', () => {
 
     expect((service as any).sendEmail).toHaveBeenCalled();
     expect(result).toMatchObject({ sent: 1, skipped: 0, failed: 0 });
+  });
+
+  it('no envía si el documento fue cancelado después de cargar la tanda', async () => {
+    firestore.getPendingEmails.mockResolvedValue([queued()]);
+    firestore.getEmailTemplateByKey.mockResolvedValue({
+      content: {
+        A: {
+          es: { subject: 'Asunto', body: '<p>Contenido</p>' },
+        },
+      },
+    });
+    firestore.claimPendingEmail.mockResolvedValue(false);
+    sendEmailSpy.mockRestore();
+    const resendSend = jest.fn();
+    (service as any).resend = { emails: { send: resendSend } };
+
+    const result = await service.processQueue();
+
+    // El snapshot seguía diciendo pending, pero la transacción es la autoridad
+    // final. Sobrescribir cancelled con sent reactivaría un correo de la baja.
+    expect(firestore.claimPendingEmail).toHaveBeenCalledWith('q-1');
+    expect(resendSend).not.toHaveBeenCalled();
+    expect(firestore.updateEmailQueueStatus).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ sent: 0, failed: 0, skipped: 1 });
   });
 
   it('no envía un email de producto si el usuario desactivó esa categoría', async () => {

--- a/src/modules/email/email.service.spec.ts
+++ b/src/modules/email/email.service.spec.ts
@@ -588,3 +588,176 @@ describe('EmailService.scheduleHighUsageEmails', () => {
     expect(firestore.getUsersWithHighUsage).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * Las preferencias se comprueban justo antes de enviar y no solo al encolar: las
+ * secuencias de onboarding se programan con días de antelación, y en ese hueco
+ * el usuario puede desactivar la categoría o darse de baja (issue #99).
+ */
+describe('EmailService.processQueue — preferencias de notificación', () => {
+  let service: EmailService;
+  let firestore: {
+    getPendingEmails: jest.Mock;
+    getUserById: jest.Mock;
+    cancelQueuedEmail: jest.Mock;
+    updateEmailQueueStatus: jest.Mock;
+  };
+
+  function queued(overrides: Record<string, any> = {}) {
+    return {
+      id: 'q-1',
+      userId: 'uid-1',
+      userEmail: 'user@example.com',
+      emailType: 'welcome',
+      abVariant: 'A',
+      language: 'es',
+      scheduledFor: new Date(),
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    firestore = {
+      getPendingEmails: jest.fn().mockResolvedValue([]),
+      getUserById: jest.fn().mockResolvedValue({ id: 'uid-1' }),
+      cancelQueuedEmail: jest.fn().mockResolvedValue(undefined),
+      updateEmailQueueStatus: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmailService,
+        PeriodCalculatorService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) =>
+              key === 'RESEND_API_KEY' ? 'test-key' : undefined,
+          },
+        },
+        { provide: FirestoreService, useValue: firestore },
+      ],
+    }).compile();
+
+    service = module.get<EmailService>(EmailService);
+    // El envío real se prueba aparte; aquí interesa quién llega a él.
+    jest
+      .spyOn(service as any, 'sendEmail')
+      .mockResolvedValue(undefined as never);
+  });
+
+  it('envía cuando la categoría del email sigue activada', async () => {
+    firestore.getPendingEmails.mockResolvedValue([queued()]);
+    firestore.getUserById.mockResolvedValue({
+      id: 'uid-1',
+      notificationPreferences: { product: true },
+    });
+
+    const result = await service.processQueue();
+
+    expect((service as any).sendEmail).toHaveBeenCalled();
+    expect(result).toMatchObject({ sent: 1, skipped: 0, failed: 0 });
+  });
+
+  it('no envía un email de producto si el usuario desactivó esa categoría', async () => {
+    firestore.getPendingEmails.mockResolvedValue([queued()]);
+    firestore.getUserById.mockResolvedValue({
+      id: 'uid-1',
+      notificationPreferences: { product: false },
+    });
+
+    const result = await service.processQueue();
+
+    expect((service as any).sendEmail).not.toHaveBeenCalled();
+    expect(firestore.cancelQueuedEmail).toHaveBeenCalledWith(
+      'q-1',
+      'notifications_off:product',
+    );
+    // Cancelado no es fallido: un pico de bajas no puede leerse como avería.
+    expect(result).toMatchObject({ sent: 0, skipped: 1, failed: 0 });
+  });
+
+  it('desactivar producto no silencia los avisos de cobro ni los de cuota', async () => {
+    firestore.getPendingEmails.mockResolvedValue([
+      queued({ id: 'q-billing', emailType: 'payment_failed' }),
+      queued({ id: 'q-usage', emailType: 'limit_80_percent' }),
+    ]);
+    firestore.getUserById.mockResolvedValue({
+      id: 'uid-1',
+      notificationPreferences: { product: false },
+    });
+
+    const result = await service.processQueue();
+
+    expect(result).toMatchObject({ sent: 2, skipped: 0 });
+  });
+
+  it('respeta cada categoría por separado', async () => {
+    firestore.getPendingEmails.mockResolvedValue([
+      queued({ id: 'q-billing', emailType: 'subscription_downgraded' }),
+      queued({ id: 'q-usage', emailType: 'conversion_blocked' }),
+    ]);
+    firestore.getUserById.mockResolvedValue({
+      id: 'uid-1',
+      notificationPreferences: { billing: false, usageReminders: true },
+    });
+
+    const result = await service.processQueue();
+
+    expect(firestore.cancelQueuedEmail).toHaveBeenCalledTimes(1);
+    expect(firestore.cancelQueuedEmail).toHaveBeenCalledWith(
+      'q-billing',
+      'notifications_off:billing',
+    );
+    expect(result).toMatchObject({ sent: 1, skipped: 1 });
+  });
+
+  it('no escribe a una cuenta que ya no existe', async () => {
+    firestore.getPendingEmails.mockResolvedValue([queued()]);
+    firestore.getUserById.mockResolvedValue(null);
+
+    const result = await service.processQueue();
+
+    expect((service as any).sendEmail).not.toHaveBeenCalled();
+    expect(firestore.cancelQueuedEmail).toHaveBeenCalledWith(
+      'q-1',
+      'user_deleted',
+    );
+    expect(result).toMatchObject({ skipped: 1 });
+  });
+
+  it('lee las preferencias una sola vez por usuario en cada tanda', async () => {
+    firestore.getPendingEmails.mockResolvedValue([
+      queued({ id: 'q-1' }),
+      queued({ id: 'q-2', emailType: 'tutorial' }),
+      queued({ id: 'q-3', userId: 'uid-2' }),
+    ]);
+
+    await service.processQueue();
+
+    expect(firestore.getUserById).toHaveBeenCalledTimes(2);
+  });
+
+  it('ante un fallo al leer al usuario, envía en vez de silenciar', async () => {
+    firestore.getPendingEmails.mockResolvedValue([
+      queued({ emailType: 'payment_failed' }),
+    ]);
+    firestore.getUserById.mockRejectedValue(new Error('firestore caído'));
+
+    const result = await service.processQueue();
+
+    expect((service as any).sendEmail).toHaveBeenCalled();
+    expect(result).toMatchObject({ sent: 1, skipped: 0 });
+  });
+
+  it('envía los tipos que no estén clasificados en ninguna categoría', async () => {
+    firestore.getPendingEmails.mockResolvedValue([
+      queued({ emailType: 'plantilla_creada_a_mano' }),
+    ]);
+
+    const result = await service.processQueue();
+
+    expect((service as any).sendEmail).toHaveBeenCalled();
+    expect(result).toMatchObject({ sent: 1 });
+  });
+});

--- a/src/modules/email/email.service.ts
+++ b/src/modules/email/email.service.ts
@@ -466,24 +466,31 @@ export class EmailService {
       // lo tomó otro worker, Resend no debe recibir esta llamada.
       const claimed = await this.firestoreService.claimPendingEmail(
         queueItem.id,
+        queueItem.userId,
       );
       if (!claimed) {
         return false;
       }
 
       // Send via Resend
-      const result = await this.resend.emails.send({
-        from: this.fromEmail,
-        to: queueItem.userEmail,
-        subject,
-        html,
-        text,
-        tags: [
-          { name: 'email_type', value: queueItem.emailType },
-          { name: 'ab_variant', value: queueItem.abVariant },
-          { name: 'user_id', value: queueItem.userId },
-        ],
-      });
+      const result = await this.resend.emails.send(
+        {
+          from: this.fromEmail,
+          to: queueItem.userEmail,
+          subject,
+          html,
+          text,
+          tags: [
+            { name: 'email_type', value: queueItem.emailType },
+            { name: 'ab_variant', value: queueItem.abVariant },
+            { name: 'user_id', value: queueItem.userId },
+          ],
+        },
+        // El id de la cola como clave de idempotencia: un envío que quedó en
+        // `sending` porque el proceso murió se puede reintentar sin arriesgar
+        // que al destinatario le llegue dos veces el mismo correo.
+        { idempotencyKey: queueItem.id },
+      );
 
       // Update queue status
       await this.firestoreService.updateEmailQueueStatus(

--- a/src/modules/email/email.service.ts
+++ b/src/modules/email/email.service.ts
@@ -19,6 +19,11 @@ import type {
   ProPowerUser,
   EmailSkipReasons,
 } from './interfaces/email.interface.js';
+import { getEmailNotificationCategory } from './email-categories.js';
+import {
+  resolveNotificationPreferences,
+  type NotificationPreferences,
+} from '../../common/interfaces/notification-preferences.interface.js';
 // Note: Hardcoded templates removed. All content now comes from Firestore with A/B support.
 
 @Injectable()
@@ -275,19 +280,38 @@ export class EmailService {
    */
   async processQueue(): Promise<ProcessQueueResult> {
     if (!this.isEnabled) {
-      return { sent: 0, failed: 0, executedAt: new Date() };
+      return { sent: 0, failed: 0, skipped: 0, executedAt: new Date() };
     }
 
     const startTime = Date.now();
     let sent = 0;
     let failed = 0;
+    let skipped = 0;
 
     try {
       const pendingEmails = await this.firestoreService.getPendingEmails(50);
       this.logger.log(`Processing ${pendingEmails.length} pending emails`);
 
+      // Una lectura por usuario y no por email: un mismo usuario puede tener
+      // varios pendientes en la misma tanda.
+      const preferencesCache = new Map<
+        string,
+        NotificationPreferences | null
+      >();
+
       for (const email of pendingEmails) {
         try {
+          const skipReason = await this.resolveSkipReason(
+            email,
+            preferencesCache,
+          );
+
+          if (skipReason) {
+            await this.firestoreService.cancelQueuedEmail(email.id, skipReason);
+            skipped++;
+            continue;
+          }
+
           await this.sendEmail(email);
           sent++;
         } catch (error) {
@@ -300,13 +324,66 @@ export class EmailService {
 
       const duration = Date.now() - startTime;
       this.logger.log(
-        `Email queue processed in ${duration}ms: ${sent} sent, ${failed} failed`,
+        `Email queue processed in ${duration}ms: ${sent} sent, ${failed} failed, ${skipped} skipped`,
       );
     } catch (error) {
       this.logger.error(`Error processing email queue: ${error.message}`);
     }
 
-    return { sent, failed, executedAt: new Date() };
+    return { sent, failed, skipped, executedAt: new Date() };
+  }
+
+  /**
+   * Decide si un email de la cola NO debe salir, y por qué.
+   *
+   * La comprobación vive aquí, justo antes del envío, y no solo en el momento de
+   * encolar: entre una cosa y otra pasan horas o días —las secuencias de
+   * onboarding se programan con antelación—, y en ese intervalo el usuario puede
+   * haber desactivado la categoría o haberse dado de baja. Comprobarlo solo al
+   * encolar dejaría salir precisamente los emails que más molestan.
+   *
+   * Ante la duda se envía: un tipo de email sin clasificar o un fallo al leer el
+   * usuario no bastan para silenciar un aviso de cobro fallido.
+   *
+   * @returns el código del motivo para no enviar, o `null` si el envío procede.
+   */
+  private async resolveSkipReason(
+    email: { id: string; userId: string; emailType: string },
+    cache: Map<string, NotificationPreferences | null>,
+  ): Promise<string | null> {
+    const category = getEmailNotificationCategory(email.emailType);
+
+    if (!category) {
+      this.logger.warn(
+        `Email type "${email.emailType}" is not mapped to a notification category; sending anyway`,
+      );
+      return null;
+    }
+
+    let preferences = cache.get(email.userId);
+
+    if (preferences === undefined) {
+      try {
+        const user = await this.firestoreService.getUserById(email.userId);
+        // El usuario borrado se distingue del que no se pudo leer: al primero no
+        // se le escribe nunca más; con el segundo se mantiene el envío.
+        preferences = user
+          ? resolveNotificationPreferences(user.notificationPreferences)
+          : null;
+      } catch (error) {
+        this.logger.warn(
+          `Could not read notification preferences for ${email.userId}: ${error.message}`,
+        );
+        return null;
+      }
+      cache.set(email.userId, preferences);
+    }
+
+    if (preferences === null) {
+      return 'user_deleted';
+    }
+
+    return preferences[category] ? null : `notifications_off:${category}`;
   }
 
   /**

--- a/src/modules/email/email.service.ts
+++ b/src/modules/email/email.service.ts
@@ -312,8 +312,14 @@ export class EmailService {
             continue;
           }
 
-          await this.sendEmail(email);
-          sent++;
+          const didSend = await this.sendEmail(email);
+          if (didSend) {
+            sent++;
+          } else {
+            // Otro worker pudo reclamar el documento o una baja cancelarlo
+            // después de getPendingEmails. Ninguno de los dos casos es fallo.
+            skipped++;
+          }
         } catch (error) {
           this.logger.error(
             `Failed to send email ${email.id}: ${error.message}`,
@@ -408,7 +414,7 @@ export class EmailService {
     abVariant: string;
     language: string;
     metadata?: Record<string, any>;
-  }): Promise<void> {
+  }): Promise<boolean> {
     try {
       // Get template from Firestore (required - no fallback)
       const firestoreTemplate =
@@ -455,6 +461,16 @@ export class EmailService {
         .replace(/\s+/g, ' ')
         .trim();
 
+      // La lista de pendientes es solo un snapshot. La transición atómica es
+      // la autorización real para enviar: si el documento fue cancelado o ya
+      // lo tomó otro worker, Resend no debe recibir esta llamada.
+      const claimed = await this.firestoreService.claimPendingEmail(
+        queueItem.id,
+      );
+      if (!claimed) {
+        return false;
+      }
+
       // Send via Resend
       const result = await this.resend.emails.send({
         from: this.fromEmail,
@@ -479,6 +495,7 @@ export class EmailService {
       this.logger.debug(
         `Email sent to ${queueItem.userEmail}: ${result.data?.id}`,
       );
+      return true;
     } catch (error) {
       // Update queue status with error
       await this.firestoreService.updateEmailQueueStatus(

--- a/src/modules/email/interfaces/email.interface.ts
+++ b/src/modules/email/interfaces/email.interface.ts
@@ -174,6 +174,12 @@ export interface EmailMetricsByType {
 export interface ProcessQueueResult {
   sent: number;
   failed: number;
+  /**
+   * Emails que no salieron porque el usuario desactivó esa categoría de
+   * notificaciones o porque su cuenta ya no existe. No son fallos: cuentan
+   * aparte para que un pico de bajas no se lea como una avería de la cola.
+   */
+  skipped: number;
   executedAt: Date;
 }
 

--- a/src/modules/email/interfaces/email.interface.ts
+++ b/src/modules/email/interfaces/email.interface.ts
@@ -48,7 +48,12 @@ export type EmailType =
   | ReactivationEmailType
   | PaymentEmailType;
 
-export type EmailStatus = 'pending' | 'sent' | 'failed' | 'cancelled';
+export type EmailStatus =
+  | 'pending'
+  | 'sending'
+  | 'sent'
+  | 'failed'
+  | 'cancelled';
 
 export type EmailEventType =
   | 'delivered'
@@ -74,6 +79,7 @@ export interface EmailQueue {
   language: EmailLanguage;
   metadata?: Record<string, any>;
   scheduledFor: Date;
+  sendingAt?: Date;
   sentAt?: Date;
   errorMessage?: string;
   createdAt: Date;

--- a/src/modules/storage/storage.service.spec.ts
+++ b/src/modules/storage/storage.service.spec.ts
@@ -160,3 +160,78 @@ describe('StorageService — bucket público', () => {
     ).rejects.toThrow('permiso denegado');
   });
 });
+
+/**
+ * El borrado por prefijo lo estrena la baja de cuenta (issue #99), que lo llama
+ * con `debug-zpl/<uid>/`. Sin la barra final, el prefijo de `uid1` casaría
+ * también con `uid10` y se llevaría por delante los archivos de otro usuario.
+ */
+describe('StorageService — borrado', () => {
+  function buildService(files: Array<{ name: string }> = []) {
+    const deleteFiles = jest.fn().mockResolvedValue(undefined);
+    const getFiles = jest.fn().mockResolvedValue([files]);
+    const deleteFile = jest.fn().mockResolvedValue(undefined);
+    const bucket = jest.fn().mockReturnValue({
+      getFiles,
+      deleteFiles,
+      file: jest.fn().mockReturnValue({ delete: deleteFile }),
+    });
+
+    const service: any = new StorageService(
+      { get: jest.fn().mockReturnValue('mi-bucket') } as any,
+      {},
+    );
+    service.storage = { bucket };
+
+    return { service, getFiles, deleteFiles, deleteFile };
+  }
+
+  it('rechaza un prefijo sin barra final en vez de borrar de más', async () => {
+    const { service, deleteFiles } = buildService();
+
+    await expect(service.deleteByPrefix('debug-zpl/uid1')).rejects.toThrow(
+      /debe terminar en/,
+    );
+    expect(deleteFiles).not.toHaveBeenCalled();
+  });
+
+  it('devuelve cuántos objetos había bajo el prefijo', async () => {
+    const { service, deleteFiles } = buildService([
+      { name: 'debug-zpl/uid1/a.zpl' },
+      { name: 'debug-zpl/uid1/b.zpl' },
+    ]);
+
+    await expect(service.deleteByPrefix('debug-zpl/uid1/')).resolves.toBe(2);
+    expect(deleteFiles).toHaveBeenCalledWith({
+      prefix: 'debug-zpl/uid1/',
+      force: true,
+    });
+  });
+
+  it('no llama al borrado si no hay nada bajo el prefijo', async () => {
+    const { service, deleteFiles } = buildService([]);
+
+    await expect(service.deleteByPrefix('debug-zpl/uid1/')).resolves.toBe(0);
+    expect(deleteFiles).not.toHaveBeenCalled();
+  });
+
+  it('trata como no borrado el objeto que ya no existía', async () => {
+    const { service } = buildService();
+    service.storage.bucket().file = jest.fn().mockReturnValue({
+      delete: jest.fn().mockRejectedValue({ code: 404 }),
+    });
+
+    await expect(service.deleteFile('label-viejo.pdf')).resolves.toBe(false);
+  });
+
+  it('relanza cualquier otro error de borrado', async () => {
+    const { service } = buildService();
+    service.storage.bucket().file = jest.fn().mockReturnValue({
+      delete: jest.fn().mockRejectedValue({ code: 403, message: 'denegado' }),
+    });
+
+    await expect(service.deleteFile('label.pdf')).rejects.toMatchObject({
+      code: 403,
+    });
+  });
+});

--- a/src/modules/storage/storage.service.ts
+++ b/src/modules/storage/storage.service.ts
@@ -150,6 +150,60 @@ export class StorageService {
   }
 
   /**
+   * Borra un objeto del bucket.
+   *
+   * Devuelve `false` si el objeto ya no estaba (404 de GCS) en vez de lanzar: al
+   * dar de baja una cuenta se recorren registros de conversiones antiguas cuyo
+   * PDF pudo caducar hace meses, y esa ausencia es el estado deseado, no un
+   * fallo que deba abortar el borrado.
+   */
+  async deleteFile(filePath: string): Promise<boolean> {
+    try {
+      await this.storage.bucket(this.bucketName).file(filePath).delete();
+      return true;
+    } catch (error) {
+      if (error?.code === 404) {
+        return false;
+      }
+      this.logger.error(
+        `Error al borrar el archivo ${filePath}: ${error.message}`,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Borra todos los objetos que cuelgan de un prefijo y devuelve cuántos había.
+   *
+   * `deleteFiles` no informa de cuántos borró, así que se listan antes: la baja
+   * de cuenta tiene que poder decirle al usuario cuántos archivos suyos se
+   * eliminaron, y un número inventado sería peor que no darlo.
+   *
+   * El prefijo debe terminar en `/`: sin la barra, `debug-zpl/uid1` también
+   * casaría con `debug-zpl/uid10/...` y se llevaría por delante los archivos de
+   * otro usuario.
+   */
+  async deleteByPrefix(prefix: string): Promise<number> {
+    if (!prefix.endsWith('/')) {
+      throw new Error(`El prefijo de borrado debe terminar en "/": ${prefix}`);
+    }
+
+    const [files] = await this.storage
+      .bucket(this.bucketName)
+      .getFiles({ prefix });
+
+    if (files.length === 0) {
+      return 0;
+    }
+
+    await this.storage
+      .bucket(this.bucketName)
+      .deleteFiles({ prefix, force: true });
+
+    return files.length;
+  }
+
+  /**
    * Genera una URL firmada para cualquier archivo en el bucket
    * @param filePath Path del archivo en el bucket (ej: label-xxx.pdf)
    * @param downloadFilename Nombre del archivo para descarga (opcional)

--- a/src/modules/users/account-deletion.service.spec.ts
+++ b/src/modules/users/account-deletion.service.spec.ts
@@ -88,7 +88,14 @@ function buildService(
   const storage = {
     deleteFile: jest.fn().mockResolvedValue(true),
     deleteByPrefix: jest.fn().mockResolvedValue(1),
+    deletePublicFile: jest.fn().mockResolvedValue(undefined),
     ...overrides.storage,
+  };
+
+  const users = {
+    getProfilePhotoPath: jest
+      .fn()
+      .mockImplementation((uid: string) => `users/${uid}/avatar.webp`),
   };
 
   const firebaseAdmin = { deleteUser: jest.fn().mockResolvedValue(undefined) };
@@ -134,9 +141,10 @@ function buildService(
   service.firestoreService = firestore;
   service.firebaseAdminService = firebaseAdmin;
   service.storageService = storage;
+  service.usersService = users;
   service.stripe = stripe;
 
-  return { service, firestore, storage, firebaseAdmin, stripe };
+  return { service, firestore, storage, firebaseAdmin, stripe, users };
 }
 
 describe('AccountDeletionService — baja completa', () => {
@@ -209,6 +217,33 @@ describe('AccountDeletionService — baja completa', () => {
     );
     // 2 PDF del historial + 3 prefijos (debug-zpl y los dos batches) x 2.
     expect(result.deleted.storedFiles).toBe(8);
+  });
+
+  it('borra la foto de perfil, que vive en el bucket público', async () => {
+    const { service, storage } = buildService({
+      user: { ...baseUser, photoURL: 'https://cdn/uid-1/avatar.webp?v=1' },
+    });
+
+    const result = await service.deleteAccount('uid-1');
+
+    // Su URL no está firmada ni caduca: dejarla ahí mantendría la cara del
+    // titular accesible a cualquiera después de la baja.
+    expect(storage.deletePublicFile).toHaveBeenCalledWith(
+      'users/uid-1/avatar.webp',
+    );
+    // 2 PDF + 1 prefijo de debug-zpl + la foto.
+    expect(result.deleted.storedFiles).toBe(4);
+  });
+
+  it('no cuenta una foto que el perfil nunca tuvo', async () => {
+    const { service, storage } = buildService();
+
+    const result = await service.deleteAccount('uid-1');
+
+    // El borrado se intenta igual —el perfil pudo quedar desincronizado—, pero
+    // `deletePublicFile` da por bueno el 404 y sumarlo inflaría el recuento.
+    expect(storage.deletePublicFile).toHaveBeenCalled();
+    expect(result.deleted.storedFiles).toBe(3);
   });
 
   it('anonimiza también los registros contables locales', async () => {

--- a/src/modules/users/account-deletion.service.spec.ts
+++ b/src/modules/users/account-deletion.service.spec.ts
@@ -273,6 +273,38 @@ describe('AccountDeletionService — baja completa', () => {
     expect(result.deleted.subscription.cancelled).toBe(true);
   });
 
+  it('no se bloquea si el id de suscripción guardado ya no existe en Stripe', async () => {
+    const { service, stripe } = buildService();
+    stripe.subscriptions.retrieve.mockRejectedValue(
+      Object.assign(new Error('No such subscription'), {
+        code: 'resource_missing',
+      }),
+    );
+    stripe.subscriptions.list.mockResolvedValue({
+      data: [{ id: 'sub_real', status: 'active' }],
+    });
+
+    const result = await service.deleteAccount('uid-1');
+
+    // Un id basura de un checkout que no cuajó no puede dejar a nadie sin poder
+    // darse de baja.
+    expect(stripe.subscriptions.cancel).toHaveBeenCalledWith('sub_real');
+    expect(result.deleted.subscription.cancelled).toBe(true);
+  });
+
+  it('borra el historial completo cuando ocupa un múltiplo exacto de la página', async () => {
+    const fullPages = Array.from({ length: 40 }, (_, page) =>
+      Array.from({ length: 500 }, (_, i) => historyRecord(`p${page}-h${i}`)),
+    );
+    const { service } = buildService({ history: fullPages });
+
+    // Agotar las 40 páginas no implica que quede algo: la 41ª lectura confirma
+    // que el historial está vacío y la baja no debe declararse incompleta.
+    const result = await service.deleteAccount('uid-1');
+
+    expect(result.deleted.conversions).toBe(20000);
+  });
+
   it('conserva la fila del historial cuyo archivo no se pudo borrar', async () => {
     const { service, firestore } = buildService({
       storage: {
@@ -379,6 +411,33 @@ describe('AccountDeletionService — baja completa', () => {
 });
 
 describe('AccountDeletionService — Stripe rechaza cancelar', () => {
+  it('declara qué suscripciones sí quedaron canceladas antes del rechazo', async () => {
+    const { service, stripe } = buildService();
+    stripe.subscriptions.list.mockResolvedValue({
+      data: [
+        { id: 'sub_1', status: 'active' },
+        { id: 'sub_2', status: 'active' },
+      ],
+    });
+    stripe.subscriptions.cancel
+      .mockResolvedValueOnce({ id: 'sub_1', canceled_at: 1 })
+      .mockRejectedValueOnce(
+        Object.assign(new Error('nope'), { code: 'api_error' }),
+      );
+
+    const error: HttpException = await service
+      .deleteAccount('uid-1')
+      .catch((e: HttpException) => e);
+
+    // `sub_1` ya no vuelve: decir "no se ha tocado nada" sería falso.
+    expect(error.getResponse()).toMatchObject({
+      data: {
+        cancelledSubscriptions: ['sub_1'],
+        pendingSubscriptions: ['sub_2'],
+      },
+    });
+  });
+
   it('responde SUBSCRIPTION_CANCEL_FAILED y no borra absolutamente nada', async () => {
     const { service, firestore, storage, firebaseAdmin, stripe } =
       buildService();
@@ -455,6 +514,22 @@ describe('AccountDeletionService — borrado parcial', () => {
     // Sin cuenta de Auth el usuario no podría autenticarse para reintentar la
     // baja, y quedaría un documento huérfano en Firestore.
     expect(firebaseAdmin.deleteUser).not.toHaveBeenCalled();
+  });
+
+  it('no borra Firebase Auth si el barrido final de PII falla', async () => {
+    const { service, firebaseAdmin, firestore } = buildService();
+    (firestore.anonymizeUserFinancialRecords as jest.Mock)
+      .mockResolvedValueOnce(3)
+      .mockRejectedValueOnce(new Error('firestore caído'));
+
+    const error: HttpException = await service
+      .deleteAccount('uid-1')
+      .catch((e: HttpException) => e);
+
+    // Quedan registros con PII: el usuario necesita sus credenciales para
+    // reintentar la limpieza.
+    expect(firebaseAdmin.deleteUser).not.toHaveBeenCalled();
+    expect((error.getResponse() as any).data.accountDeleted).toBe(false);
   });
 
   it('declara la cuenta viva si Firebase Auth no la borra, aunque el perfil sí se fuera', async () => {

--- a/src/modules/users/account-deletion.service.spec.ts
+++ b/src/modules/users/account-deletion.service.spec.ts
@@ -79,6 +79,8 @@ function buildService(
     deleteTaxProfile: jest.fn().mockResolvedValue(true),
     anonymizeUserCfdis: jest.fn().mockResolvedValue(3),
     cancelPendingEmails: jest.fn().mockResolvedValue(0),
+    markAccountDeletion: jest.fn().mockResolvedValue(undefined),
+    clearAccountDeletionMark: jest.fn().mockResolvedValue(undefined),
     deleteUser: jest.fn().mockResolvedValue(undefined),
     ...overrides.firestore,
   };
@@ -168,6 +170,15 @@ describe('AccountDeletionService — baja completa', () => {
     expect(firestore.deleteUsageByUserId).toHaveBeenCalledWith('uid-1');
     expect(firestore.deleteUser).toHaveBeenCalledWith('uid-1');
     expect(firebaseAdmin.deleteUser).toHaveBeenCalledWith('uid-1');
+    // La lápida queda como segunda red para los ID tokens que sigan vivos tras
+    // borrar Auth; retirarla aquí permitiría recrear el perfil.
+    expect(firestore.markAccountDeletion).toHaveBeenCalledWith('uid-1');
+    expect(firestore.clearAccountDeletionMark).not.toHaveBeenCalled();
+    expect(
+      firestore.markAccountDeletion.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      firestore.scanUserConversionHistory.mock.invocationCallOrder[0],
+    );
   });
 
   it('borra los batches del usuario y los ZIP que cuelgan de ellos', async () => {
@@ -567,6 +578,9 @@ describe('AccountDeletionService — borrado parcial', () => {
     expect(response.data.accountDeleted).toBe(false);
     expect(firestore.deleteUser).not.toHaveBeenCalled();
     expect(firebaseAdmin.deleteUser).not.toHaveBeenCalled();
+    // Con Auth conservado, mantener la lápida bloquearía precisamente el
+    // acceso que hace posible reintentar la limpieza.
+    expect(firestore.clearAccountDeletionMark).toHaveBeenCalledWith('uid-1');
     // Los pasos posteriores al que falló sí se ejecutan.
     expect(firestore.anonymizeUserCfdis).toHaveBeenCalled();
   });

--- a/src/modules/users/account-deletion.service.spec.ts
+++ b/src/modules/users/account-deletion.service.spec.ts
@@ -1,0 +1,406 @@
+// Evitar que el constructor real de Stripe intente validar la clave de test.
+jest.mock('stripe', () => jest.fn());
+
+import { HttpException } from '@nestjs/common';
+import { AccountDeletionService } from './account-deletion.service.js';
+import { ErrorCodes } from '../../common/constants/error-codes.js';
+import { RETENTION_REASON_FISCAL } from './dto/delete-account.dto.js';
+import type { User } from '../../common/interfaces/user.interface.js';
+
+/** URL firmada con el formato real, para que se le pueda extraer el path. */
+function signedUrl(file: string): string {
+  return `https://storage.googleapis.com/bucket-zpl/${file}?X-Goog-Algorithm=GOOG4-RSA-SHA256`;
+}
+
+function historyRecord(id: string) {
+  return {
+    id,
+    userId: 'uid-1',
+    jobId: `job-${id}`,
+    labelCount: 5,
+    labelSize: '4x6',
+    status: 'completed' as const,
+    outputFormat: 'pdf' as const,
+    fileUrl: signedUrl(`label-${id}.pdf`),
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+}
+
+const baseUser: User = {
+  id: 'uid-1',
+  email: 'user@example.com',
+  emailVerified: true,
+  plan: 'pro',
+  role: 'user',
+  stripeCustomerId: 'cus_1',
+  stripeSubscriptionId: 'sub_1',
+  createdAt: new Date('2025-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+} as User;
+
+/**
+ * El servicio tiene un constructor que abre un cliente de Stripe real. Se
+ * instancia por prototipo e inyectan solo las dependencias que cada test
+ * ejercita, como en el resto de specs de este módulo.
+ */
+function buildService(
+  overrides: {
+    user?: User | null;
+    history?: ReturnType<typeof historyRecord>[][];
+    stripe?: Record<string, any> | null;
+    firestore?: Record<string, jest.Mock>;
+    storage?: Record<string, jest.Mock>;
+  } = {},
+) {
+  const history = overrides.history ?? [
+    [historyRecord('h1'), historyRecord('h2')],
+  ];
+  let page = 0;
+
+  const firestore = {
+    getUserById: jest
+      .fn()
+      .mockResolvedValue(
+        overrides.user === undefined ? baseUser : overrides.user,
+      ),
+    scanUserConversionHistory: jest
+      .fn()
+      .mockImplementation(async () => history[page++] ?? []),
+    deleteConversionHistoryByIds: jest
+      .fn()
+      .mockImplementation(async (ids: string[]) => ids.length),
+    deleteZplDebugFilesByUserId: jest.fn().mockResolvedValue(0),
+    deleteUsageByUserId: jest.fn().mockResolvedValue(2),
+    deleteTaxProfile: jest.fn().mockResolvedValue(true),
+    anonymizeUserCfdis: jest.fn().mockResolvedValue(3),
+    cancelPendingEmails: jest.fn().mockResolvedValue(0),
+    deleteUser: jest.fn().mockResolvedValue(undefined),
+    ...overrides.firestore,
+  };
+
+  const storage = {
+    deleteFile: jest.fn().mockResolvedValue(true),
+    deleteByPrefix: jest.fn().mockResolvedValue(1),
+    ...overrides.storage,
+  };
+
+  const firebaseAdmin = { deleteUser: jest.fn().mockResolvedValue(undefined) };
+
+  const stripe =
+    overrides.stripe === null
+      ? null
+      : {
+          subscriptions: {
+            retrieve: jest.fn().mockResolvedValue({
+              id: 'sub_1',
+              status: 'active',
+            }),
+            cancel: jest.fn().mockResolvedValue({
+              id: 'sub_1',
+              status: 'canceled',
+              canceled_at: Math.floor(
+                new Date('2026-08-19T10:00:00.000Z').getTime() / 1000,
+              ),
+            }),
+          },
+          invoices: {
+            list: jest.fn().mockResolvedValue({
+              data: [{ id: 'in_1' }, { id: 'in_2' }],
+              has_more: false,
+            }),
+          },
+          customers: {
+            retrieve: jest.fn().mockResolvedValue({
+              id: 'cus_1',
+              metadata: { userId: 'uid-1' },
+            }),
+            update: jest.fn().mockResolvedValue({}),
+          },
+          ...overrides.stripe,
+        };
+
+  const service: any = Object.create(AccountDeletionService.prototype);
+  service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+  service.firestoreService = firestore;
+  service.firebaseAdminService = firebaseAdmin;
+  service.storageService = storage;
+  service.stripe = stripe;
+
+  return { service, firestore, storage, firebaseAdmin, stripe };
+}
+
+describe('AccountDeletionService — baja completa', () => {
+  it('cancela la suscripción, borra los datos y devuelve el contrato del frontend', async () => {
+    const { service, firestore, storage, firebaseAdmin, stripe } =
+      buildService();
+
+    const result = await service.deleteAccount('uid-1');
+
+    expect(stripe.subscriptions.cancel).toHaveBeenCalledWith('sub_1');
+    expect(result).toEqual({
+      deleted: {
+        conversions: 2,
+        // Dos PDF del historial más el ZPL original borrado por prefijo.
+        storedFiles: 3,
+        taxProfile: true,
+        subscription: {
+          cancelled: true,
+          plan: 'pro',
+          effectiveAt: '2026-08-19T10:00:00.000Z',
+        },
+      },
+      retained: {
+        invoices: 2,
+        reason: RETENTION_REASON_FISCAL,
+      },
+    });
+
+    expect(storage.deleteFile).toHaveBeenCalledWith('label-h1.pdf');
+    expect(storage.deleteByPrefix).toHaveBeenCalledWith('debug-zpl/uid-1/');
+    expect(firestore.deleteUsageByUserId).toHaveBeenCalledWith('uid-1');
+    expect(firestore.deleteUser).toHaveBeenCalledWith('uid-1');
+    expect(firebaseAdmin.deleteUser).toHaveBeenCalledWith('uid-1');
+  });
+
+  it('anonimiza los CFDI en lugar de borrarlos, y anonimiza el customer de Stripe', async () => {
+    const { service, firestore, stripe } = buildService();
+
+    await service.deleteAccount('uid-1');
+
+    expect(firestore.anonymizeUserCfdis).toHaveBeenCalledWith('uid-1');
+    expect(stripe.customers.update).toHaveBeenCalledWith(
+      'cus_1',
+      expect.objectContaining({
+        name: 'Deleted account',
+        email: '',
+        // La metadata previa se vacía clave a clave: Stripe fusiona en vez de
+        // reemplazar, y dejar `userId` ahí reidentificaría al titular.
+        metadata: expect.objectContaining({
+          userId: '',
+          account_deleted: 'true',
+        }),
+      }),
+    );
+  });
+
+  it('no cuenta como archivo borrado el PDF que ya había caducado', async () => {
+    const { service } = buildService({
+      storage: { deleteFile: jest.fn().mockResolvedValue(false) },
+    });
+
+    const result = await service.deleteAccount('uid-1');
+
+    // Solo el prefijo de ZPL: los dos PDF del historial ya no existían.
+    expect(result.deleted.storedFiles).toBe(1);
+    expect(result.deleted.conversions).toBe(2);
+  });
+
+  it('recorre todas las páginas del historial', async () => {
+    const bigPage = Array.from({ length: 500 }, (_, i) =>
+      historyRecord(`h${i}`),
+    );
+    const { service } = buildService({
+      history: [bigPage, [historyRecord('last')]],
+    });
+
+    const result = await service.deleteAccount('uid-1');
+
+    expect(result.deleted.conversions).toBe(501);
+  });
+
+  it('informa de que no había suscripción sin dejar de borrar el resto', async () => {
+    const { service, firestore } = buildService({
+      user: { ...baseUser, stripeSubscriptionId: undefined },
+    });
+
+    const result = await service.deleteAccount('uid-1');
+
+    expect(result.deleted.subscription).toEqual({
+      cancelled: false,
+      plan: null,
+      effectiveAt: null,
+    });
+    expect(firestore.deleteUser).toHaveBeenCalled();
+  });
+
+  it('no vuelve a cancelar una suscripción que Stripe ya tenía cancelada', async () => {
+    const { service, stripe } = buildService();
+    stripe.subscriptions.retrieve.mockResolvedValue({
+      id: 'sub_1',
+      status: 'canceled',
+    });
+
+    const result = await service.deleteAccount('uid-1');
+
+    expect(stripe.subscriptions.cancel).not.toHaveBeenCalled();
+    expect(result.deleted.subscription.cancelled).toBe(false);
+  });
+
+  it('devuelve 404 con USER_NOT_FOUND si no hay perfil que borrar', async () => {
+    const { service, firestore } = buildService({ user: null });
+
+    await expect(service.deleteAccount('uid-1')).rejects.toMatchObject({
+      status: 404,
+      response: { error: ErrorCodes.USER_NOT_FOUND },
+    });
+    expect(firestore.deleteUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('AccountDeletionService — Stripe rechaza cancelar', () => {
+  it('responde SUBSCRIPTION_CANCEL_FAILED y no borra absolutamente nada', async () => {
+    const { service, firestore, storage, firebaseAdmin, stripe } =
+      buildService();
+    stripe.subscriptions.cancel.mockRejectedValue(
+      Object.assign(new Error('card_declined'), { code: 'api_error' }),
+    );
+
+    const error: HttpException = await service
+      .deleteAccount('uid-1')
+      .catch((e: HttpException) => e);
+
+    expect(error.getStatus()).toBe(409);
+    expect(error.getResponse()).toMatchObject({
+      error: ErrorCodes.SUBSCRIPTION_CANCEL_FAILED,
+      data: { plan: 'pro', subscriptionId: 'sub_1', reason: 'api_error' },
+    });
+
+    // La garantía del contrato: la cuenta queda intacta y se puede reintentar.
+    expect(firestore.deleteConversionHistoryByIds).not.toHaveBeenCalled();
+    expect(firestore.deleteUsageByUserId).not.toHaveBeenCalled();
+    expect(firestore.deleteTaxProfile).not.toHaveBeenCalled();
+    expect(firestore.anonymizeUserCfdis).not.toHaveBeenCalled();
+    expect(firestore.deleteUser).not.toHaveBeenCalled();
+    expect(firebaseAdmin.deleteUser).not.toHaveBeenCalled();
+    expect(storage.deleteFile).not.toHaveBeenCalled();
+  });
+
+  it('no borra la cuenta si hay suscripción registrada y Stripe no está configurado', async () => {
+    const { service, firestore } = buildService({ stripe: null });
+
+    const error: HttpException = await service
+      .deleteAccount('uid-1')
+      .catch((e: HttpException) => e);
+
+    expect(error.getStatus()).toBe(409);
+    expect(error.getResponse()).toMatchObject({
+      error: ErrorCodes.SUBSCRIPTION_CANCEL_FAILED,
+      data: { reason: 'stripe_not_configured' },
+    });
+    expect(firestore.deleteUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('AccountDeletionService — borrado parcial', () => {
+  it('marca la cuenta como NO borrada cuando falla el borrado en Firestore', async () => {
+    const { service } = buildService({
+      firestore: {
+        deleteUser: jest.fn().mockRejectedValue(new Error('firestore caído')),
+      },
+    });
+
+    const error: HttpException = await service
+      .deleteAccount('uid-1')
+      .catch((e: HttpException) => e);
+
+    expect(error.getStatus()).toBe(500);
+    const response = error.getResponse() as any;
+    expect(response.error).toBe(ErrorCodes.ACCOUNT_DELETION_PARTIAL);
+    expect(response.data.accountDeleted).toBe(false);
+    expect(response.data.failedSteps).toEqual(['account']);
+    // La suscripción sí se canceló: el frontend necesita poder decirlo.
+    expect(response.data.deleted.subscription.cancelled).toBe(true);
+  });
+
+  it('no borra la cuenta de Auth si el perfil no llegó a borrarse', async () => {
+    const { service, firebaseAdmin } = buildService({
+      firestore: {
+        deleteUser: jest.fn().mockRejectedValue(new Error('firestore caído')),
+      },
+    });
+
+    await service.deleteAccount('uid-1').catch(() => undefined);
+
+    // Sin cuenta de Auth el usuario no podría autenticarse para reintentar la
+    // baja, y quedaría un documento huérfano en Firestore.
+    expect(firebaseAdmin.deleteUser).not.toHaveBeenCalled();
+  });
+
+  it('declara la cuenta viva si Firebase Auth no la borra, aunque el perfil sí se fuera', async () => {
+    const { service } = buildService();
+    (service.firebaseAdminService.deleteUser as jest.Mock).mockRejectedValue(
+      new Error('auth caído'),
+    );
+
+    const error: HttpException = await service
+      .deleteAccount('uid-1')
+      .catch((e: HttpException) => e);
+
+    const response = error.getResponse() as any;
+    expect(response.data.failedSteps).toEqual(['auth']);
+    // Con la cuenta de Auth viva el usuario puede volver a entrar y el perfil se
+    // recrearía: afirmar que ya no existe sería falso.
+    expect(response.data.accountDeleted).toBe(false);
+  });
+
+  it('sigue borrando el resto aunque falle un paso intermedio', async () => {
+    const { service, firestore } = buildService({
+      firestore: {
+        deleteTaxProfile: jest.fn().mockRejectedValue(new Error('boom')),
+      },
+    });
+
+    const error: HttpException = await service
+      .deleteAccount('uid-1')
+      .catch((e: HttpException) => e);
+
+    const response = error.getResponse() as any;
+    expect(response.data.failedSteps).toEqual(['taxProfile']);
+    expect(response.data.accountDeleted).toBe(true);
+    expect(firestore.deleteUser).toHaveBeenCalled();
+  });
+});
+
+describe('AccountDeletionService — facturas conservadas', () => {
+  it('recorre las páginas de facturas de Stripe', async () => {
+    const { service, stripe } = buildService();
+    stripe.invoices.list
+      .mockResolvedValueOnce({
+        data: Array.from({ length: 100 }, (_, i) => ({ id: `in_${i}` })),
+        has_more: true,
+      })
+      .mockResolvedValueOnce({ data: [{ id: 'in_100' }], has_more: false });
+
+    const result = await service.deleteAccount('uid-1');
+
+    expect(result.retained.invoices).toBe(101);
+    expect(stripe.invoices.list).toHaveBeenLastCalledWith(
+      expect.objectContaining({ starting_after: 'in_99' }),
+    );
+  });
+
+  it('cae en el número de CFDI anonimizados si Stripe no contesta al conteo', async () => {
+    const { service, stripe } = buildService();
+    stripe.invoices.list.mockRejectedValue(new Error('rate limited'));
+
+    const result = await service.deleteAccount('uid-1');
+
+    // 3 CFDI anonimizados: un número comprobado, no una estimación.
+    expect(result.retained.invoices).toBe(3);
+    expect(result.retained.reason).toBe(RETENTION_REASON_FISCAL);
+  });
+
+  it('devuelve cero facturas para un usuario que nunca pagó', async () => {
+    const { service } = buildService({
+      user: {
+        ...baseUser,
+        stripeCustomerId: undefined,
+        stripeSubscriptionId: undefined,
+      },
+    });
+
+    const result = await service.deleteAccount('uid-1');
+
+    expect(result.retained.invoices).toBe(0);
+  });
+});

--- a/src/modules/users/account-deletion.service.spec.ts
+++ b/src/modules/users/account-deletion.service.spec.ts
@@ -70,6 +70,9 @@ function buildService(
       .fn()
       .mockImplementation(async (ids: string[]) => ids.length),
     deleteZplDebugFilesByUserId: jest.fn().mockResolvedValue(0),
+    deleteBatchJobsByUserId: jest.fn().mockResolvedValue([]),
+    deleteConversionStatusesByUserId: jest.fn().mockResolvedValue(0),
+    anonymizeUserFinancialRecords: jest.fn().mockResolvedValue(0),
     deleteUsageByUserId: jest.fn().mockResolvedValue(2),
     deleteTaxProfile: jest.fn().mockResolvedValue(true),
     anonymizeUserCfdis: jest.fn().mockResolvedValue(3),
@@ -160,6 +163,60 @@ describe('AccountDeletionService — baja completa', () => {
     expect(firestore.deleteUsageByUserId).toHaveBeenCalledWith('uid-1');
     expect(firestore.deleteUser).toHaveBeenCalledWith('uid-1');
     expect(firebaseAdmin.deleteUser).toHaveBeenCalledWith('uid-1');
+  });
+
+  it('borra los batches del usuario y los ZIP que cuelgan de ellos', async () => {
+    const { service, firestore, storage } = buildService({
+      firestore: {
+        deleteBatchJobsByUserId: jest
+          .fn()
+          .mockResolvedValue(['batch-1', 'batch-2']),
+      },
+      storage: {
+        deleteFile: jest.fn().mockResolvedValue(true),
+        deleteByPrefix: jest.fn().mockResolvedValue(2),
+      },
+    });
+
+    const result = await service.deleteAccount('uid-1');
+
+    expect(storage.deleteByPrefix).toHaveBeenCalledWith('batches/batch-1/');
+    expect(storage.deleteByPrefix).toHaveBeenCalledWith('batches/batch-2/');
+    // El doc de estado sirve `GET /zpl/status/:jobId` con la URL del resultado.
+    expect(firestore.deleteConversionStatusesByUserId).toHaveBeenCalledWith(
+      'uid-1',
+    );
+    // 2 PDF del historial + 3 prefijos (debug-zpl y los dos batches) x 2.
+    expect(result.deleted.storedFiles).toBe(8);
+  });
+
+  it('anonimiza también los registros contables locales', async () => {
+    const { service, firestore } = buildService();
+
+    await service.deleteAccount('uid-1');
+
+    // stripe_transactions y subscription_events llevan userId y userEmail: se
+    // conservan por contabilidad, pero dejan de nombrar al titular.
+    expect(firestore.anonymizeUserFinancialRecords).toHaveBeenCalledWith(
+      'uid-1',
+    );
+  });
+
+  it('no da por buena la baja si el customer de Stripe se queda sin anonimizar', async () => {
+    const { service } = buildService({
+      user: { ...baseUser, stripeSubscriptionId: undefined },
+      stripe: null,
+    });
+
+    const error: HttpException = await service
+      .deleteAccount('uid-1')
+      .catch((e: HttpException) => e);
+
+    // Sin cliente de Stripe, el customer conserva nombre, email y metadata:
+    // responder 200 afirmaría lo contrario de lo que pasó.
+    const response = error.getResponse() as any;
+    expect(response.error).toBe(ErrorCodes.ACCOUNT_DELETION_PARTIAL);
+    expect(response.data.failedSteps).toContain('retainedRecords');
   });
 
   it('anonimiza los CFDI en lugar de borrarlos, y anonimiza el customer de Stripe', async () => {

--- a/src/modules/users/account-deletion.service.spec.ts
+++ b/src/modules/users/account-deletion.service.spec.ts
@@ -70,7 +70,9 @@ function buildService(
       .fn()
       .mockImplementation(async (ids: string[]) => ids.length),
     deleteZplDebugFilesByUserId: jest.fn().mockResolvedValue(0),
-    deleteBatchJobsByUserId: jest.fn().mockResolvedValue([]),
+    getBatchIdsByUserId: jest.fn().mockResolvedValue([]),
+    deleteBatchJobsByIds: jest.fn().mockResolvedValue(0),
+    anonymizeUserActivityRecords: jest.fn().mockResolvedValue(0),
     deleteConversionStatusesByUserId: jest.fn().mockResolvedValue(0),
     anonymizeUserFinancialRecords: jest.fn().mockResolvedValue(0),
     deleteUsageByUserId: jest.fn().mockResolvedValue(2),
@@ -98,6 +100,7 @@ function buildService(
               id: 'sub_1',
               status: 'active',
             }),
+            list: jest.fn().mockResolvedValue({ data: [] }),
             cancel: jest.fn().mockResolvedValue({
               id: 'sub_1',
               status: 'canceled',
@@ -118,6 +121,8 @@ function buildService(
               metadata: { userId: 'uid-1' },
             }),
             update: jest.fn().mockResolvedValue({}),
+            listTaxIds: jest.fn().mockResolvedValue({ data: [] }),
+            deleteTaxId: jest.fn().mockResolvedValue({}),
           },
           ...overrides.stripe,
         };
@@ -168,7 +173,7 @@ describe('AccountDeletionService — baja completa', () => {
   it('borra los batches del usuario y los ZIP que cuelgan de ellos', async () => {
     const { service, firestore, storage } = buildService({
       firestore: {
-        deleteBatchJobsByUserId: jest
+        getBatchIdsByUserId: jest
           .fn()
           .mockResolvedValue(['batch-1', 'batch-2']),
       },
@@ -182,6 +187,11 @@ describe('AccountDeletionService — baja completa', () => {
 
     expect(storage.deleteByPrefix).toHaveBeenCalledWith('batches/batch-1/');
     expect(storage.deleteByPrefix).toHaveBeenCalledWith('batches/batch-2/');
+    // Los documentos se borran DESPUÉS de sus archivos, y solo los limpiados.
+    expect(firestore.deleteBatchJobsByIds).toHaveBeenCalledWith([
+      'batch-1',
+      'batch-2',
+    ]);
     // El doc de estado sirve `GET /zpl/status/:jobId` con la URL del resultado.
     expect(firestore.deleteConversionStatusesByUserId).toHaveBeenCalledWith(
       'uid-1',
@@ -203,20 +213,84 @@ describe('AccountDeletionService — baja completa', () => {
   });
 
   it('no da por buena la baja si el customer de Stripe se queda sin anonimizar', async () => {
-    const { service } = buildService({
+    const { service, firestore, stripe } = buildService();
+    stripe.customers.update.mockRejectedValue(new Error('stripe caído'));
+
+    const error: HttpException = await service
+      .deleteAccount('uid-1')
+      .catch((e: HttpException) => e);
+
+    // El customer conservaría nombre, email y domicilio: responder 200
+    // afirmaría lo contrario de lo que pasó.
+    const response = error.getResponse() as any;
+    expect(response.error).toBe(ErrorCodes.ACCOUNT_DELETION_PARTIAL);
+    expect(response.data.failedSteps).toContain('retainedRecords');
+    expect(firestore.deleteUser).not.toHaveBeenCalled();
+  });
+
+  it('borra el domicilio y los tax IDs del customer, no solo su email', async () => {
+    const { service, stripe } = buildService();
+    stripe.customers.listTaxIds.mockResolvedValue({
+      data: [{ id: 'txi_1' }, { id: 'txi_2' }],
+    });
+
+    await service.deleteAccount('uid-1');
+
+    expect(stripe.customers.update).toHaveBeenCalledWith(
+      'cus_1',
+      expect.objectContaining({ address: null, phone: '' }),
+    );
+    expect(stripe.customers.deleteTaxId).toHaveBeenCalledWith('cus_1', 'txi_1');
+    expect(stripe.customers.deleteTaxId).toHaveBeenCalledWith('cus_1', 'txi_2');
+  });
+
+  it('anonimiza la cola de emails, sus eventos y el feedback', async () => {
+    const { service, firestore } = buildService();
+
+    await service.deleteAccount('uid-1');
+
+    expect(firestore.anonymizeUserActivityRecords).toHaveBeenCalledWith(
+      'uid-1',
+    );
+    // Segundo pase tras borrar el perfil: cierra la ventana en la que el
+    // webhook de Stripe pudo reescribir el email del titular.
+    expect(firestore.anonymizeUserFinancialRecords).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancela una suscripción activa que el perfil no tenía registrada', async () => {
+    const { service, stripe } = buildService({
       user: { ...baseUser, stripeSubscriptionId: undefined },
-      stripe: null,
+    });
+    stripe.subscriptions.list.mockResolvedValue({
+      data: [{ id: 'sub_huerfana', status: 'active' }],
+    });
+
+    const result = await service.deleteAccount('uid-1');
+
+    // Sin esta búsqueda por customer, la cuenta se borraría y Stripe seguiría
+    // cobrando una suscripción que nadie puede cancelar ya.
+    expect(stripe.subscriptions.cancel).toHaveBeenCalledWith('sub_huerfana');
+    expect(result.deleted.subscription.cancelled).toBe(true);
+  });
+
+  it('conserva la fila del historial cuyo archivo no se pudo borrar', async () => {
+    const { service, firestore } = buildService({
+      storage: {
+        deleteFile: jest.fn().mockRejectedValue({ code: 403 }),
+        deleteByPrefix: jest.fn().mockResolvedValue(0),
+      },
     });
 
     const error: HttpException = await service
       .deleteAccount('uid-1')
       .catch((e: HttpException) => e);
 
-    // Sin cliente de Stripe, el customer conserva nombre, email y metadata:
-    // responder 200 afirmaría lo contrario de lo que pasó.
+    // La `fileUrl` de la fila es la única pista para reintentar el borrado del
+    // objeto: si se fuera la fila, el archivo quedaría en el bucket sin rastro.
+    expect(firestore.deleteConversionHistoryByIds).toHaveBeenCalledWith([]);
     const response = error.getResponse() as any;
-    expect(response.error).toBe(ErrorCodes.ACCOUNT_DELETION_PARTIAL);
-    expect(response.data.failedSteps).toContain('retainedRecords');
+    expect(response.data.failedSteps).toContain('storedFiles');
+    expect(response.data.accountDeleted).toBe(false);
   });
 
   it('anonimiza los CFDI en lugar de borrarlos, y anonimiza el customer de Stripe', async () => {
@@ -400,8 +474,8 @@ describe('AccountDeletionService — borrado parcial', () => {
     expect(response.data.accountDeleted).toBe(false);
   });
 
-  it('sigue borrando el resto aunque falle un paso intermedio', async () => {
-    const { service, firestore } = buildService({
+  it('no borra la identidad si quedó un paso intermedio pendiente', async () => {
+    const { service, firestore, firebaseAdmin } = buildService({
       firestore: {
         deleteTaxProfile: jest.fn().mockRejectedValue(new Error('boom')),
       },
@@ -413,8 +487,13 @@ describe('AccountDeletionService — borrado parcial', () => {
 
     const response = error.getResponse() as any;
     expect(response.data.failedSteps).toEqual(['taxProfile']);
-    expect(response.data.accountDeleted).toBe(true);
-    expect(firestore.deleteUser).toHaveBeenCalled();
+    // El perfil fiscal seguiría ahí: borrar la cuenta lo dejaría sin dueño y al
+    // usuario sin credenciales para reintentar la baja.
+    expect(response.data.accountDeleted).toBe(false);
+    expect(firestore.deleteUser).not.toHaveBeenCalled();
+    expect(firebaseAdmin.deleteUser).not.toHaveBeenCalled();
+    // Los pasos posteriores al que falló sí se ejecutan.
+    expect(firestore.anonymizeUserCfdis).toHaveBeenCalled();
   });
 });
 

--- a/src/modules/users/account-deletion.service.spec.ts
+++ b/src/modules/users/account-deletion.service.spec.ts
@@ -493,6 +493,30 @@ describe('AccountDeletionService — Stripe rechaza cancelar', () => {
 });
 
 describe('AccountDeletionService — borrado parcial', () => {
+  it('declara el fallo de la lápida sin ocultar que Stripe ya canceló', async () => {
+    const { service, firestore, firebaseAdmin } = buildService({
+      firestore: {
+        markAccountDeletion: jest
+          .fn()
+          .mockRejectedValue(new Error('firestore caído')),
+      },
+    });
+
+    const error: HttpException = await service
+      .deleteAccount('uid-1')
+      .catch((e: HttpException) => e);
+
+    const response = error.getResponse() as any;
+    expect(response.error).toBe(ErrorCodes.ACCOUNT_DELETION_PARTIAL);
+    expect(response.data.failedSteps).toEqual(['deletionMark']);
+    // La suscripción ya murió antes de intentar escribir la lápida: el
+    // cliente necesita mostrar ese hecho aunque la baja de datos quede parcial.
+    expect(response.data.deleted.subscription.cancelled).toBe(true);
+    expect(response.data.accountDeleted).toBe(false);
+    expect(firestore.deleteUser).not.toHaveBeenCalled();
+    expect(firebaseAdmin.deleteUser).not.toHaveBeenCalled();
+  });
+
   it('marca la cuenta como NO borrada cuando falla el borrado en Firestore', async () => {
     const { service } = buildService({
       firestore: {

--- a/src/modules/users/account-deletion.service.spec.ts
+++ b/src/modules/users/account-deletion.service.spec.ts
@@ -79,6 +79,7 @@ function buildService(
     deleteTaxProfile: jest.fn().mockResolvedValue(true),
     anonymizeUserCfdis: jest.fn().mockResolvedValue(3),
     cancelPendingEmails: jest.fn().mockResolvedValue(0),
+    countInFlightEmails: jest.fn().mockResolvedValue(0),
     markAccountDeletion: jest.fn().mockResolvedValue(undefined),
     clearAccountDeletionMark: jest.fn().mockResolvedValue(undefined),
     deleteUser: jest.fn().mockResolvedValue(undefined),
@@ -349,6 +350,68 @@ describe('AccountDeletionService — baja completa', () => {
     const result = await service.deleteAccount('uid-1');
 
     expect(result.deleted.conversions).toBe(20000);
+  });
+
+  it('espera a que salgan los correos ya reclamados antes de dar la baja por buena', async () => {
+    const countInFlightEmails = jest
+      .fn()
+      .mockResolvedValueOnce(1)
+      .mockResolvedValue(0);
+    const { service, firestore } = buildService({
+      firestore: { countInFlightEmails },
+    });
+
+    const result = await service.deleteAccount('uid-1');
+
+    // Confirmar el borrado y mandar después un correo a la dirección que se
+    // acaba de prometer olvidar es el incumplimiento que esta espera evita.
+    expect(countInFlightEmails).toHaveBeenCalledWith('uid-1');
+    expect(countInFlightEmails.mock.calls.length).toBeGreaterThan(1);
+    expect(firestore.deleteUser).toHaveBeenCalled();
+    expect(result.deleted.subscription.cancelled).toBe(true);
+  });
+
+  it('no confirma la baja si un correo sigue en vuelo tras la espera', async () => {
+    const { service, firestore } = buildService({
+      firestore: { countInFlightEmails: jest.fn().mockResolvedValue(1) },
+    });
+
+    const error: HttpException = await service
+      .deleteAccount('uid-1')
+      .catch((e: HttpException) => e);
+
+    const response = error.getResponse() as any;
+    expect(response.data.failedSteps).toContain('pendingEmails');
+    expect(response.data.accountDeleted).toBe(false);
+    expect(firestore.deleteUser).not.toHaveBeenCalled();
+  });
+
+  it('cancela las suscripciones de todas las páginas del customer', async () => {
+    const { service, stripe } = buildService({
+      user: { ...baseUser, stripeSubscriptionId: undefined },
+    });
+    stripe.subscriptions.list
+      .mockResolvedValueOnce({
+        data: Array.from({ length: 100 }, (_, i) => ({
+          id: `sub_${i}`,
+          status: 'active',
+        })),
+        has_more: true,
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: 'sub_ultima', status: 'active' }],
+        has_more: false,
+      });
+
+    await service.deleteAccount('uid-1');
+
+    // Quedarse en la primera página dejaría suscripciones vivas cobrando a una
+    // cuenta ya borrada.
+    expect(stripe.subscriptions.cancel).toHaveBeenCalledWith('sub_ultima');
+    expect(stripe.subscriptions.cancel).toHaveBeenCalledTimes(101);
+    expect(stripe.subscriptions.list).toHaveBeenLastCalledWith(
+      expect.objectContaining({ starting_after: 'sub_99' }),
+    );
   });
 
   it('conserva la fila del historial cuyo archivo no se pudo borrar', async () => {

--- a/src/modules/users/account-deletion.service.ts
+++ b/src/modules/users/account-deletion.service.ts
@@ -26,6 +26,7 @@ export type AccountDeletionStep =
   | 'batches'
   | 'usage'
   | 'taxProfile'
+  | 'pendingEmails'
   | 'retainedRecords'
   | 'account'
   | 'auth';
@@ -39,6 +40,20 @@ const HISTORY_DELETION_PAGE_SIZE = 500;
  * que acumula la cuenta más activa.
  */
 const MAX_HISTORY_DELETION_PAGES = 40;
+
+/**
+ * Vueltas y espera entre ellas para los correos que un worker ya reclamó. Tres
+ * segundos en total: un envío por Resend se resuelve en mucho menos, y alargarlo
+ * solo haría esperar al usuario ante un worker que ya murió —ese caso lo
+ * recupera el lease de la cola, no esta espera—.
+ */
+const IN_FLIGHT_EMAIL_ATTEMPTS = 6;
+const IN_FLIGHT_EMAIL_POLL_MS = 500;
+
+/** Páginas de suscripciones que se recorren al buscar las que siguen vivas. */
+const MAX_SUBSCRIPTION_PAGES = 10;
+
+const SUBSCRIPTION_PAGE_SIZE = 100;
 
 /** Páginas de facturas que se recorren al contar lo que se conserva. */
 const MAX_INVOICE_PAGES = 10;
@@ -217,10 +232,9 @@ export class AccountDeletionService {
     // el barrido de cancelación ya no encontraría sus documentos por `userId`.
     try {
       await this.firestoreService.cancelPendingEmails(userId);
+      await this.waitForInFlightEmails(userId);
     } catch (error) {
-      this.logger.warn(
-        `Baja de cuenta ${userId}: no se pudieron cancelar los emails pendientes — ${error.message}`,
-      );
+      failed('pendingEmails', error);
     }
 
     try {
@@ -483,17 +497,40 @@ export class AccountDeletionService {
     }
 
     if (user.stripeCustomerId) {
-      const subscriptions = await this.stripe.subscriptions.list({
-        customer: user.stripeCustomerId,
-        status: 'all',
-        limit: 100,
-      });
+      let startingAfter: string | undefined;
 
-      for (const subscription of subscriptions.data) {
-        if (subscription.status !== 'canceled') {
-          ids.add(subscription.id);
+      // Se recorren todas las páginas, como en el conteo de facturas: quedarse
+      // en la primera dejaría suscripciones vivas cobrando a una cuenta ya
+      // borrada, que es justo lo que esta búsqueda existe para evitar.
+      for (let page = 0; page < MAX_SUBSCRIPTION_PAGES; page++) {
+        const subscriptions = await this.stripe.subscriptions.list({
+          customer: user.stripeCustomerId,
+          status: 'all',
+          limit: SUBSCRIPTION_PAGE_SIZE,
+          ...(startingAfter && { starting_after: startingAfter }),
+        });
+
+        for (const subscription of subscriptions.data) {
+          if (subscription.status !== 'canceled') {
+            ids.add(subscription.id);
+          }
         }
+
+        if (!subscriptions.has_more || subscriptions.data.length === 0) {
+          return [...ids];
+        }
+
+        startingAfter = subscriptions.data[subscriptions.data.length - 1].id;
       }
+
+      // Un customer con más suscripciones que este tope no existe en este
+      // producto, pero dar la baja por buena sin haberlas mirado todas sería
+      // afirmar algo que no se comprobó.
+      throw new Error(
+        `El customer ${user.stripeCustomerId} tiene más de ` +
+          `${MAX_SUBSCRIPTION_PAGES * SUBSCRIPTION_PAGE_SIZE} suscripciones; ` +
+          'no se puede garantizar que no quede ninguna activa',
+      );
     }
 
     return [...ids];
@@ -614,6 +651,53 @@ export class AccountDeletionService {
     }
 
     return { conversions, storedFiles, storageFailed, incomplete };
+  }
+
+  /**
+   * Espera a que no quede ningún correo suyo a medio enviar.
+   *
+   * `cancelPendingEmails` solo alcanza a los `pending`. El que un worker ya
+   * reclamó está en `sending` con el destinatario cargado en memoria, y va a
+   * llamar a Resend de todas formas: lo único que se puede hacer es no dar la
+   * baja por terminada hasta que se resuelva. Confirmarle a alguien que su
+   * cuenta ya no existe y mandarle a continuación un correo a la dirección que
+   * acabamos de prometer olvidar es precisamente lo que se denuncia como
+   * incumplimiento.
+   *
+   * La marca de baja ya impide que se reclamen nuevos —`claimPendingEmail` la
+   * lee dentro de su transacción—, así que esta espera solo cubre los que
+   * salieron antes y termina en cuanto el worker escribe su resultado.
+   *
+   * Si al agotar la espera sigue habiendo alguno, se lanza: el paso cuenta como
+   * fallido, la identidad no se borra y la respuesta lo declara, en vez de
+   * afirmar un borrado que aún puede producir un envío.
+   */
+  private async waitForInFlightEmails(userId: string): Promise<void> {
+    for (let attempt = 0; attempt < IN_FLIGHT_EMAIL_ATTEMPTS; attempt++) {
+      const inFlight = await this.firestoreService.countInFlightEmails(userId);
+
+      if (inFlight === 0) {
+        return;
+      }
+
+      this.logger.warn(
+        `Baja de cuenta ${userId}: ${inFlight} email(s) en vuelo; se espera a que terminen`,
+      );
+
+      await new Promise((resolve) =>
+        setTimeout(resolve, IN_FLIGHT_EMAIL_POLL_MS),
+      );
+    }
+
+    const remaining = await this.firestoreService.countInFlightEmails(userId);
+
+    if (remaining > 0) {
+      throw new Error(
+        `${remaining} email(s) siguen en vuelo tras esperar ${
+          (IN_FLIGHT_EMAIL_ATTEMPTS * IN_FLIGHT_EMAIL_POLL_MS) / 1000
+        }s`,
+      );
+    }
   }
 
   /**

--- a/src/modules/users/account-deletion.service.ts
+++ b/src/modules/users/account-deletion.service.ts
@@ -21,6 +21,7 @@ import {
 export type AccountDeletionStep =
   | 'conversions'
   | 'storedFiles'
+  | 'batches'
   | 'usage'
   | 'taxProfile'
   | 'retainedRecords'
@@ -62,9 +63,11 @@ const INVOICE_PAGE_SIZE = 100;
  * ## Lo que no se borra
  *
  * Los CFDI timbrados y las facturas de Stripe se conservan cinco años por
- * obligación fiscal (México). No se borran: se **desvinculan** del usuario —el
- * `userId` del CFDI pasa a un marcador, y el customer de Stripe pierde nombre y
- * email—, de modo que el comprobante sobrevive sin identificar a nadie. La
+ * obligación fiscal (México), y los registros contables locales
+ * (`stripe_transactions`, `subscription_events`) sostienen las métricas de
+ * ingresos y churn. No se borran: se **desvinculan** del usuario —`userId` pasa
+ * a un marcador, `userEmail` se vacía y el customer de Stripe pierde nombre,
+ * email y metadata—, de modo que el registro sobrevive sin identificar a nadie. La
  * respuesta lo declara en `retained`, para que el diálogo de confirmación del
  * frontend pueda enumerar exactamente qué se pierde y qué se queda.
  */
@@ -142,6 +145,26 @@ export class AccountDeletionService {
       failed('storedFiles', error);
     }
 
+    // Las conversiones batch no pasan por `conversion_history` con su archivo:
+    // el ZIP vive en `batches/<batchId>/` y el documento de `zpl-batches` lleva
+    // userId, los nombres de los ficheros subidos y una `downloadUrl` que el
+    // endpoint de estado sigue sirviendo. Sin este paso, la baja dejaría
+    // descargables los archivos de una cuenta que ya no existe.
+    try {
+      const batchIds =
+        await this.firestoreService.deleteBatchJobsByUserId(userId);
+
+      for (const batchId of batchIds) {
+        storedFiles += await this.storageService.deleteByPrefix(
+          `batches/${batchId}/`,
+        );
+      }
+
+      await this.firestoreService.deleteConversionStatusesByUserId(userId);
+    } catch (error) {
+      failed('batches', error);
+    }
+
     try {
       await this.firestoreService.deleteUsageByUserId(userId);
     } catch (error) {
@@ -156,6 +179,7 @@ export class AccountDeletionService {
 
     try {
       retainedRecords = await this.firestoreService.anonymizeUserCfdis(userId);
+      await this.firestoreService.anonymizeUserFinancialRecords(userId);
       await this.anonymizeStripeCustomer(user);
     } catch (error) {
       failed('retainedRecords', error);
@@ -446,8 +470,17 @@ export class AccountDeletionService {
    * comprobante emitido.
    */
   private async anonymizeStripeCustomer(user: User): Promise<void> {
-    if (!user.stripeCustomerId || !this.stripe) {
+    if (!user.stripeCustomerId) {
       return;
+    }
+
+    if (!this.stripe) {
+      // Sin cliente de Stripe el customer se queda con nombre, email y
+      // metadata. Devolver 200 aquí afirmaría que solo sobreviven comprobantes
+      // anonimizados, que es exactamente lo contrario de lo que pasó.
+      throw new Error(
+        'stripe_not_configured: no se puede anonimizar el customer de Stripe',
+      );
     }
 
     const customer = await this.stripe.customers.retrieve(

--- a/src/modules/users/account-deletion.service.ts
+++ b/src/modules/users/account-deletion.service.ts
@@ -1,0 +1,485 @@
+import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Stripe from 'stripe';
+import { FirestoreService } from '../cache/firestore.service.js';
+import { FirebaseAdminService } from '../auth/firebase-admin.service.js';
+import { StorageService } from '../storage/storage.service.js';
+import { ErrorCodes } from '../../common/constants/error-codes.js';
+import { extractStoragePathFromSignedUrl } from '../../common/utils/storage-url.util.js';
+import type { User } from '../../common/interfaces/user.interface.js';
+import {
+  DeleteAccountResponseDto,
+  DeletedSubscriptionDto,
+  RETENTION_REASON_FISCAL,
+} from './dto/delete-account.dto.js';
+
+/**
+ * Pasos de la baja que pueden fallar por separado. Son códigos estables: el
+ * frontend los enumera en `data.failedSteps` de `ACCOUNT_DELETION_PARTIAL` y los
+ * traduce por su cuenta.
+ */
+export type AccountDeletionStep =
+  | 'conversions'
+  | 'storedFiles'
+  | 'usage'
+  | 'taxProfile'
+  | 'retainedRecords'
+  | 'account'
+  | 'auth';
+
+/** Registros de historial que se leen y borran por vuelta. */
+const HISTORY_DELETION_PAGE_SIZE = 500;
+
+/**
+ * Tope de vueltas al borrar el historial, como salvaguarda ante un bucle que no
+ * avance. Con el tamaño de página son 20.000 conversiones, muy por encima de lo
+ * que acumula la cuenta más activa.
+ */
+const MAX_HISTORY_DELETION_PAGES = 40;
+
+/** Páginas de facturas que se recorren al contar lo que se conserva. */
+const MAX_INVOICE_PAGES = 10;
+
+const INVOICE_PAGE_SIZE = 100;
+
+/**
+ * Baja de cuenta: cancela la suscripción, borra los datos del usuario y
+ * anonimiza lo que no se puede borrar.
+ *
+ * ## Orden de las operaciones
+ *
+ * La suscripción se cancela **primero** y todo lo demás va después. Si Stripe
+ * rechaza la cancelación, la petición termina en `SUBSCRIPTION_CANCEL_FAILED`
+ * sin haber tocado un solo dato: la cuenta sigue entera y el usuario puede
+ * reintentar. Al revés —borrar y luego intentar cancelar— dejaría un contrato
+ * cobrando a alguien que ya no tiene cuenta con la que cancelarlo.
+ *
+ * Dentro del borrado, el documento de `users` y la cuenta de Firebase Auth van
+ * los **últimos**, porque son los que hacen que la cuenta exista: mientras estén
+ * ahí, el usuario puede autenticarse y repetir la baja para terminar lo que
+ * quedara a medias.
+ *
+ * ## Lo que no se borra
+ *
+ * Los CFDI timbrados y las facturas de Stripe se conservan cinco años por
+ * obligación fiscal (México). No se borran: se **desvinculan** del usuario —el
+ * `userId` del CFDI pasa a un marcador, y el customer de Stripe pierde nombre y
+ * email—, de modo que el comprobante sobrevive sin identificar a nadie. La
+ * respuesta lo declara en `retained`, para que el diálogo de confirmación del
+ * frontend pueda enumerar exactamente qué se pierde y qué se queda.
+ */
+@Injectable()
+export class AccountDeletionService {
+  private readonly logger = new Logger(AccountDeletionService.name);
+  private readonly stripe: Stripe | null = null;
+
+  constructor(
+    private readonly firestoreService: FirestoreService,
+    private readonly firebaseAdminService: FirebaseAdminService,
+    private readonly storageService: StorageService,
+    private readonly configService: ConfigService,
+  ) {
+    const stripeSecretKey = this.configService.get<string>('STRIPE_SECRET_KEY');
+    if (stripeSecretKey) {
+      this.stripe = new Stripe(stripeSecretKey);
+    }
+  }
+
+  async deleteAccount(userId: string): Promise<DeleteAccountResponseDto> {
+    const user = await this.firestoreService.getUserById(userId);
+
+    if (!user) {
+      throw new HttpException(
+        {
+          error: ErrorCodes.USER_NOT_FOUND,
+          message: 'User not found',
+        },
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    // Se cuenta antes de cancelar y de anonimizar: después, el customer de
+    // Stripe ya no lleva los datos con los que se listan sus facturas.
+    const invoicesInStripe = await this.countStripeInvoices(user);
+
+    const subscription = await this.cancelSubscription(user);
+
+    const failedSteps: AccountDeletionStep[] = [];
+    const failed = (step: AccountDeletionStep, error: unknown): void => {
+      failedSteps.push(step);
+      this.logger.error(
+        `Baja de cuenta ${userId}: falló el paso "${step}" — ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    };
+
+    let conversions = 0;
+    let storedFiles = 0;
+    let taxProfile = false;
+    let retainedRecords = 0;
+
+    try {
+      const purged = await this.purgeConversions(userId);
+      conversions = purged.conversions;
+      storedFiles = purged.storedFiles;
+      if (purged.incomplete) {
+        failed('conversions', new Error('quedaron registros sin borrar'));
+      }
+      if (purged.storageFailed) {
+        failed('storedFiles', new Error('quedaron archivos sin borrar'));
+      }
+    } catch (error) {
+      failed('conversions', error);
+    }
+
+    try {
+      storedFiles += await this.storageService.deleteByPrefix(
+        `debug-zpl/${userId}/`,
+      );
+      await this.firestoreService.deleteZplDebugFilesByUserId(userId);
+    } catch (error) {
+      failed('storedFiles', error);
+    }
+
+    try {
+      await this.firestoreService.deleteUsageByUserId(userId);
+    } catch (error) {
+      failed('usage', error);
+    }
+
+    try {
+      taxProfile = await this.firestoreService.deleteTaxProfile(userId);
+    } catch (error) {
+      failed('taxProfile', error);
+    }
+
+    try {
+      retainedRecords = await this.firestoreService.anonymizeUserCfdis(userId);
+      await this.anonymizeStripeCustomer(user);
+    } catch (error) {
+      failed('retainedRecords', error);
+    }
+
+    // La cola de emails no es un dato del usuario, pero seguir escribiéndole
+    // después de darse de baja sí sería un problema. Un fallo aquí no ensucia
+    // el resultado: los envíos comprueban de nuevo que el usuario exista.
+    try {
+      await this.firestoreService.cancelPendingEmails(userId);
+    } catch (error) {
+      this.logger.warn(
+        `Baja de cuenta ${userId}: no se pudieron cancelar los emails pendientes — ${error.message}`,
+      );
+    }
+
+    let accountDeleted = false;
+
+    try {
+      await this.firestoreService.deleteUser(userId);
+      accountDeleted = true;
+    } catch (error) {
+      failed('account', error);
+    }
+
+    if (accountDeleted) {
+      try {
+        await this.firebaseAdminService.deleteUser(userId);
+      } catch (error) {
+        // Con la cuenta de Auth viva el usuario puede volver a entrar, y su
+        // perfil se recrearía al sincronizar: decir que la cuenta ya no existe
+        // sería falso.
+        accountDeleted = false;
+        failed('auth', error);
+      }
+    } else {
+      // El perfil sigue en Firestore: borrar aquí la cuenta de Auth dejaría un
+      // documento huérfano y al usuario sin forma de autenticarse para
+      // reintentar la baja.
+      this.logger.warn(
+        `Baja de cuenta ${userId}: no se borra la cuenta de Firebase Auth porque el ` +
+          'perfil no llegó a borrarse; sin ella el usuario no podría reintentar',
+      );
+    }
+
+    const deleted = {
+      conversions,
+      storedFiles,
+      taxProfile,
+      subscription,
+    };
+
+    const retained = {
+      // Si Stripe no respondió al conteo, los CFDI anonimizados son la cota
+      // fiable que sí tenemos: mejor un número comprobado que uno inventado.
+      invoices: invoicesInStripe ?? retainedRecords,
+      reason: RETENTION_REASON_FISCAL,
+    };
+
+    if (failedSteps.length > 0) {
+      throw new HttpException(
+        {
+          error: ErrorCodes.ACCOUNT_DELETION_PARTIAL,
+          message:
+            'The subscription was cancelled but the account was not fully deleted',
+          data: {
+            // `accountDeleted: false` es la diferencia entre "quedaron restos" y
+            // "tu cuenta sigue existiendo". El frontend no puede afirmar lo
+            // segundo sin este dato.
+            accountDeleted,
+            failedSteps,
+            deleted,
+            retained,
+          },
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+
+    this.logger.log(
+      `Cuenta ${userId} dada de baja: ${conversions} conversiones, ` +
+        `${storedFiles} archivos, ${retained.invoices} facturas conservadas`,
+    );
+
+    return { deleted, retained };
+  }
+
+  /**
+   * Cancela la suscripción de Stripe si sigue viva.
+   *
+   * **Cancelación inmediata, no al final del periodo.** La cuenta desaparece en
+   * esta misma petición: dejar el contrato corriendo hasta el corte dejaría una
+   * suscripción cuyo titular ya no puede entrar al producto ni gestionarla, y
+   * sus webhooks llegarían sin usuario al que aplicarlos.
+   *
+   * **Una factura abierta no se anula.** A diferencia del flujo de impago, aquí
+   * la deuda corresponde a servicio ya prestado y puede estar timbrada; se queda
+   * en Stripe, que es exactamente lo que declara el bloque `retained`.
+   *
+   * Si Stripe rechaza la operación se lanza `SUBSCRIPTION_CANCEL_FAILED` y no se
+   * borra nada.
+   */
+  private async cancelSubscription(
+    user: User,
+  ): Promise<DeletedSubscriptionDto> {
+    if (!user.stripeSubscriptionId) {
+      return { cancelled: false, plan: null, effectiveAt: null };
+    }
+
+    if (!this.stripe) {
+      // Con una suscripción registrada y sin cliente de Stripe no hay forma de
+      // comprobar ni de cancelar: borrar la cuenta la dejaría cobrando.
+      throw this.subscriptionCancelFailed(user, 'stripe_not_configured');
+    }
+
+    try {
+      const current = await this.stripe.subscriptions.retrieve(
+        user.stripeSubscriptionId,
+      );
+
+      if (current.status === 'canceled') {
+        this.logger.log(
+          `Baja de cuenta ${user.id}: la suscripción ${current.id} ya estaba cancelada`,
+        );
+        return { cancelled: false, plan: user.plan ?? null, effectiveAt: null };
+      }
+
+      const cancelled = await this.stripe.subscriptions.cancel(
+        user.stripeSubscriptionId,
+      );
+
+      const canceledAt = cancelled.canceled_at
+        ? new Date(cancelled.canceled_at * 1000)
+        : new Date();
+
+      return {
+        cancelled: true,
+        plan: user.plan ?? null,
+        effectiveAt: canceledAt.toISOString(),
+      };
+    } catch (error) {
+      this.logger.error(
+        `Baja de cuenta ${user.id}: Stripe rechazó cancelar ${user.stripeSubscriptionId} — ${error.message}`,
+      );
+      throw this.subscriptionCancelFailed(user, error?.code ?? 'stripe_error');
+    }
+  }
+
+  private subscriptionCancelFailed(user: User, reason: string): HttpException {
+    return new HttpException(
+      {
+        error: ErrorCodes.SUBSCRIPTION_CANCEL_FAILED,
+        message: 'The subscription could not be cancelled; nothing was deleted',
+        data: {
+          plan: user.plan ?? null,
+          subscriptionId: user.stripeSubscriptionId,
+          // Código de Stripe, no frase: el frontend decide si ofrece reintentar
+          // o mandar al portal de facturación.
+          reason,
+        },
+      },
+      HttpStatus.CONFLICT,
+    );
+  }
+
+  /**
+   * Borra el historial del usuario y, con cada registro, el archivo que aún
+   * cuelgue de su URL firmada.
+   *
+   * Se va por páginas y se borra cada una antes de leer la siguiente, así que el
+   * bucle avanza aunque el usuario tenga decenas de miles de conversiones. Un
+   * archivo que ya no está en el bucket no cuenta ni como borrado ni como fallo:
+   * los PDF tienen su propio ciclo de vida y los antiguos ya no existen.
+   */
+  private async purgeConversions(userId: string): Promise<{
+    conversions: number;
+    storedFiles: number;
+    storageFailed: boolean;
+    incomplete: boolean;
+  }> {
+    let conversions = 0;
+    let storedFiles = 0;
+    let storageFailed = false;
+    let incomplete = false;
+
+    for (let page = 0; page < MAX_HISTORY_DELETION_PAGES; page++) {
+      const records = await this.firestoreService.scanUserConversionHistory(
+        userId,
+        HISTORY_DELETION_PAGE_SIZE,
+      );
+
+      if (records.length === 0) {
+        return { conversions, storedFiles, storageFailed, incomplete };
+      }
+
+      for (const record of records) {
+        const path = extractStoragePathFromSignedUrl(record.fileUrl);
+        if (!path) continue;
+
+        try {
+          if (await this.storageService.deleteFile(path)) {
+            storedFiles++;
+          }
+        } catch (error) {
+          // Un objeto que no se deja borrar no puede impedir que se borre la
+          // fila: se anota y la respuesta lo declara como baja parcial.
+          storageFailed = true;
+          this.logger.warn(
+            `Baja de cuenta ${userId}: no se pudo borrar ${path} — ${error.message}`,
+          );
+        }
+      }
+
+      conversions += await this.firestoreService.deleteConversionHistoryByIds(
+        records.map((record) => record.id),
+      );
+
+      if (records.length < HISTORY_DELETION_PAGE_SIZE) {
+        return { conversions, storedFiles, storageFailed, incomplete };
+      }
+    }
+
+    incomplete = true;
+    this.logger.error(
+      `Baja de cuenta ${userId}: se agotaron las ${MAX_HISTORY_DELETION_PAGES} páginas ` +
+        'de borrado del historial y aún quedan registros',
+    );
+
+    return { conversions, storedFiles, storageFailed, incomplete };
+  }
+
+  /**
+   * Cuenta las facturas que quedarán en Stripe, o `null` si no se pudo saber.
+   *
+   * `null` y `0` no significan lo mismo: cero es "no hay ninguna factura" y hay
+   * que poder decirlo; `null` es "Stripe no contestó", y ahí quien llama usa el
+   * número de CFDI anonimizados en vez de afirmar algo que no comprobó.
+   */
+  private async countStripeInvoices(user: User): Promise<number | null> {
+    if (!user.stripeCustomerId) {
+      return 0;
+    }
+
+    if (!this.stripe) {
+      return null;
+    }
+
+    try {
+      let count = 0;
+      let startingAfter: string | undefined;
+
+      for (let page = 0; page < MAX_INVOICE_PAGES; page++) {
+        const invoices = await this.stripe.invoices.list({
+          customer: user.stripeCustomerId,
+          limit: INVOICE_PAGE_SIZE,
+          ...(startingAfter && { starting_after: startingAfter }),
+        });
+
+        count += invoices.data.length;
+
+        if (!invoices.has_more || invoices.data.length === 0) {
+          return count;
+        }
+
+        startingAfter = invoices.data[invoices.data.length - 1].id;
+      }
+
+      this.logger.warn(
+        `Baja de cuenta ${user.id}: el conteo de facturas se detuvo en ${count} ` +
+          `(tope de ${MAX_INVOICE_PAGES} páginas)`,
+      );
+      return count;
+    } catch (error) {
+      this.logger.warn(
+        `Baja de cuenta ${user.id}: no se pudieron contar las facturas de Stripe — ${error.message}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Quita del customer de Stripe los datos que identifican a la persona.
+   *
+   * El customer no se borra: es el nexo de las facturas que hay que conservar
+   * cinco años. Lo que se va es lo personal —nombre, email, descripción y la
+   * metadata que hubiéramos guardado—; los importes, fechas y PDF de cada
+   * factura siguen en Stripe, con la copia del email que ya llevaba impresa cada
+   * comprobante emitido.
+   */
+  private async anonymizeStripeCustomer(user: User): Promise<void> {
+    if (!user.stripeCustomerId || !this.stripe) {
+      return;
+    }
+
+    const customer = await this.stripe.customers.retrieve(
+      user.stripeCustomerId,
+    );
+
+    if ((customer as Stripe.DeletedCustomer).deleted) {
+      return;
+    }
+
+    // Stripe fusiona la metadata que se envía con la que ya había; para quitar
+    // una clave hay que mandarla vacía, así que se enumeran las existentes.
+    const clearedMetadata: Record<string, string> = {};
+    for (const key of Object.keys(
+      (customer as Stripe.Customer).metadata ?? {},
+    )) {
+      clearedMetadata[key] = '';
+    }
+
+    await this.stripe.customers.update(user.stripeCustomerId, {
+      name: 'Deleted account',
+      email: '',
+      description: 'Account deleted at the user request',
+      metadata: {
+        ...clearedMetadata,
+        account_deleted: 'true',
+        account_deleted_at: new Date().toISOString(),
+      },
+    });
+
+    this.logger.log(
+      `Baja de cuenta ${user.id}: customer ${user.stripeCustomerId} anonimizado en Stripe`,
+    );
+  }
+}

--- a/src/modules/users/account-deletion.service.ts
+++ b/src/modules/users/account-deletion.service.ts
@@ -151,15 +151,21 @@ export class AccountDeletionService {
     // endpoint de estado sigue sirviendo. Sin este paso, la baja dejaría
     // descargables los archivos de una cuenta que ya no existe.
     try {
-      const batchIds =
-        await this.firestoreService.deleteBatchJobsByUserId(userId);
+      // Los ZIP primero y el documento después: el `batchId` es la única pista
+      // para encontrar `batches/<batchId>/`, así que borrar el documento antes
+      // y fallar luego en Storage dejaría los archivos huérfanos e ilocalizables
+      // para un reintento.
+      const batchIds = await this.firestoreService.getBatchIdsByUserId(userId);
+      const purgedBatchIds: string[] = [];
 
       for (const batchId of batchIds) {
         storedFiles += await this.storageService.deleteByPrefix(
           `batches/${batchId}/`,
         );
+        purgedBatchIds.push(batchId);
       }
 
+      await this.firestoreService.deleteBatchJobsByIds(purgedBatchIds);
       await this.firestoreService.deleteConversionStatusesByUserId(userId);
     } catch (error) {
       failed('batches', error);
@@ -177,17 +183,8 @@ export class AccountDeletionService {
       failed('taxProfile', error);
     }
 
-    try {
-      retainedRecords = await this.firestoreService.anonymizeUserCfdis(userId);
-      await this.firestoreService.anonymizeUserFinancialRecords(userId);
-      await this.anonymizeStripeCustomer(user);
-    } catch (error) {
-      failed('retainedRecords', error);
-    }
-
-    // La cola de emails no es un dato del usuario, pero seguir escribiéndole
-    // después de darse de baja sí sería un problema. Un fallo aquí no ensucia
-    // el resultado: los envíos comprueban de nuevo que el usuario exista.
+    // Los envíos pendientes se cancelan antes de anonimizar la cola: al revés,
+    // el barrido de cancelación ya no encontraría sus documentos por `userId`.
     try {
       await this.firestoreService.cancelPendingEmails(userId);
     } catch (error) {
@@ -196,13 +193,35 @@ export class AccountDeletionService {
       );
     }
 
+    try {
+      retainedRecords = await this.firestoreService.anonymizeUserCfdis(userId);
+      await this.firestoreService.anonymizeUserFinancialRecords(userId);
+      await this.firestoreService.anonymizeUserActivityRecords(userId);
+      await this.anonymizeStripeCustomer(user);
+    } catch (error) {
+      failed('retainedRecords', error);
+    }
+
     let accountDeleted = false;
 
-    try {
-      await this.firestoreService.deleteUser(userId);
-      accountDeleted = true;
-    } catch (error) {
-      failed('account', error);
+    // La identidad se borra solo si no quedó nada pendiente. Con datos o
+    // archivos del usuario aún sin tocar, borrar el perfil y la cuenta de Auth
+    // dejaría a esos restos sin dueño y al usuario sin forma de autenticarse
+    // para reintentar la baja: el 500 con `failedSteps` es preferible a una
+    // cuenta medio borrada que nadie puede terminar de borrar.
+    if (failedSteps.length > 0) {
+      this.logger.error(
+        `Baja de cuenta ${userId}: no se borra la identidad porque quedaron pasos ` +
+          `pendientes (${failedSteps.join(', ')}); el usuario conserva el acceso ` +
+          'para reintentar',
+      );
+    } else {
+      try {
+        await this.firestoreService.deleteUser(userId);
+        accountDeleted = true;
+      } catch (error) {
+        failed('account', error);
+      }
     }
 
     if (accountDeleted) {
@@ -223,6 +242,22 @@ export class AccountDeletionService {
         `Baja de cuenta ${userId}: no se borra la cuenta de Firebase Auth porque el ` +
           'perfil no llegó a borrarse; sin ella el usuario no podría reintentar',
       );
+    }
+
+    if (accountDeleted) {
+      // Segundo pase, idempotente y normalmente vacío. La cancelación de la
+      // suscripción dispara `customer.subscription.deleted`, cuyo manejador
+      // puede escribir un `subscription_event` con el email del titular mientras
+      // esta baja avanza. En cuanto el documento de `users` desaparece, ese
+      // manejador sale sin escribir —busca al usuario por customer y no lo
+      // encuentra—, así que barrer aquí cierra la ventana en la que el webhook
+      // pudo colarse entre la anonimización y el borrado.
+      try {
+        await this.firestoreService.anonymizeUserFinancialRecords(userId);
+        await this.firestoreService.anonymizeUserActivityRecords(userId);
+      } catch (error) {
+        failed('retainedRecords', error);
+      }
     }
 
     const deleted = {
@@ -285,17 +320,79 @@ export class AccountDeletionService {
   private async cancelSubscription(
     user: User,
   ): Promise<DeletedSubscriptionDto> {
-    if (!user.stripeSubscriptionId) {
+    if (!user.stripeSubscriptionId && !user.stripeCustomerId) {
       return { cancelled: false, plan: null, effectiveAt: null };
     }
 
     if (!this.stripe) {
-      // Con una suscripción registrada y sin cliente de Stripe no hay forma de
-      // comprobar ni de cancelar: borrar la cuenta la dejaría cobrando.
+      // Con rastro de Stripe y sin cliente no hay forma de comprobar ni de
+      // cancelar: borrar la cuenta podría dejarla cobrando.
       throw this.subscriptionCancelFailed(user, 'stripe_not_configured');
     }
 
+    let subscriptionIds: string[];
+
     try {
+      subscriptionIds = await this.resolveLiveSubscriptionIds(user);
+    } catch (error) {
+      this.logger.error(
+        `Baja de cuenta ${user.id}: no se pudieron resolver las suscripciones — ${error.message}`,
+      );
+      throw this.subscriptionCancelFailed(user, error?.code ?? 'stripe_error');
+    }
+
+    if (subscriptionIds.length === 0) {
+      return {
+        cancelled: false,
+        plan: user.stripeSubscriptionId ? (user.plan ?? null) : null,
+        effectiveAt: null,
+      };
+    }
+
+    let canceledAt: Date | null = null;
+
+    for (const subscriptionId of subscriptionIds) {
+      try {
+        const cancelled =
+          await this.stripe.subscriptions.cancel(subscriptionId);
+
+        canceledAt = cancelled.canceled_at
+          ? new Date(cancelled.canceled_at * 1000)
+          : new Date();
+      } catch (error) {
+        this.logger.error(
+          `Baja de cuenta ${user.id}: Stripe rechazó cancelar ${subscriptionId} — ${error.message}`,
+        );
+        throw this.subscriptionCancelFailed(
+          user,
+          error?.code ?? 'stripe_error',
+        );
+      }
+    }
+
+    return {
+      cancelled: true,
+      plan: user.plan ?? null,
+      effectiveAt: (canceledAt ?? new Date()).toISOString(),
+    };
+  }
+
+  /**
+   * Suscripciones vivas del usuario, mirando al customer y no solo al id que
+   * tengamos guardado.
+   *
+   * `stripeSubscriptionId` puede faltar o estar desfasado —un checkout cuyo
+   * webhook no llegó, una suscripción duplicada—, y fiarse solo de él dejaría un
+   * contrato cobrando a una cuenta que acabamos de borrar. El propio flujo de
+   * alta ya consulta por `stripeCustomerId` por este mismo motivo.
+   *
+   * Se devuelven sin duplicar y solo las que no están canceladas: cancelar una
+   * ya cancelada no aporta nada y Stripe lo rechaza.
+   */
+  private async resolveLiveSubscriptionIds(user: User): Promise<string[]> {
+    const ids = new Set<string>();
+
+    if (user.stripeSubscriptionId) {
       const current = await this.stripe.subscriptions.retrieve(
         user.stripeSubscriptionId,
       );
@@ -304,28 +401,26 @@ export class AccountDeletionService {
         this.logger.log(
           `Baja de cuenta ${user.id}: la suscripción ${current.id} ya estaba cancelada`,
         );
-        return { cancelled: false, plan: user.plan ?? null, effectiveAt: null };
+      } else {
+        ids.add(current.id);
       }
-
-      const cancelled = await this.stripe.subscriptions.cancel(
-        user.stripeSubscriptionId,
-      );
-
-      const canceledAt = cancelled.canceled_at
-        ? new Date(cancelled.canceled_at * 1000)
-        : new Date();
-
-      return {
-        cancelled: true,
-        plan: user.plan ?? null,
-        effectiveAt: canceledAt.toISOString(),
-      };
-    } catch (error) {
-      this.logger.error(
-        `Baja de cuenta ${user.id}: Stripe rechazó cancelar ${user.stripeSubscriptionId} — ${error.message}`,
-      );
-      throw this.subscriptionCancelFailed(user, error?.code ?? 'stripe_error');
     }
+
+    if (user.stripeCustomerId) {
+      const subscriptions = await this.stripe.subscriptions.list({
+        customer: user.stripeCustomerId,
+        status: 'all',
+        limit: 100,
+      });
+
+      for (const subscription of subscriptions.data) {
+        if (subscription.status !== 'canceled') {
+          ids.add(subscription.id);
+        }
+      }
+    }
+
+    return [...ids];
   }
 
   private subscriptionCancelFailed(user: User, reason: string): HttpException {
@@ -375,29 +470,42 @@ export class AccountDeletionService {
         return { conversions, storedFiles, storageFailed, incomplete };
       }
 
+      const deletableIds: string[] = [];
+
       for (const record of records) {
         const path = extractStoragePathFromSignedUrl(record.fileUrl);
-        if (!path) continue;
+
+        if (!path) {
+          deletableIds.push(record.id);
+          continue;
+        }
 
         try {
           if (await this.storageService.deleteFile(path)) {
             storedFiles++;
           }
+          deletableIds.push(record.id);
         } catch (error) {
-          // Un objeto que no se deja borrar no puede impedir que se borre la
-          // fila: se anota y la respuesta lo declara como baja parcial.
+          // La fila se queda: su `fileUrl` es la única pista para volver a
+          // intentar borrar el objeto. Borrarla ahora dejaría el archivo en el
+          // bucket y sin nada que lo señale.
           storageFailed = true;
           this.logger.warn(
-            `Baja de cuenta ${userId}: no se pudo borrar ${path} — ${error.message}`,
+            `Baja de cuenta ${userId}: no se pudo borrar ${path}; se conserva la ` +
+              `fila ${record.id} para poder reintentarlo — ${error.message}`,
           );
         }
       }
 
-      conversions += await this.firestoreService.deleteConversionHistoryByIds(
-        records.map((record) => record.id),
-      );
+      conversions +=
+        await this.firestoreService.deleteConversionHistoryByIds(deletableIds);
 
-      if (records.length < HISTORY_DELETION_PAGE_SIZE) {
+      // Sin ninguna fila borrada, la siguiente lectura devolvería las mismas y
+      // el bucle daría vueltas hasta agotar el tope de páginas.
+      if (
+        deletableIds.length === 0 ||
+        records.length < HISTORY_DELETION_PAGE_SIZE
+      ) {
         return { conversions, storedFiles, storageFailed, incomplete };
       }
     }
@@ -503,6 +611,11 @@ export class AccountDeletionService {
     await this.stripe.customers.update(user.stripeCustomerId, {
       name: 'Deleted account',
       email: '',
+      phone: '',
+      // El perfil fiscal propaga el domicilio al customer
+      // (`BillingService.syncTaxProfileToStripe`): vaciarlo es tan necesario
+      // como el email, es la dirección de una persona.
+      address: null,
       description: 'Account deleted at the user request',
       metadata: {
         ...clearedMetadata,
@@ -511,8 +624,25 @@ export class AccountDeletionService {
       },
     });
 
+    // El RFC/VAT vive en objetos aparte del customer, así que el update anterior
+    // no lo toca. Las facturas ya emitidas conservan su copia impresa —eso es lo
+    // retenido—, pero el identificador fiscal reutilizable no puede quedarse
+    // colgando de un customer sin titular.
+    await this.deleteCustomerTaxIds(user.stripeCustomerId);
+
     this.logger.log(
       `Baja de cuenta ${user.id}: customer ${user.stripeCustomerId} anonimizado en Stripe`,
     );
+  }
+
+  /** Borra los tax IDs (RFC, VAT) asociados al customer. */
+  private async deleteCustomerTaxIds(customerId: string): Promise<void> {
+    const taxIds = await this.stripe.customers.listTaxIds(customerId, {
+      limit: 100,
+    });
+
+    for (const taxId of taxIds.data) {
+      await this.stripe.customers.deleteTaxId(customerId, taxId.id);
+    }
   }
 }

--- a/src/modules/users/account-deletion.service.ts
+++ b/src/modules/users/account-deletion.service.ts
@@ -19,6 +19,7 @@ import {
  * traduce por su cuenta.
  */
 export type AccountDeletionStep =
+  | 'deletionMark'
   | 'conversions'
   | 'storedFiles'
   | 'batches'
@@ -107,11 +108,6 @@ export class AccountDeletionService {
 
     const subscription = await this.cancelSubscription(user);
 
-    // Desde este punto ninguna conversión, batch ni petición nueva puede volver
-    // a escribir datos del UID. La marca se conserva tras el éxito para cubrir
-    // tokens de Firebase todavía válidos y se retira si la identidad sobrevive.
-    await this.firestoreService.markAccountDeletion(userId);
-
     const failedSteps: AccountDeletionStep[] = [];
     const failed = (step: AccountDeletionStep, error: unknown): void => {
       failedSteps.push(step);
@@ -121,6 +117,18 @@ export class AccountDeletionService {
         }`,
       );
     };
+
+    // Desde este punto ninguna conversión, batch ni petición nueva puede volver
+    // a escribir datos del UID. La marca se conserva tras el éxito para cubrir
+    // tokens de Firebase todavía válidos y se retira si la identidad sobrevive.
+    try {
+      await this.firestoreService.markAccountDeletion(userId);
+    } catch (error) {
+      // Stripe ya pudo haber cancelado la suscripción. La respuesta debe
+      // conservar ese dato financiero y declarar qué barrera falló, igual que
+      // cualquier otro paso parcial, en vez de escapar como un 500 genérico.
+      failed('deletionMark', error);
+    }
 
     let conversions = 0;
     let storedFiles = 0;

--- a/src/modules/users/account-deletion.service.ts
+++ b/src/modules/users/account-deletion.service.ts
@@ -4,6 +4,7 @@ import Stripe from 'stripe';
 import { FirestoreService } from '../cache/firestore.service.js';
 import { FirebaseAdminService } from '../auth/firebase-admin.service.js';
 import { StorageService } from '../storage/storage.service.js';
+import { UsersService } from './users.service.js';
 import { ErrorCodes } from '../../common/constants/error-codes.js';
 import { extractStoragePathFromSignedUrl } from '../../common/utils/storage-url.util.js';
 import type { User } from '../../common/interfaces/user.interface.js';
@@ -81,6 +82,7 @@ export class AccountDeletionService {
     private readonly firestoreService: FirestoreService,
     private readonly firebaseAdminService: FirebaseAdminService,
     private readonly storageService: StorageService,
+    private readonly usersService: UsersService,
     private readonly configService: ConfigService,
   ) {
     const stripeSecretKey = this.configService.get<string>('STRIPE_SECRET_KEY');
@@ -154,6 +156,21 @@ export class AccountDeletionService {
         `debug-zpl/${userId}/`,
       );
       await this.firestoreService.deleteZplDebugFilesByUserId(userId);
+
+      // La foto de perfil (#106) vive en el bucket PÚBLICO, así que no cae con
+      // los prefijos del privado. Y es el archivo más expuesto de todos: su URL
+      // no está firmada y no caduca, de modo que dejarla ahí mantendría la cara
+      // del titular accesible a cualquiera después de la baja.
+      await this.storageService.deletePublicFile(
+        this.usersService.getProfilePhotoPath(userId),
+      );
+
+      // Solo se cuenta si el perfil declaraba tener foto: `deletePublicFile`
+      // trata el 404 como éxito, y sumar siempre inflaría el recuento con un
+      // archivo que quizá nunca existió.
+      if (user.photoURL) {
+        storedFiles++;
+      }
     } catch (error) {
       failed('storedFiles', error);
     }

--- a/src/modules/users/account-deletion.service.ts
+++ b/src/modules/users/account-deletion.service.ts
@@ -225,6 +225,26 @@ export class AccountDeletionService {
     }
 
     if (accountDeleted) {
+      // Segundo pase, idempotente y normalmente vacío. La cancelación de la
+      // suscripción dispara `customer.subscription.deleted`, cuyo manejador
+      // puede escribir un `subscription_event` con el email del titular mientras
+      // esta baja avanza. En cuanto el documento de `users` desaparece, ese
+      // manejador sale sin escribir —busca al usuario por customer y no lo
+      // encuentra—, así que barrer aquí cierra la ventana en la que el webhook
+      // pudo colarse entre la anonimización y el borrado.
+      //
+      // Va ANTES de borrar Firebase Auth: si falla, el usuario conserva las
+      // credenciales con las que reintentar la baja y terminar la limpieza.
+      try {
+        await this.firestoreService.anonymizeUserFinancialRecords(userId);
+        await this.firestoreService.anonymizeUserActivityRecords(userId);
+      } catch (error) {
+        failed('retainedRecords', error);
+        accountDeleted = false;
+      }
+    }
+
+    if (accountDeleted) {
       try {
         await this.firebaseAdminService.deleteUser(userId);
       } catch (error) {
@@ -242,22 +262,6 @@ export class AccountDeletionService {
         `Baja de cuenta ${userId}: no se borra la cuenta de Firebase Auth porque el ` +
           'perfil no llegó a borrarse; sin ella el usuario no podría reintentar',
       );
-    }
-
-    if (accountDeleted) {
-      // Segundo pase, idempotente y normalmente vacío. La cancelación de la
-      // suscripción dispara `customer.subscription.deleted`, cuyo manejador
-      // puede escribir un `subscription_event` con el email del titular mientras
-      // esta baja avanza. En cuanto el documento de `users` desaparece, ese
-      // manejador sale sin escribir —busca al usuario por customer y no lo
-      // encuentra—, así que barrer aquí cierra la ventana en la que el webhook
-      // pudo colarse entre la anonimización y el borrado.
-      try {
-        await this.firestoreService.anonymizeUserFinancialRecords(userId);
-        await this.firestoreService.anonymizeUserActivityRecords(userId);
-      } catch (error) {
-        failed('retainedRecords', error);
-      }
     }
 
     const deleted = {
@@ -350,12 +354,14 @@ export class AccountDeletionService {
     }
 
     let canceledAt: Date | null = null;
+    const cancelledIds: string[] = [];
 
     for (const subscriptionId of subscriptionIds) {
       try {
         const cancelled =
           await this.stripe.subscriptions.cancel(subscriptionId);
 
+        cancelledIds.push(subscriptionId);
         canceledAt = cancelled.canceled_at
           ? new Date(cancelled.canceled_at * 1000)
           : new Date();
@@ -363,9 +369,18 @@ export class AccountDeletionService {
         this.logger.error(
           `Baja de cuenta ${user.id}: Stripe rechazó cancelar ${subscriptionId} — ${error.message}`,
         );
+        // Lo ya cancelado no se deshace, así que la respuesta lo dice: decirle
+        // "no se ha tocado nada" a quien acaba de perder una suscripción sería
+        // un estado financiero falso, aunque no se haya borrado ningún dato.
         throw this.subscriptionCancelFailed(
           user,
           error?.code ?? 'stripe_error',
+          {
+            cancelledSubscriptions: cancelledIds,
+            pendingSubscriptions: subscriptionIds.filter(
+              (id) => !cancelledIds.includes(id),
+            ),
+          },
         );
       }
     }
@@ -393,16 +408,31 @@ export class AccountDeletionService {
     const ids = new Set<string>();
 
     if (user.stripeSubscriptionId) {
-      const current = await this.stripe.subscriptions.retrieve(
-        user.stripeSubscriptionId,
-      );
-
-      if (current.status === 'canceled') {
-        this.logger.log(
-          `Baja de cuenta ${user.id}: la suscripción ${current.id} ya estaba cancelada`,
+      try {
+        const current = await this.stripe.subscriptions.retrieve(
+          user.stripeSubscriptionId,
         );
-      } else {
-        ids.add(current.id);
+
+        if (current.status === 'canceled') {
+          this.logger.log(
+            `Baja de cuenta ${user.id}: la suscripción ${current.id} ya estaba cancelada`,
+          );
+        } else {
+          ids.add(current.id);
+        }
+      } catch (error) {
+        // Un id guardado que Stripe ya no conoce es basura de un checkout que
+        // no cuajó, no un motivo para dejar a alguien sin poder darse de baja:
+        // se sigue con las suscripciones reales del customer. Cualquier otro
+        // fallo sí aborta, porque entonces no sabemos qué hay vivo.
+        if (error?.code !== 'resource_missing') {
+          throw error;
+        }
+
+        this.logger.warn(
+          `Baja de cuenta ${user.id}: la suscripción ${user.stripeSubscriptionId} ` +
+            'ya no existe en Stripe; se comprueban las del customer',
+        );
       }
     }
 
@@ -423,7 +453,14 @@ export class AccountDeletionService {
     return [...ids];
   }
 
-  private subscriptionCancelFailed(user: User, reason: string): HttpException {
+  private subscriptionCancelFailed(
+    user: User,
+    reason: string,
+    partial?: {
+      cancelledSubscriptions: string[];
+      pendingSubscriptions: string[];
+    },
+  ): HttpException {
     return new HttpException(
       {
         error: ErrorCodes.SUBSCRIPTION_CANCEL_FAILED,
@@ -434,6 +471,10 @@ export class AccountDeletionService {
           // Código de Stripe, no frase: el frontend decide si ofrece reintentar
           // o mandar al portal de facturación.
           reason,
+          // Presentes solo cuando el customer tenía varias suscripciones y unas
+          // se cancelaron antes del rechazo: ningún dato se ha borrado, pero
+          // esas ya no vuelven.
+          ...(partial ?? {}),
         },
       },
       HttpStatus.CONFLICT,
@@ -510,11 +551,21 @@ export class AccountDeletionService {
       }
     }
 
-    incomplete = true;
-    this.logger.error(
-      `Baja de cuenta ${userId}: se agotaron las ${MAX_HISTORY_DELETION_PAGES} páginas ` +
-        'de borrado del historial y aún quedan registros',
+    // Agotar las páginas no significa que quede algo: una cuenta con un múltiplo
+    // exacto del tamaño de página se borra entera en la última vuelta. Sin esta
+    // lectura, esa baja devolvería un 500 y conservaría la identidad sin motivo.
+    const remaining = await this.firestoreService.scanUserConversionHistory(
+      userId,
+      1,
     );
+    incomplete = remaining.length > 0;
+
+    if (incomplete) {
+      this.logger.error(
+        `Baja de cuenta ${userId}: se agotaron las ${MAX_HISTORY_DELETION_PAGES} páginas ` +
+          'de borrado del historial y aún quedan registros',
+      );
+    }
 
     return { conversions, storedFiles, storageFailed, incomplete };
   }

--- a/src/modules/users/account-deletion.service.ts
+++ b/src/modules/users/account-deletion.service.ts
@@ -107,6 +107,11 @@ export class AccountDeletionService {
 
     const subscription = await this.cancelSubscription(user);
 
+    // Desde este punto ninguna conversión, batch ni petición nueva puede volver
+    // a escribir datos del UID. La marca se conserva tras el éxito para cubrir
+    // tokens de Firebase todavía válidos y se retira si la identidad sobrevive.
+    await this.firestoreService.markAccountDeletion(userId);
+
     const failedSteps: AccountDeletionStep[] = [];
     const failed = (step: AccountDeletionStep, error: unknown): void => {
       failedSteps.push(step);
@@ -279,6 +284,22 @@ export class AccountDeletionService {
     };
 
     if (failedSteps.length > 0) {
+      // Una baja parcial conserva Firebase Auth para que el titular pueda
+      // reintentar. La lápida también debe desaparecer: de lo contrario el
+      // guard rechazaría ese reintento y la cuenta quedaría inutilizable.
+      try {
+        await this.firestoreService.clearAccountDeletionMark(userId);
+      } catch (error) {
+        this.logger.error(
+          `Baja de cuenta ${userId}: no se pudo retirar la marca para reintentar — ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        if (!failedSteps.includes('account')) {
+          failedSteps.push('account');
+        }
+      }
+
       throw new HttpException(
         {
           error: ErrorCodes.ACCOUNT_DELETION_PARTIAL,

--- a/src/modules/users/dto/delete-account.dto.ts
+++ b/src/modules/users/dto/delete-account.dto.ts
@@ -1,0 +1,81 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { PlanType } from '../../../common/interfaces/user.interface.js';
+
+/**
+ * Motivo por el que algo sobrevive a la baja. Código estable, no frase: la app
+ * está en cuatro idiomas y el backend no conoce el del receptor.
+ */
+export const RETENTION_REASON_FISCAL = 'fiscal_retention';
+
+export class DeletedSubscriptionDto {
+  @ApiProperty({
+    description:
+      '`true` si esta baja canceló la suscripción. `false` cuando no había ' +
+      'ninguna o Stripe ya la tenía cancelada.',
+  })
+  cancelled: boolean;
+
+  @ApiProperty({
+    description:
+      'Plan que tenía la suscripción cancelada, o `null` si no había',
+    nullable: true,
+    example: 'pro',
+  })
+  plan: PlanType | null;
+
+  @ApiProperty({
+    description:
+      'Momento en que la cancelación surte efecto, en ISO 8601. La baja cancela ' +
+      'de inmediato —no al final del periodo—, así que es el instante de la ' +
+      'petición. `null` si no se canceló nada.',
+    nullable: true,
+    example: '2026-09-01T00:00:00.000Z',
+  })
+  effectiveAt: string | null;
+}
+
+export class DeletedResourcesDto {
+  @ApiProperty({ description: 'Registros de `conversion_history` borrados' })
+  conversions: number;
+
+  @ApiProperty({
+    description:
+      'Objetos borrados de Cloud Storage: los PDF/PNG/JPEG del historial y los ' +
+      'ZPL originales que siguieran dentro de su ventana de retención. Puede ser ' +
+      'menor que `conversions` porque los archivos de las conversiones antiguas ' +
+      'ya habían caducado.',
+  })
+  storedFiles: number;
+
+  @ApiProperty({
+    description: '`true` si el usuario tenía perfil fiscal y se borró',
+  })
+  taxProfile: boolean;
+
+  @ApiProperty({ type: DeletedSubscriptionDto })
+  subscription: DeletedSubscriptionDto;
+}
+
+export class RetainedResourcesDto {
+  @ApiProperty({
+    description:
+      'Facturas de Stripe y CFDI timbrados que se conservan. Se desvinculan del ' +
+      'usuario, pero no se borran.',
+  })
+  invoices: number;
+
+  @ApiProperty({
+    description:
+      'Código estable del motivo de retención; el texto lo traduce el frontend',
+    example: RETENTION_REASON_FISCAL,
+  })
+  reason: string;
+}
+
+export class DeleteAccountResponseDto {
+  @ApiProperty({ type: DeletedResourcesDto })
+  deleted: DeletedResourcesDto;
+
+  @ApiProperty({ type: RetainedResourcesDto })
+  retained: RetainedResourcesDto;
+}

--- a/src/modules/users/dto/notification-preferences.dto.ts
+++ b/src/modules/users/dto/notification-preferences.dto.ts
@@ -1,0 +1,64 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsObject,
+  IsOptional,
+  ValidateNested,
+} from 'class-validator';
+
+export class NotificationSettingsDto {
+  @ApiPropertyOptional({
+    description: 'Novedades y cambios del producto',
+    default: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  product?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Cobros, fallos de pago y facturas',
+    default: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  billing?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Avisos al acercarse al límite del plan',
+    default: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  usageReminders?: boolean;
+}
+
+/**
+ * Cuerpo de `PUT /users/me/preferences`.
+ *
+ * Las tres claves son opcionales y se fusionan con lo que ya hubiera guardado:
+ * la pantalla de ajustes cambia un interruptor cada vez, y exigir el objeto
+ * completo convertiría cada clic en una carrera capaz de revertir el interruptor
+ * de al lado.
+ */
+export class UpdatePreferencesDto {
+  @ApiProperty({ type: NotificationSettingsDto })
+  @IsObject()
+  @ValidateNested()
+  @Type(() => NotificationSettingsDto)
+  notifications: NotificationSettingsDto;
+}
+
+export class NotificationPreferencesResponseDto {
+  @ApiProperty({
+    type: NotificationSettingsDto,
+    description:
+      'Las tres claves vienen siempre resueltas: una cuenta que nunca tocó sus ' +
+      'preferencias las recibe todas en `true`.',
+  })
+  notifications: {
+    product: boolean;
+    billing: boolean;
+    usageReminders: boolean;
+  };
+}

--- a/src/modules/users/users.controller.spec.ts
+++ b/src/modules/users/users.controller.spec.ts
@@ -3,6 +3,7 @@ import type { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { UsersController } from './users.controller.js';
 import { UsersService, MAX_PROFILE_PHOTO_BYTES } from './users.service.js';
+import { AccountDeletionService } from './account-deletion.service.js';
 import { FirebaseAuthGuard } from '../../common/guards/firebase-auth.guard.js';
 import { HttpExceptionFilter } from '../../common/filters/http-exception.filter.js';
 
@@ -40,7 +41,13 @@ describe('UsersController — rutas del historial', () => {
 
     const moduleRef = await Test.createTestingModule({
       controllers: [UsersController],
-      providers: [{ provide: UsersService, useValue: usersService }],
+      providers: [
+        { provide: UsersService, useValue: usersService },
+        {
+          provide: AccountDeletionService,
+          useValue: { deleteAccount: jest.fn() },
+        },
+      ],
     })
       .overrideGuard(FirebaseAuthGuard)
       .useValue({
@@ -157,7 +164,13 @@ describe('UsersController — foto de perfil', () => {
 
     const moduleRef = await Test.createTestingModule({
       controllers: [UsersController],
-      providers: [{ provide: UsersService, useValue: usersService }],
+      providers: [
+        { provide: UsersService, useValue: usersService },
+        {
+          provide: AccountDeletionService,
+          useValue: { deleteAccount: jest.fn() },
+        },
+      ],
     })
       .overrideGuard(FirebaseAuthGuard)
       .useValue({
@@ -224,5 +237,175 @@ describe('UsersController — foto de perfil', () => {
     await request(app.getHttpServer()).delete('/users/me/photo').expect(204);
 
     expect(usersService.deleteProfilePhoto).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * Contrato HTTP de la baja de cuenta y de las preferencias (issue #99). La
+ * lógica vive en sus servicios; aquí se comprueba el cableado: que las rutas
+ * `me/...` no se coman a `me`, que el body se valida y que los códigos de error
+ * llegan al cliente tal cual, que es como el frontend distingue los casos.
+ */
+describe('UsersController — baja de cuenta y preferencias', () => {
+  const UID = 'uid-titular';
+
+  let app: INestApplication;
+  let usersService: {
+    getUserProfile: jest.Mock;
+    getNotificationPreferences: jest.Mock;
+    updateNotificationPreferences: jest.Mock;
+  };
+  let accountDeletionService: { deleteAccount: jest.Mock };
+
+  const deletionResult = {
+    deleted: {
+      conversions: 128,
+      storedFiles: 120,
+      taxProfile: true,
+      subscription: {
+        cancelled: true,
+        plan: 'pro',
+        effectiveAt: '2026-09-01T00:00:00.000Z',
+      },
+    },
+    retained: { invoices: 4, reason: 'fiscal_retention' },
+  };
+
+  beforeEach(async () => {
+    usersService = {
+      getUserProfile: jest.fn().mockResolvedValue({ id: UID }),
+      getNotificationPreferences: jest.fn().mockResolvedValue({
+        product: true,
+        billing: true,
+        usageReminders: true,
+      }),
+      updateNotificationPreferences: jest.fn().mockResolvedValue({
+        product: false,
+        billing: true,
+        usageReminders: true,
+      }),
+    };
+    accountDeletionService = {
+      deleteAccount: jest.fn().mockResolvedValue(deletionResult),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [
+        { provide: UsersService, useValue: usersService },
+        {
+          provide: AccountDeletionService,
+          useValue: accountDeletionService,
+        },
+      ],
+    })
+      .overrideGuard(FirebaseAuthGuard)
+      .useValue({
+        canActivate: (context) => {
+          context.switchToHttp().getRequest().user = { uid: UID };
+          return true;
+        },
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    const { ValidationPipe } = await import('@nestjs/common');
+    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+    app.useGlobalFilters(new HttpExceptionFilter());
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('DELETE /users/me devuelve el contrato con deleted y retained', async () => {
+    const response = await request(app.getHttpServer())
+      .delete('/users/me')
+      .expect(200);
+
+    expect(accountDeletionService.deleteAccount).toHaveBeenCalledWith(UID);
+    expect(response.body).toEqual(deletionResult);
+  });
+
+  it('propaga SUBSCRIPTION_CANCEL_FAILED con su data', async () => {
+    const { HttpException, HttpStatus } = await import('@nestjs/common');
+    accountDeletionService.deleteAccount.mockRejectedValue(
+      new HttpException(
+        {
+          error: 'SUBSCRIPTION_CANCEL_FAILED',
+          message: 'no',
+          data: { plan: 'pro', subscriptionId: 'sub_1', reason: 'api_error' },
+        },
+        HttpStatus.CONFLICT,
+      ),
+    );
+
+    const response = await request(app.getHttpServer())
+      .delete('/users/me')
+      .expect(409);
+
+    expect(response.body.error).toBe('SUBSCRIPTION_CANCEL_FAILED');
+    expect(response.body.data.reason).toBe('api_error');
+  });
+
+  it('propaga ACCOUNT_DELETION_PARTIAL con accountDeleted y failedSteps', async () => {
+    const { HttpException, HttpStatus } = await import('@nestjs/common');
+    accountDeletionService.deleteAccount.mockRejectedValue(
+      new HttpException(
+        {
+          error: 'ACCOUNT_DELETION_PARTIAL',
+          message: 'partial',
+          data: { accountDeleted: false, failedSteps: ['account'] },
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      ),
+    );
+
+    const response = await request(app.getHttpServer())
+      .delete('/users/me')
+      .expect(500);
+
+    expect(response.body.error).toBe('ACCOUNT_DELETION_PARTIAL');
+    expect(response.body.data).toEqual({
+      accountDeleted: false,
+      failedSteps: ['account'],
+    });
+  });
+
+  it('GET /users/me/preferences no se resuelve como GET /users/me', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/users/me/preferences')
+      .expect(200);
+
+    expect(usersService.getNotificationPreferences).toHaveBeenCalledWith(UID);
+    expect(usersService.getUserProfile).not.toHaveBeenCalled();
+    expect(response.body).toEqual({
+      notifications: { product: true, billing: true, usageReminders: true },
+    });
+  });
+
+  it('PUT /users/me/preferences pasa el bloque notifications y devuelve el estado completo', async () => {
+    const response = await request(app.getHttpServer())
+      .put('/users/me/preferences')
+      .send({ notifications: { product: false } })
+      .expect(200);
+
+    expect(usersService.updateNotificationPreferences).toHaveBeenCalledWith(
+      UID,
+      { product: false },
+    );
+    expect(response.body).toEqual({
+      notifications: { product: false, billing: true, usageReminders: true },
+    });
+  });
+
+  it('rechaza un interruptor que no sea booleano', async () => {
+    await request(app.getHttpServer())
+      .put('/users/me/preferences')
+      .send({ notifications: { product: 'sí' } })
+      .expect(400);
+
+    expect(usersService.updateNotificationPreferences).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -1,9 +1,11 @@
 import {
+  Body,
   Controller,
   Delete,
   Get,
   Param,
   Post,
+  Put,
   Query,
   UploadedFile,
   UseGuards,
@@ -35,7 +37,13 @@ import {
 import { FirebaseAuthGuard } from '../../common/guards/firebase-auth.guard.js';
 import { CurrentUser } from '../../common/decorators/current-user.decorator.js';
 import type { FirebaseUser } from '../../common/decorators/current-user.decorator.js';
+import { AccountDeletionService } from './account-deletion.service.js';
 import { UserProfileDto } from './dto/user-profile.dto.js';
+import { DeleteAccountResponseDto } from './dto/delete-account.dto.js';
+import {
+  NotificationPreferencesResponseDto,
+  UpdatePreferencesDto,
+} from './dto/notification-preferences.dto.js';
 import { UserLimitsDto } from './dto/user-limits.dto.js';
 import { VerificationStatusDto } from './dto/verification-status.dto.js';
 import { ProfilePhotoResponseDto } from './dto/profile-photo.dto.js';
@@ -56,7 +64,10 @@ import { OutputFormat } from '../zpl/enums/output-format.enum.js';
 @Controller('users')
 @UseGuards(FirebaseAuthGuard)
 export class UsersController {
-  constructor(private readonly usersService: UsersService) {}
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly accountDeletionService: AccountDeletionService,
+  ) {}
 
   @Post('sync')
   @HttpCode(HttpStatus.OK)
@@ -203,6 +214,92 @@ export class UsersController {
   @ApiResponse({ status: 204, description: 'Photo removed' })
   async deletePhoto(@CurrentUser() user: FirebaseUser): Promise<void> {
     await this.usersService.deleteProfilePhoto(user.uid);
+  }
+
+  @Delete('me')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Delete the authenticated account',
+    description:
+      'Cancela la suscripción de Stripe, borra el historial de conversiones y sus ' +
+      'archivos, el uso, el perfil fiscal, el documento de usuario y la cuenta de ' +
+      'Firebase Auth. Los CFDI timbrados y las facturas de Stripe NO se borran: se ' +
+      'conservan cinco años por obligación fiscal y solo se desvinculan del usuario. ' +
+      'La cancelación es inmediata, no al final del periodo. La operación no es ' +
+      'reversible.',
+  })
+  @ApiResponse({
+    status: 200,
+    description:
+      'Cuenta borrada. `retained.reason` es un código estable, no una frase.',
+    type: DeleteAccountResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: '`USER_NOT_FOUND` — no hay perfil que borrar',
+  })
+  @ApiResponse({
+    status: 409,
+    description:
+      '`SUBSCRIPTION_CANCEL_FAILED` — Stripe rechazó cancelar la suscripción y, ' +
+      'por tanto, NO se ha borrado nada',
+  })
+  @ApiResponse({
+    status: 500,
+    description:
+      '`ACCOUNT_DELETION_PARTIAL` — la suscripción quedó cancelada pero el borrado ' +
+      'se interrumpió. `data.accountDeleted` dice si la cuenta llegó a desaparecer y ' +
+      '`data.failedSteps` qué quedó pendiente.',
+  })
+  async deleteAccount(
+    @CurrentUser() user: FirebaseUser,
+  ): Promise<DeleteAccountResponseDto> {
+    return this.accountDeletionService.deleteAccount(user.uid);
+  }
+
+  @Get('me/preferences')
+  @ApiOperation({
+    summary: 'Get notification preferences',
+    description:
+      'Las tres claves vienen siempre resueltas: una cuenta que nunca las tocó ' +
+      'las recibe todas en `true`.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Notification preferences',
+    type: NotificationPreferencesResponseDto,
+  })
+  async getPreferences(
+    @CurrentUser() user: FirebaseUser,
+  ): Promise<NotificationPreferencesResponseDto> {
+    const notifications = await this.usersService.getNotificationPreferences(
+      user.uid,
+    );
+    return { notifications };
+  }
+
+  @Put('me/preferences')
+  @ApiOperation({
+    summary: 'Update notification preferences',
+    description:
+      'Actualización parcial: las claves que no vengan conservan su valor. ' +
+      'La respuesta trae siempre el estado completo resultante.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Preferencias actualizadas',
+    type: NotificationPreferencesResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Body inválido' })
+  async updatePreferences(
+    @CurrentUser() user: FirebaseUser,
+    @Body() body: UpdatePreferencesDto,
+  ): Promise<NotificationPreferencesResponseDto> {
+    const notifications = await this.usersService.updateNotificationPreferences(
+      user.uid,
+      body.notifications,
+    );
+    return { notifications };
   }
 
   @Get('verification-status')

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -1,6 +1,7 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { UsersController } from './users.controller.js';
 import { UsersService } from './users.service.js';
+import { AccountDeletionService } from './account-deletion.service.js';
 import { CacheModule } from '../cache/cache.module.js';
 import { ZplModule } from '../zpl/zpl.module.js';
 import { PeriodModule } from '../../common/services/period.module.js';
@@ -18,7 +19,7 @@ import { StorageModule } from '../storage/storage.module.js';
     StorageModule,
   ],
   controllers: [UsersController],
-  providers: [UsersService],
+  providers: [UsersService, AccountDeletionService],
   exports: [UsersService],
 })
 export class UsersModule {}

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -2001,3 +2001,95 @@ describe('UsersService — foto de perfil', () => {
     });
   });
 });
+
+/**
+ * Sin persistencia, los interruptores de la pantalla de ajustes serían
+ * decorativos: el frontend no los pinta hasta que estos dos métodos existen
+ * (issue #99).
+ */
+describe('UsersService — preferencias de notificación', () => {
+  function buildService(user: Record<string, unknown> | null) {
+    const updateUser = jest.fn().mockResolvedValue(undefined);
+    const service: any = Object.create(UsersService.prototype);
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    service.firestoreService = {
+      getUserById: jest.fn().mockResolvedValue(user),
+      updateUser,
+    };
+    return { service, updateUser };
+  }
+
+  it('devuelve todo activado para una cuenta que nunca tocó sus preferencias', async () => {
+    const { service } = buildService({ id: 'uid-1' });
+
+    await expect(service.getNotificationPreferences('uid-1')).resolves.toEqual({
+      product: true,
+      billing: true,
+      usageReminders: true,
+    });
+  });
+
+  it('completa las claves que falten en el documento guardado', async () => {
+    const { service } = buildService({
+      id: 'uid-1',
+      notificationPreferences: { product: false },
+    });
+
+    await expect(service.getNotificationPreferences('uid-1')).resolves.toEqual({
+      product: false,
+      billing: true,
+      usageReminders: true,
+    });
+  });
+
+  it('fusiona la actualización parcial sin tocar los interruptores ausentes', async () => {
+    const { service, updateUser } = buildService({
+      id: 'uid-1',
+      notificationPreferences: { product: false, billing: true },
+    });
+
+    const result = await service.updateNotificationPreferences('uid-1', {
+      usageReminders: false,
+    });
+
+    expect(result).toEqual({
+      product: false,
+      billing: true,
+      usageReminders: false,
+    });
+    // Se persisten siempre las tres claves resueltas.
+    expect(updateUser).toHaveBeenCalledWith('uid-1', {
+      notificationPreferences: {
+        product: false,
+        billing: true,
+        usageReminders: false,
+      },
+    });
+  });
+
+  it('una clave presente con valor undefined no revierte la preferencia guardada', async () => {
+    const { service } = buildService({
+      id: 'uid-1',
+      notificationPreferences: { product: false },
+    });
+
+    const result = await service.updateNotificationPreferences('uid-1', {
+      product: undefined,
+      billing: false,
+    });
+
+    expect(result.product).toBe(false);
+    expect(result.billing).toBe(false);
+  });
+
+  it('rechaza a un usuario que no existe', async () => {
+    const { service } = buildService(null);
+
+    await expect(
+      service.getNotificationPreferences('uid-1'),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    await expect(
+      service.updateNotificationPreferences('uid-1', { product: false }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -2009,14 +2009,16 @@ describe('UsersService — foto de perfil', () => {
  */
 describe('UsersService — preferencias de notificación', () => {
   function buildService(user: Record<string, unknown> | null) {
-    const updateUser = jest.fn().mockResolvedValue(undefined);
+    const updateNotificationPreferences = jest
+      .fn()
+      .mockResolvedValue(undefined);
     const service: any = Object.create(UsersService.prototype);
     service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
     service.firestoreService = {
       getUserById: jest.fn().mockResolvedValue(user),
-      updateUser,
+      updateNotificationPreferences,
     };
-    return { service, updateUser };
+    return { service, updateNotificationPreferences };
   }
 
   it('devuelve todo activado para una cuenta que nunca tocó sus preferencias', async () => {
@@ -2043,7 +2045,7 @@ describe('UsersService — preferencias de notificación', () => {
   });
 
   it('fusiona la actualización parcial sin tocar los interruptores ausentes', async () => {
-    const { service, updateUser } = buildService({
+    const { service, updateNotificationPreferences } = buildService({
       id: 'uid-1',
       notificationPreferences: { product: false, billing: true },
     });
@@ -2057,13 +2059,26 @@ describe('UsersService — preferencias de notificación', () => {
       billing: true,
       usageReminders: false,
     });
-    // Se persisten siempre las tres claves resueltas.
-    expect(updateUser).toHaveBeenCalledWith('uid-1', {
-      notificationPreferences: {
-        product: false,
-        billing: true,
-        usageReminders: false,
-      },
+    // Solo se escribe la clave que vino: escribir el objeto entero haría que dos
+    // cambios simultáneos se pisaran.
+    expect(updateNotificationPreferences).toHaveBeenCalledWith('uid-1', {
+      usageReminders: false,
+    });
+  });
+
+  it('no escribe nada si la petición no trae ningún interruptor', async () => {
+    const { service, updateNotificationPreferences } = buildService({
+      id: 'uid-1',
+      notificationPreferences: { product: false },
+    });
+
+    const result = await service.updateNotificationPreferences('uid-1', {});
+
+    expect(updateNotificationPreferences).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      product: false,
+      billing: true,
+      usageReminders: true,
     });
   });
 

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -2008,14 +2008,35 @@ describe('UsersService — foto de perfil', () => {
  * (issue #99).
  */
 describe('UsersService — preferencias de notificación', () => {
-  function buildService(user: Record<string, unknown> | null) {
+  function buildService(
+    user: Record<string, any> | null,
+    concurrentChanges: Record<string, boolean> = {},
+  ) {
+    const storedUser = user
+      ? {
+          ...user,
+          notificationPreferences: {
+            ...(user.notificationPreferences || {}),
+          },
+        }
+      : null;
     const updateNotificationPreferences = jest
       .fn()
-      .mockResolvedValue(undefined);
+      .mockImplementation(
+        async (_userId: string, changes: Record<string, boolean>) => {
+          if (storedUser) {
+            storedUser.notificationPreferences = {
+              ...storedUser.notificationPreferences,
+              ...changes,
+              ...concurrentChanges,
+            };
+          }
+        },
+      );
     const service: any = Object.create(UsersService.prototype);
     service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
     service.firestoreService = {
-      getUserById: jest.fn().mockResolvedValue(user),
+      getUserById: jest.fn().mockImplementation(() => storedUser),
       updateNotificationPreferences,
     };
     return { service, updateNotificationPreferences };
@@ -2097,6 +2118,32 @@ describe('UsersService — preferencias de notificación', () => {
     expect(result.billing).toBe(false);
   });
 
+  it('relee el estado persistido después de una actualización concurrente', async () => {
+    const { service } = buildService(
+      {
+        id: 'uid-1',
+        notificationPreferences: {
+          product: true,
+          billing: true,
+          usageReminders: true,
+        },
+      },
+      { billing: false },
+    );
+
+    const result = await service.updateNotificationPreferences('uid-1', {
+      product: false,
+    });
+
+    // El otro PUT cambió billing durante nuestro await. Componer la respuesta
+    // con la lectura inicial lo devolvería reactivado aunque Firestore diga no.
+    expect(result).toEqual({
+      product: false,
+      billing: false,
+      usageReminders: true,
+    });
+  });
+
   it('rechaza a un usuario que no existe', async () => {
     const { service } = buildService(null);
 
@@ -2106,5 +2153,50 @@ describe('UsersService — preferencias de notificación', () => {
     await expect(
       service.updateNotificationPreferences('uid-1', { product: false }),
     ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});
+
+/**
+ * Los trabajos asíncronos sobreviven a la request que los creó. La lápida se
+ * consulta de nuevo al autorizar y al registrar para que ese desfase no deje
+ * historial o uso bajo un UID ya dado de baja.
+ */
+describe('UsersService — marca de baja en conversiones', () => {
+  function buildMarkedService() {
+    const service: any = Object.create(UsersService.prototype);
+    service.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    service.firestoreService = {
+      isAccountDeletionMarked: jest.fn().mockResolvedValue(true),
+      getUserById: jest.fn(),
+      saveConversionHistory: jest.fn(),
+      incrementUsageWithPeriod: jest.fn(),
+    };
+    return service;
+  }
+
+  it('rechaza una autorización nueva sin volver a crear usage', async () => {
+    const service = buildMarkedService();
+
+    await expect(service.checkCanConvert('uid-1', 1)).resolves.toEqual({
+      allowed: false,
+      error: 'User not found',
+      errorCode: 'USER_NOT_FOUND',
+      userEmail: null,
+    });
+    expect(service.firestoreService.getUserById).not.toHaveBeenCalled();
+  });
+
+  it('aborta un trabajo que terminó después de iniciarse la baja', async () => {
+    const service = buildMarkedService();
+
+    await expect(
+      service.recordConversion('uid-1', 'job-1', 1, '4x6', 'completed'),
+    ).rejects.toBeInstanceOf(GoneException);
+    expect(
+      service.firestoreService.saveConversionHistory,
+    ).not.toHaveBeenCalled();
+    expect(
+      service.firestoreService.incrementUsageWithPeriod,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -52,6 +52,11 @@ import { EmailService } from '../email/email.service.js';
 import { StorageService } from '../storage/storage.service.js';
 import { normalizeLabelSize } from '../zpl/enums/label-size.enum.js';
 import { normalizeOutputFormat } from '../zpl/enums/output-format.enum.js';
+import { extractStoragePathFromSignedUrl } from '../../common/utils/storage-url.util.js';
+import {
+  resolveNotificationPreferences,
+  type NotificationPreferences,
+} from '../../common/interfaces/notification-preferences.interface.js';
 
 export interface CheckCanConvertResult {
   allowed: boolean;
@@ -357,6 +362,63 @@ export class UsersService {
     }
 
     return user.photoURL ?? authPhotoURL;
+  }
+
+  /**
+   * Preferencias de notificación del usuario, siempre con las tres claves.
+   *
+   * Una cuenta anterior a esta feature no tiene el campo guardado y recibe todo
+   * en `true`: nunca pidió dejar de recibir nada.
+   */
+  async getNotificationPreferences(
+    userId: string,
+  ): Promise<NotificationPreferences> {
+    const user = await this.firestoreService.getUserById(userId);
+
+    if (!user) {
+      throw new ForbiddenException('User not found');
+    }
+
+    return resolveNotificationPreferences(user.notificationPreferences);
+  }
+
+  /**
+   * Guarda las preferencias que vengan y devuelve el estado completo resultante.
+   *
+   * La actualización es parcial a propósito —la pantalla de ajustes cambia un
+   * interruptor cada vez—, pero lo que se persiste son siempre las tres claves
+   * resueltas: así el documento no depende de en qué orden se tocaron, y una
+   * clave que el cliente no envía no se queda a medio camino entre "sin definir"
+   * y "desactivada".
+   */
+  async updateNotificationPreferences(
+    userId: string,
+    changes: Partial<NotificationPreferences>,
+  ): Promise<NotificationPreferences> {
+    const user = await this.firestoreService.getUserById(userId);
+
+    if (!user) {
+      throw new ForbiddenException('User not found');
+    }
+
+    // Clave a clave y no con un spread: un DTO parcial puede traer la clave
+    // presente con valor `undefined`, y el spread la impondría sobre la
+    // preferencia guardada, desactivando de vuelta un interruptor que el usuario
+    // no ha tocado en esta petición.
+    const current = resolveNotificationPreferences(
+      user.notificationPreferences,
+    );
+    const updated: NotificationPreferences = {
+      product: changes.product ?? current.product,
+      billing: changes.billing ?? current.billing,
+      usageReminders: changes.usageReminders ?? current.usageReminders,
+    };
+
+    await this.firestoreService.updateUser(userId, {
+      notificationPreferences: updated,
+    });
+
+    return updated;
   }
 
   async getVerificationStatus(userId: string): Promise<VerificationStatusDto> {
@@ -1324,8 +1386,7 @@ export class UsersService {
     downloadFilename: string | null;
   } {
     // Extraer path: https://storage.googleapis.com/bucket/label-xxx.pdf?X-Goog-...
-    const pathMatch = signedUrl.match(/googleapis\.com\/[^/]+\/([^?]+)/);
-    const storagePath = pathMatch ? pathMatch[1] : null;
+    const storagePath = extractStoragePathFromSignedUrl(signedUrl);
 
     // Extraer nombre de descarga del parámetro response-content-disposition
     // Formato: ...&response-content-disposition=attachment%3B%20filename%3D%22nombre.pdf%22&...

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -405,18 +405,31 @@ export class UsersService {
     // presente con valor `undefined`, y el spread la impondría sobre la
     // preferencia guardada, desactivando de vuelta un interruptor que el usuario
     // no ha tocado en esta petición.
+    const applied: Record<string, boolean> = {};
+    for (const key of [
+      'product',
+      'billing',
+      'usageReminders',
+    ] as (keyof NotificationPreferences)[]) {
+      if (typeof changes[key] === 'boolean') {
+        applied[key] = changes[key];
+      }
+    }
+
     const current = resolveNotificationPreferences(
       user.notificationPreferences,
     );
-    const updated: NotificationPreferences = {
-      product: changes.product ?? current.product,
-      billing: changes.billing ?? current.billing,
-      usageReminders: changes.usageReminders ?? current.usageReminders,
-    };
+    const updated = resolveNotificationPreferences({ ...current, ...applied });
 
-    await this.firestoreService.updateUser(userId, {
-      notificationPreferences: updated,
-    });
+    if (Object.keys(applied).length > 0) {
+      // Solo las claves que vienen, con ruta anidada: escribir el objeto entero
+      // haría que dos cambios simultáneos se pisaran, revirtiendo el interruptor
+      // que el otro acabara de mover.
+      await this.firestoreService.updateNotificationPreferences(
+        userId,
+        applied,
+      );
+    }
 
     return updated;
   }

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -429,6 +429,16 @@ export class UsersService {
         userId,
         applied,
       );
+
+      // La lectura inicial solo sirve para validar la cuenta y completar el
+      // caso local. Otro PUT puede haber fusionado una clave distinta mientras
+      // este esperaba la escritura; responder aquel snapshot inventaría un
+      // estado que ya no es el persistido.
+      const persisted = await this.firestoreService.getUserById(userId);
+      if (!persisted) {
+        throw new ForbiddenException('User not found');
+      }
+      return resolveNotificationPreferences(persisted.notificationPreferences);
     }
 
     return updated;
@@ -1429,6 +1439,15 @@ export class UsersService {
     userId: string,
     labelCount: number,
   ): Promise<CheckCanConvertResult> {
+    if (await this.firestoreService.isAccountDeletionMarked(userId)) {
+      return {
+        allowed: false,
+        error: 'User not found',
+        errorCode: ErrorCodes.USER_NOT_FOUND,
+        userEmail: null,
+      };
+    }
+
     const user = await this.firestoreService.getUserById(userId);
 
     if (!user) {
@@ -1522,6 +1541,14 @@ export class UsersService {
     periodInfo?: PeriodInfo,
     userPlan?: PlanType,
   ): Promise<void> {
+    // Una conversión puede terminar mucho después de la request que la inició.
+    // La segunda comprobación evita que ese trabajo reanime datos ya barridos;
+    // Firestore repite la misma condición dentro de las escrituras para cerrar
+    // también la carrera entre esta lectura y el commit.
+    if (await this.firestoreService.isAccountDeletionMarked(userId)) {
+      throw new GoneException('Account deletion in progress');
+    }
+
     // Save to history (use null instead of undefined for Firestore)
     await this.firestoreService.saveConversionHistory({
       userId,

--- a/src/modules/zpl/zpl.service.spec.ts
+++ b/src/modules/zpl/zpl.service.spec.ts
@@ -19,6 +19,7 @@ jest.mock('@google-cloud/storage', () => ({
 }));
 
 import { ZplService, LabelSize } from './zpl.service.js';
+import { OutputFormat } from './enums/output-format.enum.js';
 
 /**
  * Regresión: una etiqueta de envío real (Amazon Logistics) que empieza con un
@@ -223,6 +224,102 @@ describe('ZplService — generateFilenames (issue #100: timestamp truncado)', ()
     );
 
     expect(downloadFilename).toBe('zplpdf_50x80mm_20260819T1542.pdf');
+  });
+});
+
+/**
+ * Un worker puede seguir convirtiendo cuando la baja ya barrió Firestore y
+ * Storage. La comprobación debe vivir justo junto a la subida: el guard de la
+ * request original ocurrió demasiado pronto para proteger este punto.
+ */
+describe('ZplService — la lápida bloquea subidas tardías', () => {
+  function buildUploadService(marks: boolean[]) {
+    const save = jest.fn().mockResolvedValue(undefined);
+    const remove = jest.fn().mockResolvedValue(undefined);
+    const file = jest.fn().mockReturnValue({ save, delete: remove });
+    const isAccountDeletionMarked = jest
+      .fn()
+      .mockImplementation(async () => marks.shift() ?? false);
+    const saveZplDebugFile = jest.fn().mockResolvedValue(undefined);
+
+    const service = Object.create(ZplService.prototype) as any;
+    Object.assign(service, {
+      logger: {
+        log: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+      },
+      bucket: 'test-bucket',
+      jobs: new Map(),
+      storage: { bucket: () => ({ file }) },
+      firestoreService: {
+        isAccountDeletionMarked,
+        saveZplDebugFile,
+        updateConversionStatus: jest.fn().mockResolvedValue(undefined),
+      },
+      usersService: {},
+      logError: jest.fn().mockResolvedValue(true),
+    });
+
+    return {
+      service,
+      save,
+      remove,
+      isAccountDeletionMarked,
+      saveZplDebugFile,
+    };
+  }
+
+  it('no sube el PDF si la cuenta ya estaba marcada al llegar a GCS', async () => {
+    const { service, save, isAccountDeletionMarked } = buildUploadService([
+      true,
+    ]);
+    service.jobs.set('job-1', {
+      id: 'job-1',
+      zplContent: '^XA^FDhola^FS^XZ',
+      labelSize: LabelSize.FOUR_BY_SIX,
+      outputFormat: OutputFormat.PDF,
+      status: 'pending',
+      progress: 0,
+      createdAt: new Date(),
+      userPlan: 'pro',
+    });
+    service.convertZplToPdf = jest.fn().mockResolvedValue(Buffer.from('pdf'));
+
+    await service.processZplConversion(
+      '^XA^FDhola^FS^XZ',
+      '4x6',
+      'job-1',
+      OutputFormat.PDF,
+      'uid-1',
+      'pro',
+    );
+
+    expect(isAccountDeletionMarked).toHaveBeenCalledWith('uid-1');
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('retira el ZPL si la baja empieza mientras GCS termina la subida', async () => {
+    const { service, save, remove, saveZplDebugFile } = buildUploadService([
+      false,
+      true,
+    ]);
+
+    await service.saveZplForDebug(
+      '^XA^FDhola^FS^XZ',
+      'job-1',
+      'uid-1',
+      'user@example.com',
+      '4x6',
+      1,
+      OutputFormat.PDF,
+    );
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(remove).toHaveBeenCalledTimes(1);
+    // No queda metadata apuntando a un objeto que la propia carrera retiró.
+    expect(saveZplDebugFile).not.toHaveBeenCalled();
   });
 });
 
@@ -671,6 +768,7 @@ describe('ZplService — el batch deja el ZPL disponible para reconvertir', () =
       },
       firestoreService: {
         getBatchJob: jest.fn().mockResolvedValue({ userId: 'uid-pro' }),
+        isAccountDeletionMarked: jest.fn().mockResolvedValue(false),
         updateZplDebugResult,
       },
       usersService: {

--- a/src/modules/zpl/zpl.service.ts
+++ b/src/modules/zpl/zpl.service.ts
@@ -6,6 +6,7 @@ import {
   Inject,
   forwardRef,
   ForbiddenException,
+  GoneException,
   Optional,
 } from '@nestjs/common';
 import {
@@ -65,6 +66,7 @@ interface ConversionJob {
   progress: number;
   resultUrl?: string;
   filename?: string;
+  storagePath?: string;
   error?: string;
   createdAt: Date;
   originalFilename?: string;
@@ -158,6 +160,76 @@ export class ZplService {
   }
 
   /**
+   * Sube un objeto solo mientras la cuenta continúa activa.
+   *
+   * La lápida se consulta aquí, en el borde de GCS, y no en cada escritura de
+   * progreso. La segunda lectura cubre que la baja empiece durante la propia
+   * subida: en ese caso se retira el objeto antes de devolver el control, porque
+   * su metadata ya pudo haber sido barrida y el jobId dejaría de ser localizable.
+   */
+  private async uploadForActiveAccount(
+    userId: string | undefined,
+    storagePath: string,
+    content: string | Buffer,
+    contentType: string,
+  ): Promise<void> {
+    if (
+      userId &&
+      (await this.firestoreService.isAccountDeletionMarked(userId))
+    ) {
+      throw new GoneException('Account deletion in progress');
+    }
+
+    await this.storage
+      .bucket(this.bucket)
+      .file(storagePath)
+      .save(content, { contentType });
+
+    if (
+      userId &&
+      (await this.firestoreService.isAccountDeletionMarked(userId))
+    ) {
+      await this.deleteStorageObject(storagePath);
+      throw new GoneException('Account deletion in progress');
+    }
+  }
+
+  /** Retira un objeto recién subido; un 404 ya equivale al estado deseado. */
+  private async deleteStorageObject(storagePath: string): Promise<void> {
+    try {
+      await this.storage.bucket(this.bucket).file(storagePath).delete();
+    } catch (error) {
+      if (error?.code !== 404) {
+        this.logger.error(
+          `No se pudo retirar de Storage ${storagePath}: ${error.message}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Cierra la carrera entre la comprobación posterior a la subida y el commit
+   * del historial. Si ese commit pierde contra la lápida, el PDF/ZIP ya subido
+   * se elimina en vez de quedar sin una fila que permita encontrarlo.
+   */
+  private async cleanupUploadIfDeletionStarted(
+    userId: string,
+    storagePath: string | undefined,
+  ): Promise<void> {
+    if (!storagePath) return;
+
+    try {
+      if (await this.firestoreService.isAccountDeletionMarked(userId)) {
+        await this.deleteStorageObject(storagePath);
+      }
+    } catch (error) {
+      this.logger.error(
+        `No se pudo comprobar la baja antes de limpiar ${storagePath}: ${error.message}`,
+      );
+    }
+  }
+
+  /**
    * Registra un error en el log de errores de admin.
    * @returns `true` si el registro se guardó, `false` si el write falló.
    *   Permite a quien lo llama decidir si confiar en que el error quedó
@@ -237,16 +309,21 @@ export class ZplService {
     labelCount: number,
     outputFormat: OutputFormat,
   ): Promise<void> {
+    let uploaded = false;
+    let storagePath: string | undefined;
+
     try {
       const dateStr = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
-      const storagePath = `debug-zpl/${userId}/${dateStr}/${jobId}.zpl`;
+      storagePath = `debug-zpl/${userId}/${dateStr}/${jobId}.zpl`;
       const fileSize = Buffer.byteLength(zplContent, 'utf8');
 
-      // Guardar archivo en GCS
-      await this.storage
-        .bucket(this.bucket)
-        .file(storagePath)
-        .save(zplContent, { contentType: 'text/plain' });
+      await this.uploadForActiveAccount(
+        userId,
+        storagePath,
+        zplContent,
+        'text/plain',
+      );
+      uploaded = true;
 
       // Guardar metadata en Firestore
       await this.firestoreService.saveZplDebugFile({
@@ -262,6 +339,12 @@ export class ZplService {
 
       this.logger.debug(`ZPL saved for debugging: ${storagePath}`);
     } catch (error) {
+      // Sin metadata, `storagePath` no queda registrado en ninguna parte. Se
+      // borra incluso si el fallo no fue la lápida: conservarlo crearía el
+      // mismo huérfano imposible de localizar en un reintento.
+      if (uploaded && storagePath) {
+        await this.deleteStorageObject(storagePath);
+      }
       this.logger.warn(`Failed to save ZPL for debug: ${error.message}`);
       // No lanzar error - esto es opcional y no debe afectar la conversión
     }
@@ -499,6 +582,10 @@ export class ZplService {
       this.logger.error(
         `Error in processZplConversionWithUser: ${error.message}`,
       );
+      await this.cleanupUploadIfDeletionStarted(
+        userId,
+        this.jobs.get(jobId)?.storagePath,
+      );
       // Record failed conversion
       try {
         await this.usersService.recordConversion(
@@ -616,13 +703,13 @@ export class ZplService {
       // Fase 4: Subiendo archivo (90%)
       this.updateProgress(jobId, 90, 'uploading');
 
-      // Guardar el archivo en Google Cloud Storage
-      await this.storage
-        .bucket(this.bucket)
-        .file(storageFilename)
-        .save(resultBuffer, {
-          contentType,
-        });
+      await this.uploadForActiveAccount(
+        userId,
+        storageFilename,
+        resultBuffer,
+        contentType,
+      );
+      job.storagePath = storageFilename;
 
       // Generar URL firmada
       const signedUrl = await this.generateSignedUrl(
@@ -2217,6 +2304,7 @@ export class ZplService {
         );
       }
 
+      let uploadedTempPath: string | undefined;
       try {
         // Actualizar estado a procesando
         job.status = 'processing';
@@ -2258,10 +2346,13 @@ export class ZplService {
 
         // Guardar archivo temporal en GCS
         const tempPath = `batches/${batchId}/temp/${job.jobId}.${fileExtension}`;
-        await this.storage
-          .bucket(this.bucket)
-          .file(tempPath)
-          .save(resultBuffer, { contentType });
+        await this.uploadForActiveAccount(
+          userId,
+          tempPath,
+          resultBuffer,
+          contentType,
+        );
+        uploadedTempPath = tempPath;
 
         // Marcar como completado
         job.status = 'completed';
@@ -2296,6 +2387,9 @@ export class ZplService {
           `Batch ${batchId}: Archivo ${file.fileName} completado`,
         );
       } catch (error) {
+        if (userId) {
+          await this.cleanupUploadIfDeletionStarted(userId, uploadedTempPath);
+        }
         this.logger.error(
           `Batch ${batchId}: Error procesando ${file.fileName}: ${error.message}`,
         );
@@ -2348,6 +2442,7 @@ export class ZplService {
       completedCount,
       failedCount,
       outputFormat,
+      userId,
     );
   }
 
@@ -2376,6 +2471,7 @@ export class ZplService {
     completedCount: number,
     failedCount: number,
     outputFormat: 'pdf' | 'png' | 'jpeg',
+    userId?: string,
   ): Promise<void> {
     try {
       const completedJobs = jobs.filter(
@@ -2407,9 +2503,12 @@ export class ZplService {
       const zipFilename = `zpl-batch-${timestamp}.zip`;
       const zipPath = `batches/${batchId}/${zipFilename}`;
 
-      await this.storage.bucket(this.bucket).file(zipPath).save(zipBuffer, {
-        contentType: 'application/zip',
-      });
+      await this.uploadForActiveAccount(
+        userId,
+        zipPath,
+        zipBuffer,
+        'application/zip',
+      );
 
       // Generar URL firmada
       const downloadUrl = await this.generateSignedUrl(zipPath, zipFilename);


### PR DESCRIPTION
Closes #99

Los dos endpoints que el frontend necesita para cerrar la pantalla de ajustes (gustavojmarrero/zplpdf_front#218).

## 1. `DELETE /api/users/me`

Toda la lógica en `src/modules/users/account-deletion.service.ts`. Encadena, **en este orden**:

1. Cuenta las facturas de Stripe que van a conservarse (antes de anonimizar el customer, que es lo que permite listarlas).
2. **Cancela la suscripción.** Si Stripe la rechaza, la petición muere aquí con `409 SUBSCRIPTION_CANCEL_FAILED` y **no se borra nada**. Esa es la razón de que vaya primero.
3. `conversion_history` + los archivos de Storage que cuelguen de la URL firmada de cada fila, el prefijo `debug-zpl/<uid>/` y sus docs de `zpl_debug_files`.
4. `usage`, `tax_profiles` y los emails pendientes en cola.
5. Anonimiza lo que tiene retención legal.
6. Doc de `users` y, por último, la cuenta de Firebase Auth.

Respuesta 200, el contrato del issue:

```jsonc
{
  "deleted": {
    "conversions": 128,
    "storedFiles": 120,
    "taxProfile": true,
    "subscription": { "cancelled": true, "plan": "pro", "effectiveAt": "2026-08-19T10:00:00.000Z" }
  },
  "retained": { "invoices": 4, "reason": "fiscal_retention" }
}
```

### Decisiones que conviene revisar

- **Cancelación inmediata, no a fin de periodo.** La cuenta desaparece en la misma petición: dejar el contrato corriendo hasta el corte dejaría una suscripción cuyo titular ya no puede entrar al producto ni gestionarla, y sus webhooks llegarían sin usuario al que aplicarlos. `effectiveAt` es, por tanto, el instante de la cancelación.
- **Una factura abierta no se anula.** A diferencia del flujo de impago (#65), aquí la deuda es de servicio ya prestado y puede estar timbrada. Se queda en Stripe, que es justo lo que declara `retained`.
- **Anonimizar ≠ borrar.** Los `cfdis` del usuario pasan a `userId: 'deleted_user'` + `anonymizedAt`, y el customer de Stripe pierde nombre, email y metadata. El XML/PDF timbrado no se toca: es el documento fiscal, alterarlo lo invalidaría.
- **Si falla el borrado del doc de `users`, NO se borra la cuenta de Auth.** Sin ella el usuario no podría autenticarse para reintentar la baja, y quedaría un documento huérfano.

### Códigos de error (los dos casos que pedía el issue)

| Código | Status | Significa |
|---|---|---|
| `SUBSCRIPTION_CANCEL_FAILED` | 409 | Stripe rechazó cancelar. **No se borró nada**; `data.reason` trae el código de Stripe. |
| `ACCOUNT_DELETION_PARTIAL` | 500 | La suscripción sí se canceló, el borrado se interrumpió. `data.accountDeleted` dice si la cuenta llegó a desaparecer y `data.failedSteps` qué quedó pendiente. |

`data.accountDeleted` es lo que evita decirle al usuario que su cuenta ya no existe cuando sigue existiendo.

## 2. `GET` / `PUT /api/users/me/preferences`

`{ notifications: { product, billing, usageReminders } }`, en el doc de `users`. Ausente = todo activado, tanto para cuentas antiguas como nuevas. El `PUT` es parcial (la pantalla mueve un interruptor cada vez) y la respuesta trae siempre las tres claves resueltas.

`EmailService.processQueue` las comprueba **justo antes de enviar**, no solo al encolar: entre una cosa y otra pasan días —las secuencias de onboarding se programan con antelación— y en ese hueco el usuario puede haber desactivado la categoría o dado de baja. Lo que no sale se marca `cancelled` con su `skipReason` y cuenta en `skipped`, no en `failed`. El mapa tipo → categoría (`email-categories.ts`) es un `Record<EmailType, …>` completo: un tipo de email nuevo sin clasificar no compila, en vez de saltarse en silencio unas preferencias que el usuario cree respetadas. Ante la duda se envía (tipo sin clasificar, o fallo al leer el usuario): no se silencia un aviso de cobro por un error de lectura.

## Verificación

- `npm test` — 528 tests, 20 suites en verde (16 nuevos del servicio de baja, 8 del filtro de emails, 5 de preferencias, 6 del controller, 5 de Storage).
- `npm run lint` y `tsc --noEmit`, limpios.
- Servidor levantado en local (`PORT=8083`): las cuatro rutas se registran (`/api/users/me` DELETE, `/api/users/me/preferences` GET y PUT), el guard responde 401 sin token y Swagger las documenta.
- **No probado contra Stripe/Firestore reales**: la baja es irreversible y no se ha ejecutado sobre ninguna cuenta. Vale la pena una prueba controlada con una cuenta de test antes de desplegar.

## Sin tocar el frontend

Ningún cambio fuera de este repo, como marca CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EGh1RnLEuuHnSeVvxwXp5